### PR TITLE
Improve custom themes

### DIFF
--- a/UI/Theme.cpp
+++ b/UI/Theme.cpp
@@ -50,7 +50,7 @@ struct ThemeInfo {
 	uint32_t uInfoStyleFg = 0xFFFFFFFF;
 	uint32_t uInfoStyleBg = 0x00000000;
 	uint32_t uPopupStyleFg = 0xFFFFFFFF;
-	uint32_t uPopupStyleBg = 0xFF303030;
+	uint32_t uPopupStyleBg = 0xFF5E4D1F;
 	uint32_t uPopupTitleStyleFg = 0xFFFFFFFF;
 	uint32_t uPopupTitleStyleBg = 0x00000000;  // default to invisible
 	uint32_t uTooltipStyleFg = 0xFFFFFFFF;

--- a/assets/themes/1995.ini
+++ b/assets/themes/1995.ini
@@ -2,16 +2,21 @@
 # Inspired by Windows 95
 
 # Colors Used:
-# Desktop    #008080FF
-# Forms      #C0C0C0FF
-# Work area  #FFFFFFFF
-# Tooltip    #FFFFAAFF
-# Text       #000000FF
-# Disabled   #808080FF
-# Highlight  #000080FF
+#  Desktop    #008080FF
+#  Forms      #C0C0C0FF
+#  Work area  #FFFFFFFF
+#  Tooltip    #FFFFAAFF
+#  Text       #000000FF
+#  Disabled   #808080FF
+#  Highlight  #000080FF
+#  Blue       #0000FFFF
 
 [1995]
 Name = "1995"
+
+BackgroundColor = "#008080FF"
+ScrollbarColor = "#808080FF"
+
 ItemStyleFg = "#000000FF"
 ItemStyleBg = "#C0C0C0FF"
 ItemFocusedStyleFg = "#FFFFFFFF"
@@ -20,18 +25,20 @@ ItemDownStyleFg = "#FFFFFFFF"
 ItemDownStyleBg = "#000080FF"
 ItemDisabledStyleFg = "#808080FF"
 ItemDisabledStyleBg = "#C0C0C0FF"
-HeaderStyleFg = "#FFFFFFFF"
-HeaderStyleBg = "#00000000"
+
+HeaderStyleFg = "#C0C0C0FF"
+HeaderStyleBg = "#808080FF"
+CollapsibleHeaderStyleFg = "#C0C0C0FF"
+CollapsibleHeaderStyleBg = "#808080FF"
+
 InfoStyleFg = "#FFFFFFFF"
-InfoStyleBg = "#00000000"
+InfoStyleBg = "#008080FF"
+TooltipStyleFg = "#000000FF"
+TooltipStyleBg = "#FFFFAAFF"
+
 PopupStyleFg = "#000000FF"
-PopupStyleBg = "#FFFFAAFF"
+PopupStyleBg = "#FFFFFFFF"
 PopupTitleStyleFg = "#FFFFFFFF"
 PopupTitleStyleBg = "#000080FF"
-CollapsibleHeaderStyleFg = "#000000FF"
-CollapsibleHeaderStyleBg = "#C0C0C0FF"
-TooltipStyleFg = "#FFFFFFFF"
-TooltipStyleBg = "#000080D0"
-BackgroundColor = "#008080FF"
-ScrollbarColor = "#00000080"
-UIAtlas = "../ui_atlas"
+PopupSliderColor = "#000000FF"
+PopupSliderFocusedColor = "#0000FFFF"

--- a/assets/themes/slateforest.ini
+++ b/assets/themes/slateforest.ini
@@ -1,15 +1,20 @@
-########## Slate Forest by Jacob Olesen ##########
-# https://www.color-meanings.com/category/color-design/
+########## Slate Forest by NABN00B ##########
+# Original color palette by Jacob Olesen
+# https://www.color-meanings.com/dark-color-palettes/
 
 # Colors Used:
-# Prussian blue     #122537FF
-# Pickled bluewood  #2D4459B0
-# Cadet gray        #9498A1FF
-# Coffee            #74563BFF
-# Taupe             #4E433BFF
+#  Prussian blue     #122537FF
+#  Pickled bluewood  #2D4459B0
+#  Cadet gray        #9498A1FF
+#  Coffee            #74563BFF
+#  Taupe             #4E433BFF
 
 [SlateForest]
 Name = "Slate Forest"
+
+BackgroundColor = "#122537FF"
+ScrollbarColor = "#FFFFFF80"
+
 ItemStyleFg = "#FFFFFFFF"
 ItemStyleBg = "#2D4459B0"
 ItemFocusedStyleFg = "#FFFFFFFF"
@@ -18,18 +23,20 @@ ItemDownStyleFg = "#FFFFFFFF"
 ItemDownStyleBg = "#4E433BFF"
 ItemDisabledStyleFg = "#EEEEEE80"
 ItemDisabledStyleBg = "#00000055"
+
 HeaderStyleFg = "#FFFFFFFF"
 HeaderStyleBg = "#00000000"
-InfoStyleFg = "#FFFFFFFF"
-InfoStyleBg = "#00000000"
-PopupStyleFg = "#FFFFFFFF"
-PopupStyleBg = "#9498A1FF"
-PopupTitleStyleFg = "#FFFFFFFF"
-PopupTitleStyleBg = "#00000000"
 CollapsibleHeaderStyleFg = "#FFFFFFFF"
 CollapsibleHeaderStyleBg = "#2D4459B0"
+
+InfoStyleFg = "#FFFFFFFF"
+InfoStyleBg = "#00000000"
 TooltipStyleFg = "#FFFFFFFF"
-TooltipStyleBg = "#303030C0"
-BackgroundColor = "#122537FF"
-ScrollbarColor = "#FFFFFF80"
-UIAtlas = "../ui_atlas"
+TooltipStyleBg = "#9498A1FF"
+
+PopupStyleFg = "#FFFFFFFF"
+PopupStyleBg = "#9498A1FF"
+PopupTitleStyleFg = "#122537FF"
+PopupTitleStyleBg = "#00000000"
+PopupSliderColor = "#FFFFFFFF"
+PopupSliderFocusedColor = "#122537FF"

--- a/assets/themes/vinewood.ini
+++ b/assets/themes/vinewood.ini
@@ -2,35 +2,43 @@
 # Inspired by Grand Theft Auto: San Andreas - The Definitive Edition artworks
 
 # Colors Used:
-# Sky           #C3D7A4FF
-# Silhouettes   #94B185FF
-# Ground        #62865AFF
-# Highlight     #656B5EFF
-# Gold brown 1  #B2A170FF
-# Gold brown 2  #B49566FF
+#  Sky art         #C3D7A4FF
+#  Silhouette art  #94B185FF
+#  Ground art      #62865AFF
+#  Menu item       #000000DA
+#  Highlight       #666A5DFF
+#  Unavailable fg  #666666FF
+#  Unavailable bg  #00000094
+#  Slider          #FFFFFFD9
 
 [Vinewood]
 Name = "Vinewood"
+
+BackgroundColor = "#62865AFF"
+ScrollbarColor = "#FFFFFFD9"
+
 ItemStyleFg = "#C3D7A4FF"
-ItemStyleBg = "#000000C0"
+ItemStyleBg = "#000000DA"
 ItemFocusedStyleFg = "#FFFFFFFF"
-ItemFocusedStyleBg = "#656B5EFF"
+ItemFocusedStyleBg = "#666A5DFF"
 ItemDownStyleFg = "#000000FF"
 ItemDownStyleBg = "#FFFFFFFF"
-ItemDisabledStyleFg = "#FFFFFFC0"
-ItemDisabledStyleBg = "#000000FF"
+ItemDisabledStyleFg = "#666666FF"
+ItemDisabledStyleBg = "#00000094"
+
 HeaderStyleFg = "#FFFFFFFF"
 HeaderStyleBg = "#00000000"
+CollapsibleHeaderStyleFg = "#C3D7A4FF"
+CollapsibleHeaderStyleBg = "#000000DA"
+
 InfoStyleFg = "#FFFFFFFF"
 InfoStyleBg = "#00000000"
-PopupStyleFg = "#C3D7A4FF"
+TooltipStyleFg = "#FFFFFFFF"
+TooltipStyleBg = "#000000FF"
+
+PopupStyleFg = "#FFFFFFFF"
 PopupStyleBg = "#94B185FF"
 PopupTitleStyleFg = "#FFFFFFFF"
 PopupTitleStyleBg = "#00000000"
-CollapsibleHeaderStyleFg = "#C3D7A4FF"
-CollapsibleHeaderStyleBg = "#000000C0"
-TooltipStyleFg = "#FFFFFFFF"
-TooltipStyleBg = "#303030C0"
-BackgroundColor = "#62865AFF"
-ScrollbarColor = "#FFFFFF80"
-UIAtlas = "../ui_atlas"
+PopupSliderColor = "#FFFFFFD9"
+PopupSliderFocusedColor = "#FFFFFFFF"


### PR DESCRIPTION
Follow-up to #20308 .

Updates my custom themes and the fallback PopupStyleBg to match the new default since #16779 (improves #18802 point `13`).

EDIT: forgot to mention at first, but I also reorganized the order of properties into blocks. Improves readability a ton.

![image](https://github.com/user-attachments/assets/d2fdf736-e6b0-4bc1-b27b-ea5fc71968ad)
![image](https://github.com/user-attachments/assets/900a8f8a-c0d6-4ebb-b809-f9e01887e7df)
![image](https://github.com/user-attachments/assets/05784c25-6159-48e8-8fec-28dd85388de9)