### PR TITLE
Libretro: Fix reset hang

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1331,6 +1331,7 @@ namespace Libretro
       PSP_RunLoopWhileState();
       switch (coreState) {
       case CORE_NEXTFRAME:
+      case CORE_POWERDOWN:
          // Reached the end of the frame while running at full blast, all good. Set back to running for the next frame
          coreState = CORE_RUNNING_CPU;
          break;


### PR DESCRIPTION
The latest changes caused runloop to hang after triggering reset, and this seems like the cleanest way to recover from `coreState` staying as `CORE_POWERDOWN`. Or would it be better to change it already in `retro_reset()` right after `PSP_Shutdown()`? Real unload shutdown does not reach this current point, so I guess it is fine, and it works fine.

