### PR TITLE
Avoid using shader blending in skip-buffer-effects mode

### DIFF
--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -74,10 +74,6 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 		// ARM best practices: index buffer usage warning (too few indices used compared to value range).
 		// This should be looked into more - happens even in moppi-flower which is weird.
 		return false;
-	case 337425955:
-		// False positive
-		// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3615
-		return false;
 	case 227275665:
 		// PowerVR (and all other) best practices: LOAD_OP_LOAD used in render pass.
 		return false;

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -104,7 +104,7 @@ bool VulkanTexture::CreateDirect(int w, int h, int depth, int numMips, VkFormat 
 
 	if (initialLayout != VK_IMAGE_LAYOUT_UNDEFINED && initialLayout != VK_IMAGE_LAYOUT_PREINITIALIZED) {
 		VkPipelineStageFlags dstStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		VkAccessFlagBits dstAccessFlags;
+		VkAccessFlagBits dstAccessFlags = (VkAccessFlagBits)0;
 		switch (initialLayout) {
 		case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
 			dstStage = VK_PIPELINE_STAGE_TRANSFER_BIT;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1379,6 +1379,7 @@ void VulkanRenderManager::BlitFramebuffer(VKRFramebuffer *src, VkRect2D srcRect,
 
 VkImageView VulkanRenderManager::BindFramebufferAsTexture(VKRFramebuffer *fb, int binding, VkImageAspectFlags aspectBit, int layer) {
 	_dbg_assert_(curRenderStep_ != nullptr);
+	_dbg_assert_(fb != nullptr);
 
 	// We don't support texturing from stencil, neither do we support texturing from depth|stencil together (nonsensical).
 	_dbg_assert_(aspectBit == VK_IMAGE_ASPECT_COLOR_BIT || aspectBit == VK_IMAGE_ASPECT_DEPTH_BIT);

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -54,7 +54,7 @@ private:
 	std::string filename_;
 	TempImage *tempImage_;
 	ImageFileType type_;
-	bool generateMips_;
+	bool generateMips_;  // not yet used
 	ManagedTexture::LoadState *state_;
 };
 

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -71,7 +71,6 @@ private:
 	std::string filename_;  // Textures that are loaded from files can reload themselves automatically.
 	bool generateMips_ = false;
 	ImageFileType type_ = ImageFileType::DETECT;
-	TextureLoadTask *loadTask_ = nullptr;
 	LimitedWaitable *taskWaitable_ = nullptr;
 	TempImage pendingImage_;
 	LoadState state_ = LoadState::PENDING;

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -515,11 +515,11 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 			// Clamp to the remaining size, but read what we can.
 			const s64 newSize = fileSize - (s64)e.seekPos;
 			// Reading beyond the file is really quite normal behavior (if return value handled correctly), so
-			// not doing WARN here. Still, can potentially be useful to see so leaving at INFO.
+			// not doing WARN here.
 			if (newSize == 0) {
-				INFO_LOG(Log::FileSystem, "Attempted read at end of file, 0-size read simulated");
+				DEBUG_LOG(Log::FileSystem, "Attempted read at end of file, 0-size read simulated");
 			} else {
-				INFO_LOG(Log::FileSystem, "Reading beyond end of file from seekPos %d, clamping size %lld to %lld", e.seekPos, size, newSize);
+				DEBUG_LOG(Log::FileSystem, "Reading beyond end of file from seekPos %d, clamping size %lld to %lld", e.seekPos, size, newSize);
 			}
 			size = newSize;
 		}

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -594,7 +594,6 @@ void DrawEngineCommon::ApplyFramebufferRead(FBOTexState *fboTexState) {
 		gpuStats.numCopiesForShaderBlend++;
 		*fboTexState = FBO_TEX_COPY_BIND_TEX;
 	}
-
 	gstate_c.Dirty(DIRTY_SHADERBLEND);
 }
 

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1446,6 +1446,8 @@ static void ConvertLogicOpState(GenericLogicState &logicOpState, bool logicSuppo
 		return;
 	}
 
+	// TODO: Brave story uses GE_INVERTED, this is easy to convert to a blend function - unless blend is also enabled simultaneously.
+
 	if (forceApplyFramebuffer && shaderBitOpsSupported) {
 		// We have to emulate logic ops in the shader.
 		logicOpState.logicOpEnabled = false;  // Don't use any hardware logic op, supported or not.

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -256,7 +256,7 @@ struct ComputedPipelineState {
 	GenericMaskState maskState;
 	GenericLogicState logicState;
 
-	void Convert(bool shaderBitOpsSupported);
+	void Convert(bool shaderBitOpsSupported, bool fbReadAllowed);
 
 	bool FramebufferRead() const {
 		// If blending is off, its applyFramebufferRead can be false even after state propagation.

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -146,7 +146,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 		} else {
 			keys_.blend.value = 0;
 
-			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps);
+			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps, gstate_c.Use(GPU_USE_SHADER_BLENDING));
 			GenericMaskState &maskState = pipelineState_.maskState;
 			GenericBlendState &blendState = pipelineState_.blendState;
 			// We ignore the logicState on D3D since there's no support, the emulation of it is blend-and-shader only.

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -126,7 +126,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			}
 			dxstate.colorMask.set(mask);
 		} else {
-			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps);
+			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps, gstate_c.Use(GPU_USE_SHADER_BLENDING));
 			GenericMaskState &maskState = pipelineState_.maskState;
 			GenericBlendState &blendState = pipelineState_.blendState;
 			// We ignore the logicState on D3D since there's no support, the emulation of it is blend-and-shader only.

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -136,7 +136,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 			bool alphaMask = gstate.isClearModeAlphaMask();
 			renderManager->SetNoBlendAndMask((colorMask ? 7 : 0) | (alphaMask ? 8 : 0));
 		} else {
-			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps);
+			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps, gstate_c.Use(GPU_USE_SHADER_BLENDING));
 			GenericMaskState &maskState = pipelineState_.maskState;
 			GenericBlendState &blendState = pipelineState_.blendState;
 			GenericLogicState &logicState = pipelineState_.logicState;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -618,6 +618,11 @@ u32 GPUCommonHW::CheckGPUFeatures() const {
 
 	if (draw_->GetDeviceCaps().framebufferFetchSupported) {
 		features |= GPU_USE_FRAMEBUFFER_FETCH;
+		features |= GPU_USE_SHADER_BLENDING;   // doesn't matter if we are buffered or not here.
+	} else {
+		if (!g_Config.bSkipBufferEffects) {
+			features |= GPU_USE_SHADER_BLENDING;
+		}
 	}
 
 	if (draw_->GetShaderLanguageDesc().bitwiseOps && g_Config.bUberShaderVertex) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -480,6 +480,7 @@ enum {
 	GPU_ROUND_DEPTH_TO_16BIT = FLAG_BIT(23),  // Can be disabled either per game or if we use a real 16-bit depth buffer
 	GPU_USE_CLIP_DISTANCE = FLAG_BIT(24),
 	GPU_USE_CULL_DISTANCE = FLAG_BIT(25),
+	GPU_USE_SHADER_BLENDING = FLAG_BIT(26),  // This is set to false when skip buffer effects is enabled and GPU_USE_FRAMEBUFFER_FETCH is not.
 
 	// VR flags (reserved or in-use)
 	GPU_USE_VIRTUAL_REALITY = FLAG_BIT(29),

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -101,6 +101,7 @@ static inline void DrawSinglePixel(u16 *pixel, const u32 color_in) {
 			old_color = RGBA4444ToRGBA8888(*pixel);
 			break;
 		default:
+			old_color = 0;  // avoid warning. can't get here though since we enumerate all 16-bit formats above.
 			break;
 		}
 

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -141,7 +141,7 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 			bool alphaMask = gstate.isClearModeAlphaMask();
 			key.colorWriteMask = (colorMask ? (VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT) : 0) | (alphaMask ? VK_COLOR_COMPONENT_A_BIT : 0);
 		} else {
-			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps);
+			pipelineState_.Convert(draw_->GetShaderLanguageDesc().bitwiseOps, gstate_c.Use(GPU_USE_SHADER_BLENDING));
 			GenericMaskState &maskState = pipelineState_.maskState;
 			GenericBlendState &blendState = pipelineState_.blendState;
 			GenericLogicState &logicState = pipelineState_.logicState;

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -96,7 +96,7 @@ private:
 class KeyMappingNewMouseKeyDialog : public PopupScreen {
 public:
 	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyMap::MultiInputMapping)> callback, I18NCat i18n)
