### PR TITLE
Cleanup GTA compat entries

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -293,10 +293,10 @@ ULJS00180 = true
 ULJS00267 = true
 ULJM05904 = true
 NPJH50440 = true
-# Midnight Club 3 : DUB edition
+# Midnight Club 3: DUB Edition
 ULUS10021 = true
 ULES00108 = true
-# GTA : VCS
+# Grand Theft Auto: Vice City Stories
 ULUS10160 = true
 ULES00502 = true
 ULES00503 = true
@@ -304,9 +304,9 @@ ULJM05297 = true
 ULJM05395 = true
 ULJM05884 = true
 NPJH50827 = true
-# GTA : VCS Prototypes
+# Grand Theft Auto: Vice City Stories (prototypes)
 ULET00417 = true
-# GTA : LCS
+# Grand Theft Auto: Liberty City Stories
 ULUS10041 = true
 ULES00151 = true
 ULES00182 = true
@@ -314,11 +314,9 @@ ULJM05255 = true
 ULJM05359 = true
 ULJM05885 = true
 NPJH50825 = true
-ULKS46157 = true
-# GTA : LCS Prototypes
-ULUS01826 = true
+# Grand Theft Auto: Liberty City Stories (prototypes)
 ULUX80146 = true
-# Sindacco Chronicles total conversion
+# Grand Theft Auto: Sindacco Chronicles (romhack)
 ULUS01826 = true
 
 # GOW : Ghost of Sparta
@@ -518,7 +516,7 @@ ULJS00180 = true
 ULJS00267 = true
 ULJM05904 = true
 NPJH50440 = true
-# Midnight Club 3 : DUB edition
+# Midnight Club 3: DUB Edition
 ULUS10021 = true
 ULES00108 = true
 

--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -126,15 +126,14 @@ UCUS98632 = true
 
 # Grand Theft Auto: Liberty City Stories
 NPJH50825 = true
-ULES00051 = true
 ULES00151 = true
-ULES00181 = true
 ULES00182 = true
 ULJM05255 = true
 ULJM05359 = true
 ULJM05885 = true
 ULUS10041 = true
-# Sindacco Chronicles total conversion
+
+# Grand Theft Auto: Sindacco Chronicles (romhack)
 ULUS01826 = true
 
 # Grand Theft Auto: Vice City Stories
@@ -152,8 +151,8 @@ ULUS10160 = true
 # + 3D stereoscopy  (that can work only with accurate values)
 # * 6DoF motion tracking (that can work with inaccurate values)
 
-# cube.elf
-ELF000000 = 10.0
+# cube.elf (homebrew)
+CUBE00772 = 10.0
 
 # 300: March to Glory
 ULES00766 = 0.95
@@ -849,15 +848,14 @@ ULUS10490 = 1.0
 
 # Grand Theft Auto: Liberty City Stories
 NPJH50825 = 0.5
-ULES00051 = 0.5
 ULES00151 = 0.5
-ULES00181 = 0.5
 ULES00182 = 0.5
 ULJM05255 = 0.5
 ULJM05359 = 0.5
 ULJM05885 = 0.5
 ULUS10041 = 0.5
-# Sindacco Chronicles total conversion
+
+# Grand Theft Auto: Sindacco Chronicles (romhack)
 ULUS01826 = 0.5
 
 # Grand Theft Auto: Vice City Stories


### PR DESCRIPTION
Cleanup of #12351, #17645 and #20039

- Removed duplicate entry of Sindacco Chronicles from LCS prototypes. Also renamed SC's title to be less confusing.
- Removed LCS Korean serial ULKS46157, which is only present on the box so it's useless to us
- Removed dubious LCS entries (only found in legacy online databases, most likely typos): ULES00051, ULES00181
- Updated cube.elf serial to CUBE00772


In the future the entries of compat.ini should be organized alphabetically like comparvr.ini.