### PR TITLE
Metal Gear Acid 2 oil spill crashfix

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -1168,6 +1168,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="Data\Collections\FastVec.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -1487,4 +1487,9 @@
       <Filter>ext\lua</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="Data\Collections\FastVec.natvis">
+      <Filter>Data\Collections</Filter>
+    </Natvis>
+  </ItemGroup>
 </Project>

--- a/Common/Data/Collections/FastVec.natvis
+++ b/Common/Data/Collections/FastVec.natvis
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+  <!-- FastVec -->
+  <Type Name="FastVec&lt;*&gt;">
+    <DisplayString>{{ size = {size_}, capacity = {capacity_} }}</DisplayString>
+    <Expand>
+      <Item Name="[size]">size_</Item>
+      <Item Name="[capacity]">capacity_</Item>
+      <ArrayItems>
+        <Size>size_</Size>
+        <ValuePointer>data_</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+</AutoVisualizer>

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1985,8 +1985,11 @@ void EmuScreen::AutoLoadSaveState() {
 	}
 
 	if (g_Config.iAutoLoadSaveState && autoSlot != -1) {
-		SaveState::LoadSlot(gamePath_, autoSlot, [this](SaveState::Status status, std::string_view message) {
+		SaveState::LoadSlot(gamePath_, autoSlot, [this, autoSlot](SaveState::Status status, std::string_view message) {
 			AfterSaveStateAction(status, message);
+			auto sy = GetI18NCategory(I18NCat::SYSTEM);
+			std::string msg = std::string(sy->T("Auto Load Savestate")) + ": " + StringFromFormat("%d", autoSlot);
+			g_OSD.Show(OSDType::MESSAGE_SUCCESS, msg);
 			if (status == SaveState::Status::FAILURE) {
 				autoLoadFailed_ = true;
 			}


### PR DESCRIPTION
Not really proud of this once since we are just improving a hack, but rendering this game efficiently is a challenge.

This does two things in MGA2:

* Set a max limit of commands to merge, avoiding the problem that happens at the oil slick (#20306 )
* Fixes the lack of scissor rectangle merging, which broke some graphical tricks

Additionally, throws in a natvis file so we can inspect FastVec<> in the debugger.