### PR TITLE
Revert "Get rid of remains of support for non-square screen DPIs"

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -109,14 +109,14 @@ void DrawBuffer::Rect(float x, float y, float w, float h, uint32_t color, int al
 
 void DrawBuffer::hLine(float x1, float y, float x2, uint32_t color) {
 	// Round Y to the closest full pixel, since we're making it 1-pixel-thin.
-	y -= fmodf(y, g_display.pixel_in_dps);
-	Rect(x1, y, x2 - x1, g_display.pixel_in_dps, color);
+	y -= fmodf(y, g_display.pixel_in_dps_y);
+	Rect(x1, y, x2 - x1, g_display.pixel_in_dps_y, color);
 }
 
 void DrawBuffer::vLine(float x, float y1, float y2, uint32_t color) {
 	// Round X to the closest full pixel, since we're making it 1-pixel-thin.
-	x -= fmodf(x, g_display.pixel_in_dps);
-	Rect(x, y1, g_display.pixel_in_dps, y2 - y1, color);
+	x -= fmodf(x, g_display.pixel_in_dps_x);
+	Rect(x, y1, g_display.pixel_in_dps_x, y2 - y1, color);
 }
 
 void DrawBuffer::RectVGradient(float x1, float y1, float x2, float y2, uint32_t colorTop, uint32_t colorBottom) {
@@ -129,11 +129,11 @@ void DrawBuffer::RectVGradient(float x1, float y1, float x2, float y2, uint32_t 
 }
 
 void DrawBuffer::RectOutline(float x, float y, float w, float h, uint32_t color, int align) {
-	hLine(x, y, x + w + g_display.pixel_in_dps, color);
-	hLine(x, y + h, x + w + g_display.pixel_in_dps, color);
+	hLine(x, y, x + w + g_display.pixel_in_dps_x, color);
+	hLine(x, y + h, x + w + g_display.pixel_in_dps_x, color);
 
-	vLine(x, y, y + h + g_display.pixel_in_dps, color);
-	vLine(x + w, y, y + h + g_display.pixel_in_dps, color);
+	vLine(x, y, y + h + g_display.pixel_in_dps_y, color);
+	vLine(x + w, y, y + h + g_display.pixel_in_dps_y, color);
 }
 
 void DrawBuffer::MultiVGradient(float x, float y, float w, float h, const GradientStop *stops, int numStops) {

--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -38,7 +38,7 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 float TextDrawer::CalculateDPIScale() const {
 	if (ignoreGlobalDpi_)
 		return dpiScale_;
-	return g_display.dpi_scale;
+	return g_display.dpi_scale_y;
 }
 
 void TextDrawer::DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align) {

--- a/Common/System/Display.cpp
+++ b/Common/System/Display.cpp
@@ -54,7 +54,7 @@ DisplayProperties::DisplayProperties() {
 	rot_matrix.setIdentity();
 }
 
-bool DisplayProperties::Recalculate(int new_pixel_xres, int new_pixel_yres, float new_scale, float customScale) {
+bool DisplayProperties::Recalculate(int new_pixel_xres, int new_pixel_yres, float new_scale_x, float new_scale_y, float customScale) {
 	bool px_changed = false;
 	if (new_pixel_xres > 0 && pixel_xres != new_pixel_xres) {
 		pixel_xres = new_pixel_xres;
@@ -65,14 +65,19 @@ bool DisplayProperties::Recalculate(int new_pixel_xres, int new_pixel_yres, floa
 		px_changed = true;
 	}
 
-	if (new_scale > 0) {
-		dpi_scale_real = new_scale;
+	if (new_scale_x > 0) {
+		dpi_scale_real_x = new_scale_x;
 	}
-	dpi_scale = dpi_scale_real / customScale;
-	pixel_in_dps = 1.0f / dpi_scale;
+	if (new_scale_y > 0) {
+		dpi_scale_real_y = new_scale_y;
+	}
+	dpi_scale_x = dpi_scale_real_x / customScale;
+	dpi_scale_y = dpi_scale_real_y / customScale;
+	pixel_in_dps_x = 1.0f / dpi_scale_x;
+	pixel_in_dps_y = 1.0f / dpi_scale_y;
 
-	int new_dp_xres = (int)(pixel_xres * dpi_scale);
-	int new_dp_yres = (int)(pixel_yres * dpi_scale);
+	int new_dp_xres = (int)(pixel_xres * dpi_scale_x);
+	int new_dp_yres = (int)(pixel_yres * dpi_scale_y);
 	if (new_dp_xres != dp_xres || new_dp_yres != dp_yres || px_changed) {
 		dp_xres = new_dp_xres;
 		dp_yres = new_dp_yres;
@@ -86,10 +91,10 @@ void DisplayProperties::Print() {
 	printf("dp_xres/yres: %d, %d\n", dp_xres, dp_yres);
 	printf("pixel_xres/yres: %d, %d\n", pixel_xres, pixel_yres);
 
-	printf("dpi_scale: %f\n", dpi_scale);
-	printf("pixel_in_dps: %f\n", pixel_in_dps);
+	printf("dpi_scale: %f, %f\n", dpi_scale_x, dpi_scale_y);
+	printf("pixel_in_dps: %f, %f\n", pixel_in_dps_x, pixel_in_dps_y);
 
-	printf("dpi_real: %f\n", dpi_scale_real);
+	printf("dpi_real: %f, %f\n", dpi_scale_real_x, dpi_scale_real_y);
 	printf("display_hz: %f\n", display_hz);
 
 	printf("rotation: %d\n", (int)rotation);
@@ -105,15 +110,14 @@ Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordC
 		ortho.setOrthoD3D(0.0f, xres, 0, yres, -1.0f, 1.0f);
 		break;
 	case CoordConvention::Direct3D9:
-	{
 		ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
-		// Account for the small window adjustment.
-		float half_pixel = -0.5f * g_display.dpi_scale / g_display.dpi_scale_real;
 		Matrix4x4 translation;
-		translation.setTranslation(Vec3(half_pixel, half_pixel, 0.0f));
+		// Account for the small window adjustment.
+		translation.setTranslation(Vec3(
+			-0.5f * g_display.dpi_scale_x / g_display.dpi_scale_real_x,
+			-0.5f * g_display.dpi_scale_y / g_display.dpi_scale_real_y, 0.0f));
 		ortho = translation * ortho;
 		break;
-	}
 	case CoordConvention::Direct3D11:
 		ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
 		break;

--- a/Common/System/Display.h
+++ b/Common/System/Display.h
@@ -20,17 +20,20 @@ struct DisplayProperties {
 	int pixel_xres;
 	int pixel_yres;
 
-	float dpi_scale = 1.0f;
-
 	// Display resolution in virtual ("display") pixels
 	int dp_xres;
 	int dp_yres;
 
+	float dpi_scale_x = 1.0f;
+	float dpi_scale_y = 1.0f;
+
 	// Size of a physical pixel in dps
-	float pixel_in_dps = 1.0f;
+	float pixel_in_dps_x = 1.0f;
+	float pixel_in_dps_y = 1.0f;
 
 	// If DPI is overridden (like in small window mode), this is still the original DPI scale factor.
-	float dpi_scale_real = 1.0f;
+	float dpi_scale_real_x = 1.0f;
+	float dpi_scale_real_y = 1.0f;
 
 	float display_hz = 60.0f;
 
@@ -42,7 +45,7 @@ struct DisplayProperties {
 
 	// Returns true if the dimensions changed.
 	// The first three parameters can take -1 to signify "unchanged".
-	bool Recalculate(int new_pixel_xres, int new_pixel_yres, float new_scale, float customScale);
+	bool Recalculate(int new_pixel_xres, int new_pixel_yres, float new_scale_x, float new_scale_y, float customScale);
 };
 
 extern DisplayProperties g_display;

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -163,12 +163,13 @@ Bounds UIContext::GetLayoutBounds() const {
 void UIContext::ActivateTopScissor() {
 	Bounds bounds;
 	if (scissorStack_.size()) {
-		const float scale = g_display.pixel_in_dps;
+		float scale_x = g_display.pixel_in_dps_x;
+		float scale_y = g_display.pixel_in_dps_y;
 		bounds = scissorStack_.back();
-		int x = floorf(scale * bounds.x);
-		int y = floorf(scale * bounds.y);
-		int w = std::max(0.0f, ceilf(scale * bounds.w));
-		int h = std::max(0.0f, ceilf(scale * bounds.h));
+		int x = floorf(scale_x * bounds.x);
+		int y = floorf(scale_y * bounds.y);
+		int w = std::max(0.0f, ceilf(scale_x * bounds.w));
+		int h = std::max(0.0f, ceilf(scale_y * bounds.h));
 		if (x < 0 || y < 0 || x + w > g_display.pixel_xres || y + h > g_display.pixel_yres) {
 			DEBUG_LOG(Log::G3D, "UI scissor out of bounds: %d,%d-%d,%d / %d,%d", x, y, w, h, g_display.pixel_xres, g_display.pixel_yres);
 			if (x < 0) { w += x; x = 0; }

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -202,7 +202,7 @@ void SetVRAppMode(VRAppMode mode) {
 	appMode = mode;
 }
 
-void UpdateVRInput(bool haptics, float dp_scale) {
+void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 	//axis
 	if (pspKeys[(int)VIRTKEY_VR_CAMERA_ADJUST]) {
 		AxisInput axis[2] = {};
@@ -321,8 +321,8 @@ void UpdateVRInput(bool haptics, float dp_scale) {
 		//inform engine about the status
 		TouchInput touch;
 		touch.id = mouseController;
-		touch.x = x * dp_scale;
-		touch.y = (height - y - 1) * dp_scale / VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT);
+		touch.x = x * dp_xscale;
+		touch.y = (height - y - 1) * dp_yscale / VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT);
 		bool pressed = IN_VRGetButtonState(mouseController) & ovrButton_Trigger;
 		if (mousePressed != pressed) {
 			if (pressed) {

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -322,7 +322,7 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 		TouchInput touch;
 		touch.id = mouseController;
 		touch.x = x * dp_xscale;
-		touch.y = (height - y - 1) * dp_yscale / VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT);
+		touch.y = (height - y - 1) * dp_yscale;
 		bool pressed = IN_VRGetButtonState(mouseController) & ovrButton_Trigger;
 		if (mousePressed != pressed) {
 			if (pressed) {

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -36,7 +36,7 @@ void SetVRCallbacks(void(*axis)(const AxisInput *axis, size_t count), bool(*key)
 
 // VR input integration
 void SetVRAppMode(VRAppMode mode);
-void UpdateVRInput(bool haptics, float dp_scale);
+void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale);
 bool UpdateVRAxis(const AxisInput *axes, size_t count);
 bool UpdateVRKeys(const KeyInput &key);
 

--- a/Core/TiltEventProcessor.cpp
+++ b/Core/TiltEventProcessor.cpp
@@ -360,15 +360,16 @@ void ProcessDelta(double now, float dx, float dy) {
 void MouseDeltaToAxes(double now, float *mx, float *my) {
 	std::unique_lock<std::mutex> lock(g_mouseMutex);
 
-	float scaleFactor = g_display.dpi_scale * 0.1 * g_Config.fMouseSensitivity;
+	float scaleFactor_x = g_display.dpi_scale_x * 0.1 * g_Config.fMouseSensitivity;
+	float scaleFactor_y = g_display.dpi_scale_y * 0.1 * g_Config.fMouseSensitivity;
 
 	DecayMouse(now);
 
 	// TODO: Make configurable.
 	float mouseDeadZone = 0.1f;
 
-	float outX = clamp_value(g_mouseDeltaX * scaleFactor, -1.0f, 1.0f);
-	float outY = clamp_value(g_mouseDeltaY * scaleFactor, -1.0f, 1.0f);
+	float outX = clamp_value(g_mouseDeltaX * scaleFactor_x, -1.0f, 1.0f);
+	float outY = clamp_value(g_mouseDeltaY * scaleFactor_y, -1.0f, 1.0f);
 
 	ApplyDeadzoneXY(outX, outY, mx, my, mouseDeadZone, true);
 }

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -66,10 +66,10 @@ FRect GetScreenFrame(float pixelWidth, float pixelHeight) {
 
 	if (applyInset) {
 		// Remove the DPI scale to get back to pixels.
-		float left = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT) / g_display.dpi_scale;
-		float right = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_RIGHT) / g_display.dpi_scale;
-		float top = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP) / g_display.dpi_scale;
-		float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM) / g_display.dpi_scale;
+		float left = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT) / g_display.dpi_scale_x;
+		float right = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_RIGHT) / g_display.dpi_scale_x;
+		float top = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP) / g_display.dpi_scale_y;
+		float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM) / g_display.dpi_scale_y;
 
 		// Adjust left edge to compensate for cutouts (notches) if any.
 		rc.x += left;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -138,7 +138,7 @@ void GPU_Vulkan::LoadCache(const Path &filename) {
 	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	int maxTasksSeen = rm->WaitForPipelines();
 	double seconds = time_now_d() - start;
-	INFO_LOG(Log::G3D, "Waited %0.1fms for at least %d pipeline tasks to finish compiling.", maxTasksSeen, seconds * 1000.0);
+	INFO_LOG(Log::G3D, "Waited %0.1fms for at least %d pipeline tasks to finish compiling.", seconds * 1000.0, maxTasksSeen);
 
 	if (!result) {
 		WARN_LOG(Log::G3D, "Incompatible Vulkan pipeline cache - rebuilding.");

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -588,15 +588,15 @@ bool MainUI::event(QEvent *e) {
 				break;
 			case Qt::TouchPointPressed:
 			case Qt::TouchPointReleased:
-				input.x = touchPoint.pos().x() * g_display.dpi_scale * xscale;
-				input.y = touchPoint.pos().y() * g_display.dpi_scale * yscale;
+				input.x = touchPoint.pos().x() * g_display.dpi_scale_x * xscale;
+				input.y = touchPoint.pos().y() * g_display.dpi_scale_y * yscale;
 				input.flags = (touchPoint.state() == Qt::TouchPointPressed) ? TOUCH_DOWN : TOUCH_UP;
 				input.id = touchPoint.id();
 				NativeTouch(input);
 				break;
 			case Qt::TouchPointMoved:
-				input.x = touchPoint.pos().x() * g_display.dpi_scale * xscale;
-				input.y = touchPoint.pos().y() * g_display.dpi_scale * yscale;
+				input.x = touchPoint.pos().x() * g_display.dpi_scale_x * xscale;
+				input.y = touchPoint.pos().y() * g_display.dpi_scale_y * yscale;
 				input.flags = TOUCH_MOVE;
 				input.id = touchPoint.id();
 				NativeTouch(input);
@@ -614,8 +614,8 @@ bool MainUI::event(QEvent *e) {
 	case QEvent::MouseButtonRelease:
 		switch(((QMouseEvent*)e)->button()) {
 		case Qt::LeftButton:
-			input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale * xscale;
-			input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale * yscale;
+			input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale_x * xscale;
+			input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale_y * yscale;
 			input.flags = ((e->type() == QEvent::MouseButtonPress) ? TOUCH_DOWN : TOUCH_UP) | TOUCH_MOUSE;
 			input.id = 0;
 			NativeTouch(input);
@@ -637,8 +637,8 @@ bool MainUI::event(QEvent *e) {
 		}
 		break;
 	case QEvent::MouseMove:
-		input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale * xscale;
-		input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale * yscale;
+		input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale_x * xscale;
+		input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale_y * yscale;
 		input.flags = TOUCH_MOVE | TOUCH_MOUSE;
 		input.id = 0;
 		NativeTouch(input);
@@ -844,8 +844,9 @@ int main(int argc, char *argv[])
 		res.transpose();
 
 	// We assume physicalDotsPerInchY is the same as PerInchX.
-	float dpi_scale = screen->logicalDotsPerInchX() / screen->physicalDotsPerInchX();
-	g_display.Recalculate(res.width(), res.height(), dpi_scale, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
+	float dpi_scale_x = screen->logicalDotsPerInchX() / screen->physicalDotsPerInchX();
+	float dpi_scale_y = screen->logicalDotsPerInchY() / screen->physicalDotsPerInchY();
+	g_display.Recalculate(res.width(), res.height(), dpi_scale_x, dpi_scale_y, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
 
 	refreshRate = screen->refreshRate();
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -882,8 +882,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 	// - SDL gives us motion events in "system DPI" points
 	// - Native_UpdateScreenScale expects pixels, so in a way "96 DPI" points
 	// - The UI code expects motion events in "logical DPI" points
-	float mx = event.motion.x * g_DesktopDPI * g_display.dpi_scale;
-	float my = event.motion.y * g_DesktopDPI * g_display.dpi_scale;
+	float mx = event.motion.x * g_DesktopDPI * g_display.dpi_scale_x;
+	float my = event.motion.y * g_DesktopDPI * g_display.dpi_scale_x;
 
 	switch (event.type) {
 	case SDL_QUIT:
@@ -1036,8 +1036,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			SDL_GetWindowSize(window, &w, &h);
 			TouchInput input;
 			input.id = event.tfinger.fingerId;
-			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale;
-			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale;
+			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale_x;
+			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale_x;
 			input.flags = TOUCH_MOVE;
 			input.timestamp = event.tfinger.timestamp;
 			NativeTouch(input);
@@ -1049,8 +1049,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			SDL_GetWindowSize(window, &w, &h);
 			TouchInput input;
 			input.id = event.tfinger.fingerId;
-			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale;
-			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale;
+			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale_x;
+			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale_x;
 			input.flags = TOUCH_DOWN;
 			input.timestamp = event.tfinger.timestamp;
 			NativeTouch(input);
@@ -1068,8 +1068,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			SDL_GetWindowSize(window, &w, &h);
 			TouchInput input;
 			input.id = event.tfinger.fingerId;
-			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale;
-			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale;
+			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale_x;
+			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale_x;
 			input.flags = TOUCH_UP;
 			input.timestamp = event.tfinger.timestamp;
 			NativeTouch(input);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1374,13 +1374,13 @@ void TouchTestScreen::DrawForeground(UIContext &dc) {
 	snprintf(buffer, sizeof(buffer),
 		"display_res: %dx%d\n"
 		"dp_res: %dx%d pixel_res: %dx%d\n"
-		"dpi_scale: %0.3f\n"
-		"dpi_scale_real: %0.3f\n"
+		"dpi_scale: %0.3fx%0.3f\n"
+		"dpi_scale_real: %0.3fx%0.3f\n"
 		"delta: %0.2f ms fps: %0.3f\n%s",
 		(int)System_GetPropertyInt(SYSPROP_DISPLAY_XRES), (int)System_GetPropertyInt(SYSPROP_DISPLAY_YRES),
 		g_display.dp_xres, g_display.dp_yres, g_display.pixel_xres, g_display.pixel_yres,
-		g_display.dpi_scale,
-		g_display.dpi_scale_real,
+		g_display.dpi_scale_x, g_display.dpi_scale_y,
+		g_display.dpi_scale_real_x, g_display.dpi_scale_real_y,
 		delta * 1000.0, 1.0 / delta,
 		extra_debug);
 

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -50,10 +50,10 @@ enum Mode {
 
 static Bounds FRectToBounds(FRect rc) {
 	Bounds b;
-	b.x = rc.x * g_display.dpi_scale;
-	b.y = rc.y * g_display.dpi_scale;
-	b.w = rc.w * g_display.dpi_scale;
-	b.h = rc.h * g_display.dpi_scale;
+	b.x = rc.x * g_display.dpi_scale_x;
+	b.y = rc.y * g_display.dpi_scale_y;
+	b.w = rc.w * g_display.dpi_scale_x;
+	b.h = rc.h * g_display.dpi_scale_y;
 	return b;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1120,7 +1120,8 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	PopupSliderChoice *uiScale = systemSettings->Add(new PopupSliderChoice(&g_Config.iUIScaleFactor, -8, 8, 0, sy->T("UI size adjustment (DPI)"), screenManager()));
 	uiScale->SetZeroLabel(sy->T("Off"));
 	uiScale->OnChange.Add([](UI::EventParams &e) {
-		g_display.Recalculate(-1, -1, -1, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
+		const float dpiMul = UIScaleFactorToMultiplier(g_Config.iUIScaleFactor);
+		g_display.Recalculate(-1, -1, -1, dpiMul, dpiMul);
 		NativeResized();
 		return UI::EVENT_DONE;
 	});

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -1021,8 +1021,8 @@ bool GestureGamepad::Touch(const TouchInput &input) {
 
 			if (g_Config.bAnalogGesture) {
 				const float k = g_Config.fAnalogGestureSensibility * 0.02;
-				float dx = (input.x - downX_) * g_display.dpi_scale * k;
-				float dy = (input.y - downY_) * g_display.dpi_scale * k;
+				float dx = (input.x - downX_)*g_display.dpi_scale_x * k;
+				float dy = (input.y - downY_)*g_display.dpi_scale_y * k;
 				dx = std::min(1.0f, std::max(-1.0f, dx));
 				dy = std::min(1.0f, std::max(-1.0f, dy));
 				__CtrlSetAnalogXY(0, dx, -dy);
@@ -1062,8 +1062,8 @@ void GestureGamepad::Draw(UIContext &dc) {
 
 void GestureGamepad::Update() {
 	const float th = 1.0f;
-	float dx = deltaX_ * g_display.dpi_scale * g_Config.fSwipeSensitivity;
-	float dy = deltaY_ * g_display.dpi_scale * g_Config.fSwipeSensitivity;
+	float dx = deltaX_ * g_display.dpi_scale_x * g_Config.fSwipeSensitivity;
+	float dy = deltaY_ * g_display.dpi_scale_y * g_Config.fSwipeSensitivity;
 	if (g_Config.iSwipeRight != 0) {
 		if (dx > th) {
 			controlMapper_->PSPKey(DEVICE_ID_TOUCH, GestureKey::keyList[g_Config.iSwipeRight-1], KEY_DOWN);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -154,8 +154,8 @@ public:
 			dc.Draw()->RectVGradient(x, wave1*bounds.h, nextX, bounds.h, color, 0x00000000);
 
 			// Add some "antialiasing"
-			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps, nextX, wave0 * bounds.h, 0x00000000, color);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps, nextX, wave1 * bounds.h, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, nextX, wave0 * bounds.h, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, nextX, wave1 * bounds.h, 0x00000000, color);
 		}
 
 		dc.Flush();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1579,8 +1579,8 @@ bool Native_IsWindowHidden() {
 
 static bool IsWindowSmall(int pixelWidth, int pixelHeight) {
 	// Can't take this from config as it will not be set if windows is maximized.
-	int w = (int)(pixelWidth * g_display.dpi_scale_real);
-	int h = (int)(pixelHeight * g_display.dpi_scale_real);
+	int w = (int)(pixelWidth * g_display.dpi_scale_real_x);
+	int h = (int)(pixelHeight * g_display.dpi_scale_real_y);
 	return g_Config.IsPortrait() ? (h < 480 + 80) : (w < 480 + 80);
 }
 
@@ -1603,7 +1603,7 @@ bool Native_UpdateScreenScale(int pixel_width, int pixel_height, float customSca
 		customScale = UIScaleFactorToMultiplier(g_Config.iUIScaleFactor);
 	}
 
-	if (g_display.Recalculate(pixel_width, pixel_height, g_logical_dpi / dpi, customScale)) {
+	if (g_display.Recalculate(pixel_width, pixel_height, g_logical_dpi / dpi, g_logical_dpi / dpi, customScale)) {
 		NativeResized();
 		return true;
 	} else {

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -321,8 +321,8 @@ public:
 			float xOffset = bounds_.x;
 			float yOffset = bounds_.y;
 
-			dc.Draw()->Rect((x1+x2)/2 + xOffset - g_display.pixel_in_dps, y1 + yOffset, 3.0f * g_display.pixel_in_dps, y2-y1, col);
-			dc.Draw()->Rect(x1 + xOffset, (y1+y2)/2 + yOffset - g_display.pixel_in_dps, x2-x1, 3.0f * g_display.pixel_in_dps, col);
+			dc.Draw()->Rect((x1+x2)/2 + xOffset - g_display.pixel_in_dps_x, y1 + yOffset, 3.0f * g_display.pixel_in_dps_x, y2-y1, col);
+			dc.Draw()->Rect(x1 + xOffset, (y1+y2)/2 + yOffset - g_display.pixel_in_dps_y, x2-x1, 3.0f * g_display.pixel_in_dps_y, col);
 
 			for (int x = x1 + (x1+x2)/2 % g_Config.iTouchSnapGridSize; x < x2; x += g_Config.iTouchSnapGridSize)
 				dc.Draw()->vLine(x + xOffset, y1 + yOffset, y2 + yOffset, col);
@@ -622,10 +622,10 @@ void TouchControlLayoutScreen::update() {
 
 	Bounds bounds = layoutView_->GetBounds();
 	// Convert virtual pixels to real pixels.
-	bounds.x /= g_display.dpi_scale;
-	bounds.y /= g_display.dpi_scale;
-	bounds.w /= g_display.dpi_scale;
-	bounds.h /= g_display.dpi_scale;
+	bounds.x /= g_display.dpi_scale_x;
+	bounds.y /= g_display.dpi_scale_y;
+	bounds.w /= g_display.dpi_scale_x;
+	bounds.h /= g_display.dpi_scale_y;
 	SetOverrideScreenFrame(&bounds);
 }
 

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -155,13 +155,16 @@ void PPSSPP_UWPMain::UpdateScreenState() {
 		dpi *= 96.0f / 136.0f;
 	}
 
-	g_display.dpi_scale_real = 96.0f / dpi;
+	g_display.dpi_scale_real_x = 96.0f / dpi;
+	g_display.dpi_scale_real_y = 96.0f / dpi;
 
-	g_display.dpi_scale = g_display.dpi_scale_real;
-	g_display.pixel_in_dps = 1.0f / g_display.dpi_scale;
+	g_display.dpi_scale_x = g_display.dpi_scale_real_x;
+	g_display.dpi_scale_y = g_display.dpi_scale_real_y;
+	g_display.pixel_in_dps_x = 1.0f / g_display.dpi_scale_x;
+	g_display.pixel_in_dps_y = 1.0f / g_display.dpi_scale_y;
 
-	g_display.dp_xres = g_display.pixel_xres * g_display.dpi_scale;
-	g_display.dp_yres = g_display.pixel_yres * g_display.dpi_scale;
+	g_display.dp_xres = g_display.pixel_xres * g_display.dpi_scale_x;
+	g_display.dp_yres = g_display.pixel_yres * g_display.dpi_scale_y;
 
 	context->RSSetViewports(1, &viewport);
 }
@@ -268,8 +271,8 @@ void PPSSPP_UWPMain::OnTouchEvent(int touchEvent, int touchId, float x, float y,
 	// and then apply our own "dpi".
 	float dpiFactor_x = m_deviceResources->GetActualDpi() / 96.0f;
 	float dpiFactor_y = dpiFactor_x;
-	dpiFactor_x /= g_display.pixel_in_dps;
-	dpiFactor_y /= g_display.pixel_in_dps;
+	dpiFactor_x /= g_display.pixel_in_dps_x;
+	dpiFactor_y /= g_display.pixel_in_dps_y;
 
 	TouchInput input{};
 	input.id = touchId;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -171,7 +171,7 @@ CtrlDisAsmView::CtrlDisAsmView(HWND _wnd)
 	SetWindowLong(wnd, GWL_STYLE, GetWindowLong(wnd,GWL_STYLE) | WS_VSCROLL);
 	SetScrollRange(wnd, SB_VERT, -1, 1, TRUE);
 
-	const float fontScale = 1.0f / g_display.dpi_scale_real;
+	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
 	charWidth = g_Config.iFontWidth * fontScale;
 	rowHeight = (g_Config.iFontHeight + 2) * fontScale;
 	int scaledFontHeight = g_Config.iFontHeight * fontScale;

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -35,7 +35,7 @@ CtrlMemView::CtrlMemView(HWND _wnd) {
 	SetWindowLong(wnd, GWL_STYLE, GetWindowLong(wnd,GWL_STYLE) | WS_VSCROLL);
 	SetScrollRange(wnd, SB_VERT, -1,1,TRUE);
 
-	const float fontScale = 1.0f / g_display.dpi_scale_real;
+	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
 	charWidth_ = g_Config.iFontWidth * fontScale;
 	rowHeight_ = g_Config.iFontHeight * fontScale;
 	offsetPositionY_ = offsetLine * rowHeight_;

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -131,7 +131,7 @@ CtrlRegisterList::CtrlRegisterList(HWND _wnd)
 	: wnd(_wnd) {
 	SetWindowLongPtr(wnd, GWLP_USERDATA, (LONG_PTR)this);
 
-	const float fontScale = 1.0f / g_display.dpi_scale_real;
+	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
 	rowHeight = g_Config.iFontHeight * fontScale;
 	int charWidth = g_Config.iFontWidth * fontScale;
 	font = CreateFont(rowHeight, charWidth, 0, 0,

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -255,7 +255,7 @@ void CMemoryDlg::Goto(u32 addr)
 
 void CMemoryDlg::Size()
 {
-	const float fontScale = 1.0f / g_display.dpi_scale_real;
+	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
 
 	GetClientRect(m_hDlg,&winRect);
 	int dlg_w = winRect.right - winRect.left;

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -45,7 +45,7 @@ CtrlDisplayListView::CtrlDisplayListView(HWND _wnd)
 	instructionSize = 4;
 
 	// In small window mode, g_dpi_scale may have been adjusted.
-	const float fontScale = 1.0f / g_display.dpi_scale_real;
+	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
 	int fontHeight = g_Config.iFontHeight * fontScale;
 	int charWidth = g_Config.iFontWidth * fontScale;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -668,8 +668,8 @@ namespace MainWindow
 				// Hack: Take the opportunity to show the cursor.
 				mouseButtonDown = true;
 
-				float x = GET_X_LPARAM(lParam) * g_display.dpi_scale;
-				float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale;
+				float x = GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
+				float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
 				WindowsRawInput::SetMousePos(x, y);
 
 				TouchInput touch{};
@@ -716,8 +716,8 @@ namespace MainWindow
 				prevCursorX = cursorX;
 				prevCursorY = cursorY;
 
-				float x = (float)cursorX * g_display.dpi_scale;
-				float y = (float)cursorY * g_display.dpi_scale;
+				float x = (float)cursorX * g_display.dpi_scale_x;
+				float y = (float)cursorY * g_display.dpi_scale_y;
 				WindowsRawInput::SetMousePos(x, y);
 
 				// Mouse moves now happen also when no button is pressed.
@@ -742,8 +742,8 @@ namespace MainWindow
 				// Hack: Take the opportunity to hide the cursor.
 				mouseButtonDown = false;
 
-				float x = (float)GET_X_LPARAM(lParam) * g_display.dpi_scale;
-				float y = (float)GET_Y_LPARAM(lParam) * g_display.dpi_scale;
+				float x = (float)GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
+				float y = (float)GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
 				WindowsRawInput::SetMousePos(x, y);
 
 				TouchInput touch{};
@@ -762,8 +762,8 @@ namespace MainWindow
 
 		case WM_RBUTTONDOWN:
 		{
-			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale;
-			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale;
+			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
+			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
 
 			TouchInput touch{};
 			touch.buttons = 2;
@@ -776,8 +776,8 @@ namespace MainWindow
 
 		case WM_RBUTTONUP:
 		{
-			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale;
-			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale;
+			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
+			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
 
 			TouchInput touch{};
 			touch.buttons = 2;

--- a/Windows/TouchInputHandler.cpp
+++ b/Windows/TouchInputHandler.cpp
@@ -53,8 +53,8 @@ bool TouchInputHandler::GetTouchPoint(HWND hWnd, const TOUCHINPUT &input, float 
 	point.x = (LONG)(TOUCH_COORD_TO_PIXEL(input.x));
 	point.y = (LONG)(TOUCH_COORD_TO_PIXEL(input.y));
 	if (ScreenToClient(hWnd, &point)) {
-		x = point.x * g_display.dpi_scale;
-		y = point.y * g_display.dpi_scale;
+		x = point.x * g_display.dpi_scale_x;
+		y = point.y * g_display.dpi_scale_y;
 		return true;
 	}
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -151,7 +151,8 @@ static int deviceType;
 static int display_xres;
 static int display_yres;
 static int display_dpi;
-static float display_scale;  // Scale factor due to backbuffer scaling
+static float display_scale_x;  // Scale factor due to backbuffer scaling
+static float display_scale_y;
 
 static int backbuffer_format;	// Android PixelFormat enum
 
@@ -431,13 +432,13 @@ float System_GetPropertyFloat(SystemProperty prop) {
 	case SYSPROP_DISPLAY_REFRESH_RATE:
 		return g_display.display_hz;
 	case SYSPROP_DISPLAY_SAFE_INSET_LEFT:
-		return g_safeInsetLeft * display_scale * g_display.dpi_scale;
+		return g_safeInsetLeft * display_scale_x * g_display.dpi_scale_x;
 	case SYSPROP_DISPLAY_SAFE_INSET_RIGHT:
-		return g_safeInsetRight * display_scale * g_display.dpi_scale;
+		return g_safeInsetRight * display_scale_x * g_display.dpi_scale_x;
 	case SYSPROP_DISPLAY_SAFE_INSET_TOP:
-		return g_safeInsetTop * display_scale * g_display.dpi_scale;
+		return g_safeInsetTop * display_scale_y * g_display.dpi_scale_y;
 	case SYSPROP_DISPLAY_SAFE_INSET_BOTTOM:
-		return g_safeInsetBottom * display_scale * g_display.dpi_scale;
+		return g_safeInsetBottom * display_scale_y * g_display.dpi_scale_y;
 	default:
 		return -1;
 	}
@@ -1019,14 +1020,17 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 	}
 
 	// Compute display scale factor. Always < 1.0f (well, as long as we use buffers sized smaller than the screen...)
-	display_scale = (float)pixel_xres / (float)display_xres;
+	display_scale_x = (float)pixel_xres / (float)display_xres;
+	display_scale_y = (float)pixel_yres / (float)display_yres;
 
-	float dpi = (1.0f / display_scale) * (240.0f / (float)display_dpi);
+	float dpi_x = (1.0f / display_scale_x) * (240.0f / (float)display_dpi);
+	float dpi_y = (1.0f / display_scale_y) * (240.0f / (float)display_dpi);
 
-	bool new_size = g_display.Recalculate(pixel_xres, pixel_yres, dpi, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
+	bool new_size = g_display.Recalculate(pixel_xres, pixel_yres, dpi_x, dpi_y, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
 
 	INFO_LOG(Log::G3D, "RecalcDPI: display_xres=%d display_yres=%d pixel_xres=%d pixel_yres=%d", display_xres, display_yres, g_display.pixel_xres, g_display.pixel_yres);
-	INFO_LOG(Log::G3D, "RecalcDPI: g_dpi=%d scaled_dpi=%f display_scale=%f g_dpi_scale=%f dp_xres=%d dp_yres=%d", display_dpi, dpi, display_scale, g_display.dpi_scale, g_display.dp_xres, g_display.dp_yres);
+	INFO_LOG(Log::G3D, "RecalcDPI: g_dpi=%d scaled_dpi_x=%f scaled_dpi_y=%f display_scale_x=%f display_scale_y=%f g_dpi_scale_x=%f g_dpi_scale_y=%f dp_xres=%d dp_yres=%d",
+		display_dpi, dpi_x, dpi_y, display_scale_x, display_scale_y, g_display.dpi_scale_x, g_display.dpi_scale_y, g_display.dp_xres, g_display.dp_yres);
 
 	if (new_size) {
 		INFO_LOG(Log::G3D, "Size change detected (previously %d,%d) - calling NativeResized()", old_w, old_h);
@@ -1157,7 +1161,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env,
 	}
 
 	if (IsVREnabled()) {
-		UpdateVRInput(g_Config.bHapticFeedback, g_display.dpi_scale);
+		UpdateVRInput(g_Config.bHapticFeedback, g_display.dpi_scale_x, g_display.dpi_scale_y);
 		FinishVRRender();
 	}
 }
@@ -1184,8 +1188,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 		return;
 	TouchInput touch{};
 	touch.id = pointerId;
-	touch.x = x * display_scale * g_display.dpi_scale;
-	touch.y = y * display_scale * g_display.dpi_scale;
+	touch.x = x * display_scale_x * g_display.dpi_scale_x;
+	touch.y = y * display_scale_y * g_display.dpi_scale_y;
 	touch.flags = code;
 	NativeTouch(touch);
 }
@@ -1268,8 +1272,8 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouse(
 		last_y = y;
 	}
 
-	x *= g_display.dpi_scale;
-	y *= g_display.dpi_scale;
+	x *= g_display.dpi_scale_x;
+	y *= g_display.dpi_scale_y;
 
 	if (button == 0) {
 		// It's a pure mouse move.

--- a/ext/imgui/imgui_impl_platform.cpp
+++ b/ext/imgui/imgui_impl_platform.cpp
@@ -56,8 +56,8 @@ void ImGui_ImplPlatform_TouchEvent(const TouchInput &touch) {
 	ImGuiIO& io = ImGui::GetIO();
 
 	// We use real pixels in the imgui, no DPI adjustment yet.
-	float x = touch.x / g_display.dpi_scale;
-	float y = touch.y / g_display.dpi_scale;
+	float x = touch.x / g_display.dpi_scale_x;
+	float y = touch.y / g_display.dpi_scale_y;
 
 	if (touch.flags & TOUCH_MOVE) {
 		io.AddMousePosEvent(x, y);

--- a/ext/imgui/imgui_impl_thin3d.cpp
+++ b/ext/imgui/imgui_impl_thin3d.cpp
@@ -293,13 +293,13 @@ void ImGui_ImplThin3d_DestroyDeviceObjects() {
 bool ImGui_ImplThin3d_Init(Draw::DrawContext *draw, const uint8_t *ttf_font, size_t size) {
 	ImGuiIO& io = ImGui::GetIO();
 	if (ttf_font) {
-		g_proportionalFont = io.Fonts->AddFontFromMemoryTTF((void *)ttf_font, (int)size, 21.0f / g_display.dpi_scale, nullptr, io.Fonts->GetGlyphRangesDefault());
+		g_proportionalFont = io.Fonts->AddFontFromMemoryTTF((void *)ttf_font, (int)size, 21.0f / g_display.dpi_scale_x, nullptr, io.Fonts->GetGlyphRangesDefault());
 	} else {
 		// fallback
 		g_proportionalFont = g_fixedFont;
 	}
 	g_fixedFont = io.Fonts->AddFontDefault();
-	ImGui::GetStyle().ScaleAllSizes(1.0f / g_display.dpi_scale);
+	ImGui::GetStyle().ScaleAllSizes(1.0f / g_display.dpi_scale_x);
 	ImGui::GetStyle().Colors[ImGuiCol_Border] = ImColor(IM_COL32(0x2A, 0x2F, 0x3B, 0xFF));
 
 	IMGUI_CHECKVERSION();

--- a/ios/DisplayManager.mm
+++ b/ios/DisplayManager.mm
@@ -153,8 +153,9 @@
 		dpi = diagonal * scale * 0.1f;
 	}
 
-	float dpi_scale = 240.0f / dpi;
-	g_display.Recalculate(size.width * scale, size.height * scale, dpi_scale, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
+	const float dpi_scale_x = 240.0f / dpi;
+	const float dpi_scale_y = 240.0f / dpi;
+	g_display.Recalculate(size.width * scale, size.height * scale, dpi_scale_x, dpi_scale_y, UIScaleFactorToMultiplier(g_Config.iUIScaleFactor));
 
 	[[sharedViewController getView] setContentScaleFactor:scale];
 


### PR DESCRIPTION
This reverts commit f206ed95eb3a59c640b415e9f0eba1bf6b86cf74, while taking care of a lot of resulting conflicts.

Should fix #20379 . Didn't realize our VR UI implementation relied on non-square pixel aspect ratios.