### PR TITLE
RISCV: enable some cpu extensions for spacemit k1

### DIFF
--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -201,6 +201,16 @@ void CPUInfo::Detect()
 		RiscV_Zba = true;
 		RiscV_Zbb = true;
 	}
+	if ((parser.FirmwareMatchesCompatible("spacemit,k1-x"))
+			|| (parser.FirmwareMatchesCompatible("spacemit,k1"))) {
+		RiscV_Zba = true;
+		RiscV_Zbb = true;
+		RiscV_Zbc = true;
+		RiscV_Zbs = true;
+		RiscV_Zfh = true;
+		RiscV_Zfhmin = true;
+		RiscV_Zicond = true;
+	}
 #endif
 
 #if defined(HAVE_GETAUXVAL) || defined(HAVE_ELF_AUX_INFO)


### PR DESCRIPTION
spacemit vendor linux kernel is spacemit,k1-x:
k1-x is from spacemit https://gitee.com/bianbu-linux/linux-6.6/blob/k1-bl-v2.1.y/arch/riscv/boot/dts/spacemit/k1-x.dtsi#L17 while upstream linux kernel is spacemit,k1:
https://github.com/torvalds/linux/blob/a5806cd506af5a7c19bcd596e4708b5c464bfd21/arch/riscv/boot/dts/spacemit/k1.dtsi#L11