### PR TITLE
OpenXR - Passthrough on the latest QuestOS fixed

### DIFF
--- a/Common/VR/VRBase.h
+++ b/Common/VR/VRBase.h
@@ -51,6 +51,7 @@ enum { ovrMaxNumEyes = 2 };
 typedef union {
 	XrCompositionLayerProjection Projection;
 	XrCompositionLayerCylinderKHR Cylinder;
+	XrCompositionLayerPassthroughFB Passthrough;
 } ovrCompositorLayer_Union;
 
 typedef struct {

--- a/Common/VR/VRRenderer.cpp
+++ b/Common/VR/VRRenderer.cpp
@@ -371,6 +371,16 @@ void VR_EndFrame( engine_t* engine ) {
 }
 
 void VR_FinishFrame( engine_t* engine ) {
+	if (VR_GetPlatformFlag(VRPlatformFlag::VR_PLATFORM_EXTENSION_PASSTHROUGH) && VR_GetConfig(VR_CONFIG_PASSTHROUGH)) {
+		if (passthroughLayer != XR_NULL_HANDLE) {
+			XrCompositionLayerPassthroughFB passthrough_layer = {XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB};
+			passthrough_layer.layerHandle = passthroughLayer;
+			passthrough_layer.flags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+			passthrough_layer.space = XR_NULL_HANDLE;
+			engine->appState.Layers[engine->appState.LayerCount++].Passthrough = passthrough_layer;
+		}
+	}
+
 	int vrMode = vrConfig[VR_CONFIG_MODE];
 	XrCompositionLayerProjectionView projection_layer_elements[2] = {};
 	bool headTracking = (vrMode == VR_MODE_MONO_6DOF) || (vrMode == VR_MODE_SBS_6DOF) || (vrMode == VR_MODE_STEREO_6DOF);


### PR DESCRIPTION
Meta did a behavior change of the passthrough which leads to issue that passthrough cannot be enalbed. This PR fixes that.