### PR TITLE
Vulkan: Remove mac specific hack for specifying host coherent memory

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -93,7 +93,4 @@ private:
 	VkBufferUsageFlags usage_;
 	int curBlockIndex_ = -1;
 	const char *name_;
-	#if PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(AMD64)
-	VkMemoryPropertyFlags allocation_extra_flags_;
-	#endif
 };


### PR DESCRIPTION
We need this everywhere.

Realized I forgot to finish this up before.