### PR TITLE
Misc ImDebugger improvements

### DIFF
--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -965,6 +965,21 @@ static void DrawBreakpointsView(MIPSDebugInterface *mipsDebug, ImConfig &cfg) {
 			if (ImGui::BeginChild("mc_edit")) {
 				auto &mc = mcs[cfg.selectedMemCheck];
 				ImGui::TextUnformatted("Edit memcheck");
+				if (ImGui::BeginCombo("Condition", MemCheckConditionToString(mc.cond))) {
+					if (ImGui::Selectable("Read", mc.cond == MemCheckCondition::MEMCHECK_READ)) {
+						mc.cond = MemCheckCondition::MEMCHECK_READ;
+					}
+					if (ImGui::Selectable("Write", mc.cond == MemCheckCondition::MEMCHECK_WRITE)) {
+						mc.cond = MemCheckCondition::MEMCHECK_WRITE;
+					}
+					if (ImGui::Selectable("Read / Write", mc.cond == MemCheckCondition::MEMCHECK_READWRITE)) {
+						mc.cond = MemCheckCondition::MEMCHECK_READWRITE;
+					}
+					if (ImGui::Selectable("Write On Change", mc.cond == MemCheckCondition::MEMCHECK_WRITE_ONCHANGE)) {
+						mc.cond = MemCheckCondition::MEMCHECK_WRITE_ONCHANGE;
+					}
+					ImGui::EndCombo();
+				}
 				ImGui::CheckboxFlags("Enabled", (int *)&mc.result, (int)BREAK_ACTION_PAUSE);
 				ImGui::InputScalar("Start", ImGuiDataType_U32, &mc.start, NULL, NULL, "%08x", ImGuiInputTextFlags_CharsHexadecimal);
 				ImGui::InputScalar("End", ImGuiDataType_U32, &mc.end, NULL, NULL, "%08x", ImGuiInputTextFlags_CharsHexadecimal);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1034,7 +1034,7 @@ void DrawMediaDecodersView(ImConfig &cfg, ImControl &control) {
 		auto iter = mpegCtxs.find(cfg.selectedMpegCtx);
 		if (iter != mpegCtxs.end()) {
 			const MpegContext *ctx = iter->second;
-			char temp[16];
+			char temp[28];
 			snprintf(temp, sizeof(temp), "sceMpeg context at %08x", iter->first);
 			if (ctx && ImGui::CollapsingHeader(temp, ImGuiTreeNodeFlags_DefaultOpen)) {
 				// ImGui::ProgressBar((float)sas->CurPos() / (float)info.fileDataEnd, ImVec2(200.0f, 0.0f));

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -182,7 +182,7 @@ void ImMemView::Draw(ImDrawList *drawList) {
 				int bgWidth = 2; // continueRect ? 3 : 2;
 				drawList->AddRectFilled(ImVec2(canvas_p0.x + hexX - 1, canvas_p0.y + rowY), ImVec2(canvas_p0.x + hexX + charWidth_ * bgWidth, canvas_p0.y + rowY + charHeight_), bg);
 			}
-			if (temp[0] == '0' && temp[1] == '0') {
+			if (drawZeroDark_ && temp[0] == '0' && temp[1] == '0') {
 				// if the byte is all zero make it darker
 				fg = zeroColor;
 			}
@@ -841,6 +841,10 @@ void ImMemView::setHighlightType(MemBlockFlags flags) {
 	}
 }
 
+void ImMemView::toggleDrawZeroDark(bool toggle) {
+	drawZeroDark_ = toggle;
+}
+
 void ImMemDumpWindow::Draw(ImConfig &cfg, MIPSDebugInterface *debug) {
 	ImGui::SetNextWindowSize(ImVec2(200, 300), ImGuiCond_FirstUseEver);
 
@@ -916,6 +920,16 @@ void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &
 	ImGui::SameLine();
 	if (ImGui::SmallButton("Go")) {
 		memView_.gotoAddr(gotoAddr_);
+	}
+	ImGui::SameLine();
+	if (ImGui::SmallButton("Settings")) {
+		ImGui::OpenPopup("disSettings");
+	}
+	if (ImGui::BeginPopup("disSettings")) {
+		if(ImGui::Checkbox("Darken Zeros", &drawZeroDark_)) {
+			memView_.toggleDrawZeroDark(drawZeroDark_);
+		}
+		ImGui::EndPopup();
 	}
 
 	ImVec2 size(0, -ImGui::GetFrameHeightWithSpacing());

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -150,6 +150,8 @@ void ImMemView::Draw(ImDrawList *drawList) {
 			const ImColor secondarySelFg = 0xFFFFFFFF;
 			const ImColor secondarySelBg = 0xFF808080;
 
+			const ImColor zeroColor = 0x888888ff;
+
 			if (address + j >= selectRangeStart_ && address + j < selectRangeEnd_ && !searching_) {
 				if (asciiSelected_) {
 					hexBGCol = secondarySelBg;
@@ -179,6 +181,10 @@ void ImMemView::Draw(ImDrawList *drawList) {
 			if (bg != 0) {
 				int bgWidth = 2; // continueRect ? 3 : 2;
 				drawList->AddRectFilled(ImVec2(canvas_p0.x + hexX - 1, canvas_p0.y + rowY), ImVec2(canvas_p0.x + hexX + charWidth_ * bgWidth, canvas_p0.y + rowY + charHeight_), bg);
+			}
+			if (temp[0] == '0' && temp[1] == '0') {
+				// if the byte is all zero make it darker
+				fg = zeroColor;
 			}
 			drawList->AddText(ImVec2(canvas_p0.x + hexX, canvas_p0.y + rowY), fg, &temp[0], &temp[2]);
 			if (underline >= 0) {

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -43,6 +43,8 @@ public:
 	void toggleOffsetScale(CommonToggles toggle);
 	void setHighlightType(MemBlockFlags flags);
 
+	void toggleDrawZeroDark(bool toggle);
+
 	const std::string &StatusMessage() const {
 		return statusMessage_;
 	}
@@ -108,6 +110,8 @@ private:
 
 	// Number of rows visible as of last redraw.
 	int visibleRows_ = 0;
+
+	bool drawZeroDark_ = false;
 
 	// Last used search query, used when continuing a search.
 	std::string searchQuery_;
@@ -176,6 +180,8 @@ private:
 	bool symsDirty_ = true;
 	int selectedSymbol_ = -1;
 	char selectedSymbolName_[128];
+
+	bool drawZeroDark_ = false;
 
 	ImMemView memView_;
 	char searchTerm_[64]{};


### PR DESCRIPTION
Changes

1. add the option to change MemCheck condition
2. draw zeros with a darker color in the memory viewer
3. fix a potential issue with a char array that is too small(?) in DrawMediaDecodersView. 

When reverse engineering it can be helpful for zeros to be drawn with a darker color so you can visually see the structure of data in ram.
The new color was basically just a random choice so feel free to change it. 

I only found the small char array because of a compiler warning so it is very possible that nothing bad actually happens.