### PR TITLE
Android shortcut fix

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1301,7 +1301,7 @@ bool VulkanContext::ChooseQueue() {
 			// Okay, take the first one then.
 			swapchainFormat_ = surfFormats_[0].format;
 		}
-		INFO_LOG(Log::G3D, "swapchain_format: %d (/%d)", swapchainFormat_, formatCount);
+		INFO_LOG(Log::G3D, "swapchain_format: %s (%d) (/%d)", VulkanFormatToString(swapchainFormat_), (int)swapchainFormat_, formatCount);
 	}
 
 	vkGetDeviceQueue(device_, graphics_queue_family_index_, 0, &gfx_queue_);
@@ -1388,7 +1388,6 @@ bool VulkanContext::InitSwapchain() {
 		availablePresentModes_.push_back(presentModes[i]);
 	}
 
-	INFO_LOG(Log::G3D, "Supported present modes: %s", modes.c_str());
 	for (size_t i = 0; i < presentModeCount; i++) {
 		bool match = false;
 		match = match || ((flags_ & VulkanInitFlags::PRESENT_MAILBOX) && presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR);
@@ -1415,8 +1414,8 @@ bool VulkanContext::InitSwapchain() {
 		desiredNumberOfSwapChainImages = surfCapabilities_.maxImageCount;
 	}
 
-	INFO_LOG(Log::G3D, "Chosen present mode: %d (%s). numSwapChainImages: %d (max: %d)",
-		swapchainPresentMode, VulkanPresentModeToString(swapchainPresentMode),
+	INFO_LOG(Log::G3D, "Supported present modes: %s. Chosen present mode: %d (%s). numSwapChainImages: %d (max: %d)",
+		modes.c_str(), swapchainPresentMode, VulkanPresentModeToString(swapchainPresentMode),
 		desiredNumberOfSwapChainImages, surfCapabilities_.maxImageCount);
 
 	// We mostly follow the practices from
@@ -1503,7 +1502,6 @@ bool VulkanContext::InitSwapchain() {
 
 	// We don't support screenshots on Android if TRANSFER_SRC usage flag is not supported.
 	if (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
-		INFO_LOG(Log::G3D, "Swapchain supports TRANSFER_SRC");
 		swap_chain_info.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 	}
 
@@ -1523,7 +1521,7 @@ bool VulkanContext::InitSwapchain() {
 		ERROR_LOG(Log::G3D, "vkCreateSwapchainKHR failed!");
 		return false;
 	}
-	INFO_LOG(Log::G3D, "Created swapchain: %dx%d", swap_chain_info.imageExtent.width, swap_chain_info.imageExtent.height);
+	INFO_LOG(Log::G3D, "Created swapchain: %dx%d %s", swap_chain_info.imageExtent.width, swap_chain_info.imageExtent.height, (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) ? "(TRANSFER_SRC_BIT supported)" : "");
 	return true;
 }
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -893,8 +893,6 @@ VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
 	: vulkan_(vulkan), renderManager_(vulkan, useRenderThread, frameTimeHistory_) {
 	shaderLanguageDesc_.Init(GLSL_VULKAN);
 
-	INFO_LOG(Log::G3D, "Determining Vulkan device caps");
-
 	caps_.coordConvention = CoordConvention::Vulkan;
 	caps_.setMaxFrameLatencySupported = true;
 	caps_.anisoSupported = vulkan->GetDeviceFeatures().enabled.standard.samplerAnisotropy != 0;

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -44,15 +44,22 @@ ScreenManager::~ScreenManager() {
 void ScreenManager::switchScreen(Screen *screen) {
 	// TODO: inputLock_ ?
 
+	INFO_LOG(Log::UI, "ScreenManager::switchScreen('%s')", screen->tag());
+
 	if (!nextStack_.empty() && screen == nextStack_.front().screen) {
 		ERROR_LOG(Log::UI, "Already switching to this screen");
 		return;
 	}
+
 	// Note that if a dialog is found, this will be a silent background switch that
 	// will only become apparent if the dialog is closed. The previous screen will stick around
 	// until that switch.
 	// TODO: is this still true?
 	if (!nextStack_.empty()) {
+		for (int i = 0; i < nextStack_.size(); i++) {
+			INFO_LOG(Log::UI, "NextStack contents[%d].screen->tag(): '%s'", i, nextStack_[i].screen->tag());
+		}
+
 		ERROR_LOG(Log::UI, "Already had a nextStack_! Asynchronous open while doing something? Deleting the new screen.");
 		delete screen;
 		return;

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -75,10 +75,36 @@ void ScreenManager::switchScreen(Screen *screen) {
 	}
 }
 
+void ScreenManager::cancelScreensAbove(Screen *screen) {
+	bool found = false;
+	for (int i = 0; i < stack_.size(); i++) {
+		if (stack_[i].screen == screen) {
+			found = true;
+		}
+	}
+
+	if (found) {
+		cancelScreensAbove_ = screen;
+	}
+}
+
 void ScreenManager::update() {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
 	if (!nextStack_.empty()) {
 		switchToNext();
+	}
+
+	if (cancelScreensAbove_) {
+		bool found = false;
+		for (int i = stack_.size() - 1; i >= 0; i--) {
+			if (stack_[i].screen == cancelScreensAbove_) {
+				break;
+			}
+			Layer temp = stack_.back();
+			stack_.pop_back();
+			delete temp.screen;
+		}
+		cancelScreensAbove_ = nullptr;
 	}
 
 	if (overlayScreen_) {

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -177,6 +177,8 @@ public:
 		return stack_.empty() ? nullptr : stack_.back().screen;
 	}
 
+	void cancelScreensAbove(Screen *screen);
+
 	void getFocusPosition(float &x, float &y, float &z);
 
 	// Will delete any existing overlay screen.
@@ -200,6 +202,8 @@ private:
 
 	Screen *backgroundScreen_ = nullptr;
 	Screen *overlayScreen_ = nullptr;
+
+	Screen *cancelScreensAbove_ = nullptr;
 
 	struct Layer {
 		Screen *screen;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -111,7 +111,7 @@ void GPU_Vulkan::LoadCache(const Path &filename) {
 	// First compile shaders to SPIR-V, then load the pipeline cache and recreate the pipelines.
 	// It's when recreating the pipelines that the pipeline cache is useful - in the ideal case,
 	// it can just memcpy the finished shader binaries out of the pipeline cache file.
-	bool result = shaderManagerVulkan_->LoadCacheFlags(f, &drawEngine_);
+	bool result = ShaderManagerVulkan::LoadCacheFlags(f, &drawEngine_);
 	if (!result) {
 		WARN_LOG(Log::G3D, "ShaderManagerVulkan failed to load cache header.");
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -643,6 +643,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 						fprintf(stderr, "File not found: %s\n", boot_filename.c_str());
 #if defined(_WIN32) || defined(__ANDROID__)
 						// Ignore and proceed.
+						boot_filename.clear();
 #else
 						// Bail.
 						exit(1);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -756,7 +756,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	} else if (gotoDeveloperTools) {
 		g_screenManager->switchScreen(new MainScreen());
 		g_screenManager->push(new DeveloperToolsScreen(Path()));
-	} else if (skipLogo) {
+	} else if (skipLogo && !boot_filename.empty()) {
+		INFO_LOG(Log::System, "Launching EmuScreen with boot filename '%s'", boot_filename.c_str());
 		g_screenManager->switchScreen(new EmuScreen(boot_filename));
 	} else {
 		g_screenManager->switchScreen(new LogoScreen(AfterLogoScreen::DEFAULT));

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -53,6 +53,7 @@
             android:name=".PpssppActivity"
             android:configChanges="locale|keyboard|keyboardHidden|navigation|uiMode"
             android:theme="@style/ppsspp_style"
+			android:launchMode="singleInstance"
             android:exported="true">
             <!-- android:screenOrientation="landscape" -->
             <intent-filter>

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -977,7 +977,7 @@ public abstract class NativeActivity extends Activity {
 				buffer += input.getDebugString();
 			}
 			if (buffer.isEmpty()) {
-				buffer = "(no devices)";
+				return "(no devices)";
 			}
 			return buffer;
 		} else {

--- a/android/src/org/ppsspp/ppsspp/SizeManager.java
+++ b/android/src/org/ppsspp/ppsspp/SizeManager.java
@@ -100,7 +100,11 @@ public class SizeManager implements SurfaceHolder.Callback {
 		getDesiredBackbufferSize(desiredSize);
 
 		// Note that desiredSize might be 0,0 here - but that's fine when calling setFixedSize! It means auto.
-		Log.d(TAG, "Setting fixed size " + desiredSize.x + " x " + desiredSize.y);
+		if (desiredSize.x == 0) {
+			Log.d(TAG, "Setting auto surface size (not fixed)");
+		} else {
+			Log.d(TAG, "Setting fixed surface size " + desiredSize.x + " x " + desiredSize.y);
+		}
 		holder.setFixedSize(desiredSize.x, desiredSize.y);
 	}
 


### PR DESCRIPTION
I've figured out that a major cause of Android crash reports is a game getting launched from a shortcut widget while another game is already loaded. This leads to two instances of the activity getting launched simultaneously, which is not good since we have a bunch of global state that can clash with itself.

Setting `android:launchMode="singleInstance"` in the activity manifest, and adding handling for `onNewIntent` seems to improve things a lot in this situation. However if the settings menu is open, things can get really confused in this case with game-specific configs, so we just tear down any screens sitting on top of the emu screen in this case. Hoping there are no race conditions there that I missed..

This will probably fix a commonly reported issue with launchers on Android, too (can't find the issue number right now).