-		: PopupScreen(T(i18n, "Map Mouse"), "", ""), pspBtn_(btn), callback_(callback) {}
+		: PopupScreen(T(i18n, "Map Mouse"), "", ""), callback_(callback) {}
 
 	const char *tag() const override { return "KeyMappingNewMouseKey"; }
 
@@ -111,7 +111,6 @@ protected:
 	void OnCompleted(DialogResult result) override {}
 
 private:
-	int pspBtn_;
 	std::function<void(KeyMap::MultiInputMapping)> callback_;
 	bool mapped_ = false;  // Prevent double registrations
 };

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -791,12 +791,13 @@ static void DrawSockets(ImConfig &cfg) {
 }
 
 static const char *MemCheckConditionToString(MemCheckCondition cond) {
-	switch (cond) {
-	case MEMCHECK_READ: return "Read";
-	case MEMCHECK_WRITE: return "Write";
-	case MEMCHECK_READWRITE: return "Read/Write";
-	case MEMCHECK_WRITE | MEMCHECK_WRITE_ONCHANGE: return "Write Change";
-	case MEMCHECK_READWRITE | MEMCHECK_WRITE_ONCHANGE: return "Read/Write Change";
+	// (int) casting to avoid "case not in enum" warnings
+	switch ((int)cond) {
+	case (int)MEMCHECK_READ: return "Read";
+	case (int)MEMCHECK_WRITE: return "Write";
+	case (int)MEMCHECK_READWRITE: return "Read/Write";
+	case (int)(MEMCHECK_WRITE | MEMCHECK_WRITE_ONCHANGE): return "Write Change";
+	case (int)(MEMCHECK_READWRITE | MEMCHECK_WRITE_ONCHANGE): return "Read/Write Change";
 	default:
 		return "(bad!)";
 	}
@@ -1209,7 +1210,7 @@ void DrawMediaDecodersView(ImConfig &cfg, ImControl &control) {
 				ImGui::Text("%d Hz, %d channels", ctx->SamplingRate, ctx->Channels);
 				ImGui::Text("AUBuf: %08x AUSize: %08x", ctx->AuBuf, ctx->AuBufSize);
 				ImGui::Text("PCMBuf: %08x PCMSize: %08x", ctx->PCMBuf, ctx->PCMBufSize);
-				ImGui::Text("Pos: %d (%d -> %d)", ctx->ReadPos(), ctx->startPos, ctx->endPos);
+				ImGui::Text("Pos: %d (%d -> %d)", ctx->ReadPos(), (int)ctx->startPos, (int)ctx->endPos);
 			}
 		}
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -625,9 +625,9 @@ void PromptScreen::CreateViews() {
 
 	root_ = new AnchorLayout();
 
-	root_->Add(new TextView(message_, ALIGN_LEFT | FLAG_WRAP_TEXT, false, new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 15, 15, 330, 10)))->SetClip(false);
+	root_->Add(new TextView(message_, ALIGN_LEFT | FLAG_WRAP_TEXT, false, new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 15, 105, 330, 10)))->SetClip(false);
 
