### PR TITLE
More async GPU init

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -273,14 +273,21 @@ public:
 
 	// Use during shutdown to make sure there aren't any leftover tasks sitting queued.
 	// Could probably be done more elegantly. Like waiting for all tasks of a type, or saving pointers to them, or something...
-	static void WaitForAll();
+	// Returns the maximum value of tasks in flight seen during the wait.
+	static int WaitForAll();
 	static std::atomic<int> tasksInFlight_;
 };
 
-void CreateMultiPipelinesTask::WaitForAll() {
-	while (tasksInFlight_.load() > 0) {
+int CreateMultiPipelinesTask::WaitForAll() {
+	int inFlight = 0;
+	int maxInFlight = 0;
+	while ((inFlight = tasksInFlight_.load()) > 0) {
+		if (inFlight > maxInFlight) {
+			maxInFlight = inFlight;
+		}
 		sleep_ms(2, "create-multi-pipelines-wait");
 	}
+	return maxInFlight;
 }
 
 std::atomic<int> CreateMultiPipelinesTask::tasksInFlight_;
@@ -773,6 +780,10 @@ void VulkanRenderManager::ReportBadStateForDraw() {
 		truncate_cpy(cause2, str.c_str());
 	}
 	ERROR_LOG_REPORT_ONCE(baddraw, Log::G3D, "Can't draw: %s%s. Step count: %d", cause1, cause2, (int)steps_.size());
+}
+
+int VulkanRenderManager::WaitForPipelines() {
+	return CreateMultiPipelinesTask::WaitForAll();
 }
 
 VKRGraphicsPipeline *VulkanRenderManager::CreateGraphicsPipeline(VKRGraphicsPipelineDesc *desc, PipelineFlags pipelineFlags, uint32_t variantBitmask, VkSampleCountFlagBits sampleCount, bool cacheLoad, const char *tag) {

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -410,7 +410,7 @@ void VulkanRenderManager::StopThreads() {
 		presentWaitThread_.join();
 	}
 
-	INFO_LOG(Log::G3D, "Vulkan compiler thread joined. Now wait for any straggling compile tasks.");
+	INFO_LOG(Log::G3D, "Vulkan compiler thread joined. Now wait for any straggling compile tasks. runCompileThread_ = %d", (int)runCompileThread_);
 	CreateMultiPipelinesTask::WaitForAll();
 
 	{

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -283,6 +283,8 @@ public:
 
 	void ReportBadStateForDraw();
 
+	int WaitForPipelines();
+
 	void NudgeCompilerThread() {
 		compileQueueMutex_.lock();
 		compileCond_.notify_one();

--- a/Common/Render/TextureAtlas.cpp
+++ b/Common/Render/TextureAtlas.cpp
@@ -61,8 +61,10 @@ bool Atlas::Load(const uint8_t *data, size_t data_size) {
 		return false;
 	}
 
-	images = reader.ReadMultipleAlloc<AtlasImage>(num_images, header.version >= 1);
+	delete[] images;
+	delete[] fonts;
 
+	images = reader.ReadMultipleAlloc<AtlasImage>(num_images, header.version >= 1);
 	fonts = new AtlasFont[num_fonts];
 	for (int i = 0; i < num_fonts; i++) {
 		AtlasFontHeader font_header = reader.Read<AtlasFontHeader>();

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -23,7 +23,7 @@
 #include "Core/Compatibility.h"
 #include "Core/Loaders.h"
 
-enum GPUCore {
+enum GPUCore : int {
 	GPUCORE_GLES,
 	GPUCORE_SOFTWARE,
 	GPUCORE_DIRECTX9,

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -575,6 +575,8 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 			return;
 		}
 
+		// Initialize the GPU as far as we can here (do things like load cache files).
+
 		g_bootState = BootState::Complete;
 	});
 
@@ -609,7 +611,8 @@ BootState PSP_InitUpdate(std::string *error_string) {
 		INFO_LOG(Log::Loader, "Starting graphics...");
 		Draw::DrawContext *draw = g_CoreParameter.graphicsContext ? g_CoreParameter.graphicsContext->GetDrawContext() : nullptr;
 		// This set the `gpu` global.
-		bool success = GPU_Init(g_CoreParameter.graphicsContext, draw);
+		GPUCore gpuCore = PSP_CoreParameter().gpuCore;
+		bool success = GPU_Init(gpuCore, g_CoreParameter.graphicsContext, draw);
 		if (!success) {
 			*error_string = "Unable to initialize rendering engine.";
 			PSP_Shutdown(false);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -617,17 +617,9 @@ BootState PSP_InitUpdate(std::string *error_string) {
 			*error_string = "Unable to initialize rendering engine.";
 			PSP_Shutdown(false);
 			g_bootState = BootState::Off;
+			Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);
 			return BootState::Failed;
 		}
-	}
-
-	// TODO: This should all be checked during GPU_Init.
-	if (!GPU_IsStarted()) {
-		*error_string = "Unable to initialize rendering engine.";
-		PSP_Shutdown(false);
-		g_bootState = BootState::Off;
-		Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);
-		return BootState::Failed;
 	}
 
 	Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2783,7 +2783,7 @@ void FramebufferManagerCommon::NotifyBlockTransferAfter(u32 dstBasePtr, int dstS
 
 		// A few games use this INSTEAD of actually drawing the video image to the screen, they just blast it to
 		// the backbuffer. Detect this and have the framebuffermanager draw the pixels.
-		if (!useBufferedRendering_ && currentRenderVfb_ != dstRect.vfb) {
+		if ((!useBufferedRendering_ && currentRenderVfb_ != dstRect.vfb) || dstRect.vfb == nullptr) {
 			return;
 		}
 

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -39,8 +39,6 @@ GPU_D3D11::GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	context_ = (ID3D11DeviceContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
 	D3D_FEATURE_LEVEL featureLevel = (D3D_FEATURE_LEVEL)draw->GetNativeObject(Draw::NativeObject::FEATURE_LEVEL);
 
-	stockD3D11.Create(device_);
-
 	shaderManagerD3D11_ = new ShaderManagerD3D11(draw, device_, context_, featureLevel);
 	framebufferManagerD3D11_ = new FramebufferManagerD3D11(draw);
 	framebufferManager_ = framebufferManagerD3D11_;
@@ -75,6 +73,11 @@ GPU_D3D11::GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	// Some of our defaults are different from hw defaults, let's assert them.
 	// We restore each frame anyway, but here is convenient for tests.
 	textureCache_->NotifyConfigChanged();
+}
+
+void GPU_D3D11::FinishInitOnMainThread() {
+	textureCacheD3D11_->InitDeviceObjects();
+	stockD3D11.Create(device_);
 }
 
 GPU_D3D11::~GPU_D3D11() {

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -34,6 +34,8 @@ public:
 	GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPU_D3D11();
 
+	void FinishInitOnMainThread() override;
+
 	u32 CheckGPUFeatures() const override;
 
 	void GetStats(char *buffer, size_t bufsize) override;

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -42,6 +42,8 @@ private:
 	std::map<SamplerCacheKey, Microsoft::WRL::ComPtr<ID3D11SamplerState>> cache_;
 };
 
+#define D3D11_INVALID_TEX (ID3D11ShaderResourceView *)(-1LL)
+
 class TextureCacheD3D11 : public TextureCacheCommon {
 public:
 	TextureCacheD3D11(Draw::DrawContext *draw, Draw2D *draw2D);
@@ -55,6 +57,8 @@ public:
 
 	void DeviceLost() override { draw_ = nullptr; }
 	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
+
+	void InitDeviceObjects();
 
 protected:
 	void BindTexture(TexCacheEntry *entry) override;
@@ -82,7 +86,7 @@ private:
 
 	SamplerCacheD3D11 samplerCache_;
 
-	ID3D11ShaderResourceView *lastBoundTexture;
+	ID3D11ShaderResourceView *lastBoundTexture_ = D3D11_INVALID_TEX;
 	Microsoft::WRL::ComPtr<ID3D11Buffer> depalConstants_;
 };
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -75,7 +75,6 @@ GPU_DX9::GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 
 	// Some of our defaults are different from hw defaults, let's assert them.
 	// We restore each frame anyway, but here is convenient for tests.
-	dxstate.Restore();
 	textureCache_->NotifyConfigChanged();
 
 	if (g_Config.bHardwareTessellation) {
@@ -85,6 +84,11 @@ GPU_DX9::GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 		// TODO: Badly formulated
 		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("Turn off Hardware Tessellation - unsupported"));
 	}
+}
+
+void GPU_DX9::FinishInitOnMainThread() {
+	textureCacheDX9_->InitDeviceObjects();
+	dxstate.Restore();
 }
 
 u32 GPU_DX9::CheckGPUFeatures() const {

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -34,6 +34,7 @@ class FramebufferManagerDX9;
 class GPU_DX9 : public GPUCommonHW {
 public:
 	GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
+	void FinishInitOnMainThread() override;
 
 	u32 CheckGPUFeatures() const override;
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -73,6 +73,15 @@ TextureCacheDX9::TextureCacheDX9(Draw::DrawContext *draw, Draw2D *draw2D)
 	lastBoundTexture = INVALID_TEX;
 	device_ = (LPDIRECT3DDEVICE9)draw->GetNativeObject(Draw::NativeObject::DEVICE);
 	deviceEx_ = (LPDIRECT3DDEVICE9EX)draw->GetNativeObject(Draw::NativeObject::DEVICE_EX);
+
+	InitDeviceObjects();
+}
+
+TextureCacheDX9::~TextureCacheDX9() {
+	Clear(true);
+}
+
+void TextureCacheDX9::InitDeviceObjects() {
 	D3DCAPS9 pCaps;
 	ZeroMemory(&pCaps, sizeof(pCaps));
 	HRESULT result = 0;
@@ -90,10 +99,6 @@ TextureCacheDX9::TextureCacheDX9(Draw::DrawContext *draw, Draw2D *draw2D)
 
 	nextTexture_ = nullptr;
 	device_->CreateVertexDeclaration(g_FramebufferVertexElements, &pFramebufferVertexDecl);
-}
-
-TextureCacheDX9::~TextureCacheDX9() {
-	Clear(true);
 }
 
 void TextureCacheDX9::SetFramebufferManager(FramebufferManagerDX9 *fbManager) {

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -73,8 +73,6 @@ TextureCacheDX9::TextureCacheDX9(Draw::DrawContext *draw, Draw2D *draw2D)
 	lastBoundTexture = INVALID_TEX;
 	device_ = (LPDIRECT3DDEVICE9)draw->GetNativeObject(Draw::NativeObject::DEVICE);
 	deviceEx_ = (LPDIRECT3DDEVICE9EX)draw->GetNativeObject(Draw::NativeObject::DEVICE_EX);
-
-	InitDeviceObjects();
 }
 
 TextureCacheDX9::~TextureCacheDX9() {

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -46,6 +46,7 @@ public:
 	void DeviceLost() override { draw_ = nullptr; }
 	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
 
+	void InitDeviceObjects();
 protected:
 	void BindTexture(TexCacheEntry *entry) override;
 	void Unbind() override;
@@ -54,7 +55,6 @@ protected:
 	void *GetNativeTextureView(const TexCacheEntry *entry, bool flat) const override;
 
 private:
-	void InitDeviceObjects();
 	void ApplySamplingParams(const SamplerCacheKey &key) override;
 
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -54,6 +54,7 @@ protected:
 	void *GetNativeTextureView(const TexCacheEntry *entry, bool flat) const override;
 
 private:
+	void InitDeviceObjects();
 	void ApplySamplingParams(const SamplerCacheKey &key) override;
 
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
@@ -73,7 +74,7 @@ private:
 	IDirect3DBaseTexture9 *lastBoundTexture = nullptr;
 	float maxAnisotropyLevel;
 
-	FramebufferManagerDX9 *framebufferManagerDX9_;
+	FramebufferManagerDX9 *framebufferManagerDX9_ = nullptr;
 };
 
 static D3DFORMAT getClutDestFormat(GEPaletteFormat format);

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -43,12 +43,6 @@ GPUStatistics gpuStats;
 GPUCommon *gpu;
 GPUDebugInterface *gpuDebug;
 
-template <typename T>
-static void SetGPU(T *obj) {
-	gpu = obj;
-	gpuDebug = obj;
-}
-
 #ifdef USE_CRT_DBG
 #undef new
 #endif
@@ -59,70 +53,78 @@ bool GPU_IsStarted() {
 	return false;
 }
 
-bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
-	const auto &gpuCore = PSP_CoreParameter().gpuCore;
-	_assert_(draw || gpuCore == GPUCORE_SOFTWARE);
+static GPUCommon *CreateGPUCore(GPUCore gpuCore, GraphicsContext *ctx, Draw::DrawContext *draw) {
 #if PPSSPP_PLATFORM(UWP)
+	// TODO: Can probably remove this special case.
 	if (gpuCore == GPUCORE_SOFTWARE) {
-		SetGPU(new SoftGPU(ctx, draw));
+		return new SoftGPU(ctx, draw);
 	} else {
-		SetGPU(new GPU_D3D11(ctx, draw));
+		return new GPU_D3D11(ctx, draw);
 	}
-	return true;
 #else
 	switch (gpuCore) {
 	case GPUCORE_GLES:
 		// Disable GLES on ARM Windows (but leave it enabled on other ARM platforms).
 #if PPSSPP_API(ANY_GL)
-		SetGPU(new GPU_GLES(ctx, draw));
-		break;
+		return new GPU_GLES(ctx, draw);
 #else
-		return false;
+		return nullptr;
 #endif
 	case GPUCORE_SOFTWARE:
-		SetGPU(new SoftGPU(ctx, draw));
-		break;
+		return new SoftGPU(ctx, draw);
 	case GPUCORE_DIRECTX9:
 #if PPSSPP_API(D3D9)
-		SetGPU(new GPU_DX9(ctx, draw));
-		break;
+		return new GPU_DX9(ctx, draw);
 #else
-		return false;
+		return nullptr;
 #endif
 	case GPUCORE_DIRECTX11:
 #if PPSSPP_API(D3D11)
-		SetGPU(new GPU_D3D11(ctx, draw));
-		break;
+		return new GPU_D3D11(ctx, draw);
 #else
-		return false;
+		return nullptr;
 #endif
 #if !PPSSPP_PLATFORM(SWITCH)
 	case GPUCORE_VULKAN:
 		if (!ctx) {
+			// Can this happen?
 			ERROR_LOG(Log::G3D, "Unable to init Vulkan GPU backend, no context");
-			break;
+			return nullptr;
 		}
-		SetGPU(new GPU_Vulkan(ctx, draw));
-		break;
+		return new GPU_Vulkan(ctx, draw);
 #endif
 	default:
-		break;
+		return nullptr;
 	}
-
-	if (gpu && !gpu->IsStarted())
-		SetGPU<SoftGPU>(nullptr);
-
-	return gpu != nullptr;
 #endif
 }
+
+bool GPU_Init(GPUCore gpuCore, GraphicsContext *ctx, Draw::DrawContext *draw) {
+	_assert_(draw || gpuCore == GPUCORE_SOFTWARE);
+	GPUCommon *createdGPU = CreateGPUCore(gpuCore, ctx, draw);
+
+	// This can happen on some memory allocation failure, but can probably just be ignored in practice.
+	if (createdGPU && !createdGPU->IsStarted()) {
+		delete createdGPU;
+		createdGPU = nullptr;
+	}
+
+	if (createdGPU) {
+		gpu = createdGPU;
+		gpuDebug = createdGPU;
+	}
+
+	return gpu != nullptr;
+}
+
 #ifdef USE_CRT_DBG
 #define new DBG_NEW
 #endif
 
 void GPU_Shutdown() {
-
 	delete gpu;
 	gpu = nullptr;
+	gpuDebug = nullptr;
 }
 
 const char *RasterChannelToString(RasterChannel channel) {

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -21,7 +21,7 @@
 #include <cstring>
 #include <cstdint>
 
-enum GPUCore;
+enum GPUCore : int;
 
 class GPUCommon;
 class GPUDebugInterface;

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -21,6 +21,8 @@
 #include <cstring>
 #include <cstdint>
 
+enum GPUCore;
+
 class GPUCommon;
 class GPUDebugInterface;
 class GraphicsContext;
@@ -181,7 +183,7 @@ namespace Draw {
 	class DrawContext;
 }
 
-bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw);
+bool GPU_Init(GPUCore gpuCore, GraphicsContext *ctx, Draw::DrawContext *draw);
 bool GPU_IsStarted();
 void GPU_Shutdown();
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -201,12 +201,21 @@ inline bool IsTrianglePrim(GEPrimitiveType prim) {
 
 class GPUCommon : public GPUDebugInterface {
 public:
+	// The constructor might run on the loader thread.
 	GPUCommon(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
+
+	// FinishInitOnMainThread runs on the main thread, of course.
+	virtual void FinishInitOnMainThread() {}
+
 	virtual ~GPUCommon() {}
 
 	Draw::DrawContext *GetDrawContext() {
 		return draw_;
 	}
+
+	virtual void DeviceLost() = 0;
+	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
+
 	virtual u32 CheckGPUFeatures() const = 0;
 
 	virtual void UpdateCmdInfo() = 0;
@@ -256,9 +265,6 @@ public:
 	virtual bool FramebufferReallyDirty() = 0;
 
 	virtual void ReapplyGfxState();
-
-	virtual void DeviceLost() = 0;
-	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 
 	// Returns true if we should split the call across GE execution.
 	// For example, a debugger is active.

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -229,5 +229,5 @@ private:
 	FBOTexState fboTexBindState_ = FBO_TEX_NONE;
 
 	// Hardware tessellation
-	TessellationDataTransferVulkan *tessDataTransferVulkan;
+	TessellationDataTransferVulkan *tessDataTransferVulkan = nullptr;
 };

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -65,7 +65,6 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	framebufferManagerVulkan_->SetTextureCache(textureCacheVulkan_);
 	framebufferManagerVulkan_->SetDrawEngine(&drawEngine_);
 	framebufferManagerVulkan_->SetShaderManager(shaderManagerVulkan_);
-	framebufferManagerVulkan_->Init(msaaLevel_);
 	textureCacheVulkan_->SetFramebufferManager(framebufferManagerVulkan_);
 	textureCacheVulkan_->SetShaderManager(shaderManagerVulkan_);
 	textureCacheVulkan_->SetDrawEngine(&drawEngine_);
@@ -90,6 +89,11 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	}
 
 	InitDeviceObjects();
+}
+
+void GPU_Vulkan::FinishInitOnMainThread() {
+	// This can end up stopping/starting the vulkan render manager.
+	framebufferManagerVulkan_->Init(msaaLevel_);
 }
 
 void GPU_Vulkan::LoadCache(const Path &filename) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -42,7 +42,6 @@
 GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	: GPUCommonHW(gfxCtx, draw), drawEngine_(draw) {
 	gstate_c.SetUseFlags(CheckGPUFeatures());
-	drawEngine_.InitDeviceObjects();
 
 	VulkanContext *vulkan = (VulkanContext *)gfxCtx->GetAPIContext();
 
@@ -71,8 +70,6 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	textureCacheVulkan_->SetShaderManager(shaderManagerVulkan_);
 	textureCacheVulkan_->SetDrawEngine(&drawEngine_);
 
-	InitDeviceObjects();
-
 	// Sanity check gstate
 	if ((int *)&gstate.transferstart - (int *)&gstate != 0xEA) {
 		ERROR_LOG(Log::G3D, "gstate has drifted out of sync!");
@@ -82,6 +79,8 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 
 	textureCache_->NotifyConfigChanged();
 
+	drawEngine_.InitDeviceObjects();  // Creates important things like the pipeline layout. Required for loading the disk cache.
+
 	// Load shader cache.
 	std::string discID = g_paramSFO.GetDiscID();
 	if (discID.size()) {
@@ -89,6 +88,8 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".vkshadercache");
 		LoadCache(shaderCachePath_);
 	}
+
+	InitDeviceObjects();
 }
 
 void GPU_Vulkan::LoadCache(const Path &filename) {

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -38,6 +38,8 @@ public:
 	GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPU_Vulkan();
 
+	void FinishInitOnMainThread() override;
+
 	// This gets called on startup and when we get back from settings.
 	u32 CheckGPUFeatures() const override;
 

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -95,6 +95,7 @@ public:
 	void DeviceRestore(VulkanContext *vulkan);
 
 	void InvalidateMSAAPipelines();
+	void BlockUntilReady();
 
 	std::string DebugGetObjectString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager);
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type) const;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1208,7 +1208,7 @@ void EmuScreen::CreateViews() {
 	root_->Add(buttons);
 
 	resumeButton_ = buttons->Add(new Button(dev->T("Resume")));
-	resumeButton_->OnClick.Add([this](UI::EventParams &) {
+	resumeButton_->OnClick.Add([](UI::EventParams &) {
 		if (coreState == CoreState::CORE_RUNTIME_ERROR) {
 			// Force it!
 			Memory::MemFault_IgnoreLastCrash();

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -151,9 +151,10 @@ private:
 
 	ImGuiContext *ctx_ = nullptr;
 
-	// TODO: Ugly!
 	bool frameStep_ = false;
+#ifdef MOBILE_DEVICE
 	bool startDumping_ = false;
+#endif
 };
 
 bool MustRunBehind();

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -152,7 +152,7 @@ private:
 	ImGuiContext *ctx_ = nullptr;
 
 	bool frameStep_ = false;
-#ifdef MOBILE_DEVICE
+#ifndef MOBILE_DEVICE
 	bool startDumping_ = false;
 #endif
 };

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1282,7 +1282,6 @@ bool NativeIsAtTopLevel() {
 	Screen *currentScreen = g_screenManager->topScreen();
 	if (currentScreen) {
 		bool top = currentScreen->isTopLevel();
-		INFO_LOG(Log::System, "Screen toplevel: %i", (int)top);
 		return currentScreen->isTopLevel();
 	} else {
 		ERROR_LOG(Log::System, "No current screen");


### PR DESCRIPTION
Move more of GPU init to the loader thread. This smooths out the spinner animation while loading/creating the pipeline cache, for example (with Vulkan at least).

Also fixes a minor memory leak.