-	ViewGroup *rightColumnItems = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(300, WRAP_CONTENT, NONE, 15, 15, NONE));
+	ViewGroup *rightColumnItems = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(300, WRAP_CONTENT, NONE, 105, 15, NONE));
 	root_->Add(rightColumnItems);
 
 	Choice *yesButton = rightColumnItems->Add(new Choice(yesButtonText_));

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -91,7 +91,6 @@ private:
 	void CreateSavedataTab(UI::ViewGroup *savedata);
 	void CreateSavestateTab(UI::ViewGroup *savestate);
 
-	bool gridStyle_ = false;
 	SavedataSortOption sortOption_ = SavedataSortOption::FILENAME;
 	SavedataBrowser *dataBrowser_ = nullptr;
 	SavedataBrowser *stateBrowser_ = nullptr;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1550,7 +1550,7 @@ static void ProcessFrameCommands(JNIEnv *env) {
 		frameCmd = frameCommands.front();
 		frameCommands.pop();
 
-		INFO_LOG(Log::System, "frameCommand '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
+		DEBUG_LOG(Log::System, "frameCommand '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
 
 		jstring cmd = env->NewStringUTF(frameCmd.command.c_str());
 		jstring param = env->NewStringUTF(frameCmd.params.c_str());

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -990,7 +990,7 @@ public abstract class NativeActivity extends Activity {
 	@Override
 	public boolean dispatchKeyEvent(KeyEvent event) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
-			Log.i(TAG, "key event" + event.getSource());
+			// Log.d(TAG, "key event source: " + event.getSource());
 			if (NativeSurfaceView.isFromSource(event, InputDevice.SOURCE_MOUSE)) {
 				Log.i(TAG, "Forwarding key event from mouse: " + event.getKeyCode());
 				Log.i(TAG, "usemodernb2: " + useModernMouseEventsB2);


### PR DESCRIPTION
This caused us to try to read from a nonexisting framebuffer, causing the crash in #20267 

Fixes #20267.

Also does some minor warning fixes and a small UI change.