### PR TITLE
Vertex decoder C++ fallbacks: Make sure to never read from the destination

### DIFF
--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -103,7 +103,7 @@ bool AVIDump::CreateAVI() {
 	s_format_context = avformat_alloc_context();
 
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58, 7, 0)
-	char *filename = av_strdup(video_file_name.c_str());
+	char *filename = av_strdup(g_filename.c_str());
 	// Freed when the context is freed.
 	s_format_context->url = filename;
 #else

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -412,7 +412,7 @@ void VertexDecoder::Step_TcFloatPrescale(const VertexDecoder *dec, const u8 *ptr
 }
 
 void VertexDecoder::Step_TcU8MorphToFloat(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -428,7 +428,7 @@ void VertexDecoder::Step_TcU8MorphToFloat(const VertexDecoder *dec, const u8 *pt
 }
 
 void VertexDecoder::Step_TcU16MorphToFloat(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -444,7 +444,7 @@ void VertexDecoder::Step_TcU16MorphToFloat(const VertexDecoder *dec, const u8 *p
 }
 
 void VertexDecoder::Step_TcU16DoubleMorphToFloat(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -460,7 +460,7 @@ void VertexDecoder::Step_TcU16DoubleMorphToFloat(const VertexDecoder *dec, const
 }
 
 void VertexDecoder::Step_TcFloatMorph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -476,14 +476,14 @@ void VertexDecoder::Step_TcFloatMorph(const VertexDecoder *dec, const u8 *ptr, u
 }
 
 void VertexDecoder::Step_TcU8PrescaleMorph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
-		float w = gstate_c.morphWeights[n];
+		const float w = gstate_c.morphWeights[n] * (1.f / 128.f);
 		const u8 *uvdata = (const u8 *)(ptr + dec->onesize_*n + dec->tcoff);
 
-		uv[0] += (float)uvdata[0] * (1.f / 128.f) * w;
-		uv[1] += (float)uvdata[1] * (1.f / 128.f) * w;
+		uv[0] += (float)uvdata[0] * w;
+		uv[1] += (float)uvdata[1] * w;
 	}
 
 	float *out = (float *)(decoded + dec->decFmt.uvoff);
@@ -492,14 +492,14 @@ void VertexDecoder::Step_TcU8PrescaleMorph(const VertexDecoder *dec, const u8 *p
 }
 
 void VertexDecoder::Step_TcU16PrescaleMorph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
-		float w = gstate_c.morphWeights[n];
+		const float w = gstate_c.morphWeights[n] * (1.f / 32768.f);
 		const u16_le *uvdata = (const u16_le *)(ptr + dec->onesize_*n + dec->tcoff);
 
-		uv[0] += (float)uvdata[0] * (1.f / 32768.f) * w;
-		uv[1] += (float)uvdata[1] * (1.f / 32768.f) * w;
+		uv[0] += (float)uvdata[0] * w;
+		uv[1] += (float)uvdata[1] * w;
 	}
 
 	float *out = (float *)(decoded + dec->decFmt.uvoff);
@@ -508,14 +508,14 @@ void VertexDecoder::Step_TcU16PrescaleMorph(const VertexDecoder *dec, const u8 *
 }
 
 void VertexDecoder::Step_TcU16DoublePrescaleMorph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float uv[2] = { 0, 0 };
+	float uv[2]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
-		float w = gstate_c.morphWeights[n];
+		const float w = gstate_c.morphWeights[n] * (1.f / 16384.f);
 		const u16_le *uvdata = (const u16_le *)(ptr + dec->onesize_*n + dec->tcoff);
 
-		uv[0] += (float)uvdata[0] * (1.f / 16384.f) * w;
-		uv[1] += (float)uvdata[1] * (1.f / 16384.f) * w;
+		uv[0] += (float)uvdata[0] * w;
+		uv[1] += (float)uvdata[1] * w;
 	}
 
 	float *out = (float *)(decoded + dec->decFmt.uvoff);
@@ -551,34 +551,34 @@ void VertexDecoder::Step_Color565(const VertexDecoder *dec, const u8 *ptr, u8 *d
 
 void VertexDecoder::Step_Color5551(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
 	u16 cdata = *(const u16_le *)(ptr + dec->coloff);
-	u32 *c = (u32 *)(decoded + dec->decFmt.c0off);
 	int alpha = (cdata >> 15);
 	if (!alpha) {
 		gstate_c.vertexFullAlpha = false;
 	}
+	u32 *c = (u32 *)(decoded + dec->decFmt.c0off);
 	*c = RGBA5551ToRGBA8888(cdata);
 }
 
 void VertexDecoder::Step_Color4444(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
 	u16 cdata = *(const u16_le *)(ptr + dec->coloff);
-	u32 *c = (u32 *)(decoded + dec->decFmt.c0off);
 	if ((cdata >> 12) != 0xF) {
 		gstate_c.vertexFullAlpha = false;
 	}
+	u32 *c = (u32 *)(decoded + dec->decFmt.c0off);
 	*c = RGBA4444ToRGBA8888(cdata);
 }
 
 void VertexDecoder::Step_Color8888(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	u8 *c = decoded + dec->decFmt.c0off;
 	const u8 *cdata = (const u8*)(ptr + dec->coloff);
 	if (cdata[3] != 255) {
 		gstate_c.vertexFullAlpha = false;
 	}
+	u8 *c = decoded + dec->decFmt.c0off;
 	memcpy(c, cdata, sizeof(u8) * 4);
 }
 
 void VertexDecoder::Step_Color565Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float col[3] = { 0 };
+	float col[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -596,7 +596,7 @@ void VertexDecoder::Step_Color565Morph(const VertexDecoder *dec, const u8 *ptr, 
 }
 
 void VertexDecoder::Step_Color5551Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float col[4] = { 0 };
+	float col[4]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -614,7 +614,7 @@ void VertexDecoder::Step_Color5551Morph(const VertexDecoder *dec, const u8 *ptr,
 }
 
 void VertexDecoder::Step_Color4444Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float col[4] = { 0 };
+	float col[4]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -630,7 +630,7 @@ void VertexDecoder::Step_Color4444Morph(const VertexDecoder *dec, const u8 *ptr,
 }
 
 void VertexDecoder::Step_Color8888Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float col[4] = { 0 };
+	float col[4]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float w = gstate_c.morphWeights[n];
@@ -697,43 +697,45 @@ void VertexDecoder::Step_NormalFloatSkin(const VertexDecoder *dec, const u8 *ptr
 }
 
 void VertexDecoder::Step_NormalS8Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
-	memset(normal, 0, sizeof(float) * 3);
+	float acc[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		const s8 *bv = (const s8*)(ptr + dec->onesize_*n + dec->nrmoff);
 		const float multiplier = gstate_c.morphWeights[n] * (1.0f / 128.0f);
 		for (int j = 0; j < 3; j++)
-			normal[j] += bv[j] * multiplier;
+			acc[j] += bv[j] * multiplier;
 	}
+	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
+	memcpy(normal, acc, sizeof(float) * 3);
 }
 
 void VertexDecoder::Step_NormalS16Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
-	memset(normal, 0, sizeof(float) * 3);
+	float acc[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		const s16_le *sv = (const s16_le *)(ptr + dec->onesize_*n + dec->nrmoff);
 		const float multiplier = gstate_c.morphWeights[n] * (1.0f / 32768.0f);
 		for (int j = 0; j < 3; j++)
-			normal[j] += sv[j] * multiplier;
+			acc[j] += sv[j] * multiplier;
 	}
+	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
+	memcpy(normal, acc, sizeof(float) * 3);
 }
 
 void VertexDecoder::Step_NormalFloatMorph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
-	memset(normal, 0, sizeof(float) * 3);
+	float acc[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		float multiplier = gstate_c.morphWeights[n];
 		const float_le *fv = (const float_le *)(ptr + dec->onesize_*n + dec->nrmoff);
 		for (int j = 0; j < 3; j++)
-			normal[j] += fv[j] * multiplier;
+			acc[j] += fv[j] * multiplier;
 	}
+	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
+	memcpy(normal, acc, sizeof(float) * 3);
 }
 
 void VertexDecoder::Step_NormalS8MorphSkin(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
 	float nrm[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
@@ -742,11 +744,11 @@ void VertexDecoder::Step_NormalS8MorphSkin(const VertexDecoder *dec, const u8 *p
 		for (int j = 0; j < 3; j++)
 			nrm[j] += bv[j] * multiplier;
 	}
+	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
 	Norm3ByMatrix43(normal, nrm, skinMatrix);
 }
 
 void VertexDecoder::Step_NormalS16MorphSkin(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
 	float nrm[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
@@ -755,11 +757,11 @@ void VertexDecoder::Step_NormalS16MorphSkin(const VertexDecoder *dec, const u8 *
 		for (int j = 0; j < 3; j++)
 			nrm[j] += sv[j] * multiplier;
 	}
+	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
 	Norm3ByMatrix43(normal, nrm, skinMatrix);
 }
 
 void VertexDecoder::Step_NormalFloatMorphSkin(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
 	float nrm[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
@@ -768,6 +770,7 @@ void VertexDecoder::Step_NormalFloatMorphSkin(const VertexDecoder *dec, const u8
 		for (int j = 0; j < 3; j++)
 			nrm[j] += fv[j] * multiplier;
 	}
+	float *normal = (float *)(decoded + dec->decFmt.nrmoff);
 	Norm3ByMatrix43(normal, nrm, skinMatrix);
 }
 
@@ -844,42 +847,44 @@ void VertexDecoder::Step_PosFloatThrough(const VertexDecoder *dec, const u8 *ptr
 }
 
 void VertexDecoder::Step_PosS8Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *v = (float *)(decoded + dec->decFmt.posoff);
-	memset(v, 0, sizeof(float) * 3);
+	float acc[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		const float multiplier = 1.0f / 128.0f;
 		const s8 *sv = (const s8*)(ptr + dec->onesize_*n + dec->posoff);
 		for (int j = 0; j < 3; j++)
-			v[j] += (float)sv[j] * (multiplier * gstate_c.morphWeights[n]);
+			acc[j] += (float)sv[j] * (multiplier * gstate_c.morphWeights[n]);
 	}
+	float *v = (float *)(decoded + dec->decFmt.posoff);
+	memcpy(v, acc, 12);
 }
 
 void VertexDecoder::Step_PosS16Morph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *v = (float *)(decoded + dec->decFmt.posoff);
-	memset(v, 0, sizeof(float) * 3);
+	float acc[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		const float multiplier = 1.0f / 32768.0f;
 		const s16_le *sv = (const s16_le *)(ptr + dec->onesize_*n + dec->posoff);
 		for (int j = 0; j < 3; j++)
-			v[j] += (float)sv[j] * (multiplier * gstate_c.morphWeights[n]);
+			acc[j] += (float)sv[j] * (multiplier * gstate_c.morphWeights[n]);
 	}
+	float *v = (float *)(decoded + dec->decFmt.posoff);
+	memcpy(v, acc, 12);
 }
 
 void VertexDecoder::Step_PosFloatMorph(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *v = (float *)(decoded + dec->decFmt.posoff);
-	memset(v, 0, sizeof(float) * 3);
+	float acc[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
 		const float_le *fv = (const float_le *)(ptr + dec->onesize_*n + dec->posoff);
 		for (int j = 0; j < 3; j++)
-			v[j] += fv[j] * gstate_c.morphWeights[n];
+			acc[j] += fv[j] * gstate_c.morphWeights[n];
 	}
+	float *v = (float *)(decoded + dec->decFmt.posoff);
+	memcpy(v, acc, 12);
 }
 
 void VertexDecoder::Step_PosS8MorphSkin(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *v = (float *)(decoded + dec->decFmt.posoff);
 	float pos[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
@@ -888,11 +893,11 @@ void VertexDecoder::Step_PosS8MorphSkin(const VertexDecoder *dec, const u8 *ptr,
 		for (int j = 0; j < 3; j++)
 			pos[j] += (float)sv[j] * (multiplier * gstate_c.morphWeights[n]);
 	}
+	float *v = (float *)(decoded + dec->decFmt.posoff);
 	Vec3ByMatrix43(v, pos, skinMatrix);
 }
 
 void VertexDecoder::Step_PosS16MorphSkin(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *v = (float *)(decoded + dec->decFmt.posoff);
 	float pos[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
@@ -901,11 +906,11 @@ void VertexDecoder::Step_PosS16MorphSkin(const VertexDecoder *dec, const u8 *ptr
 		for (int j = 0; j < 3; j++)
 			pos[j] += (float)sv[j] * (multiplier * gstate_c.morphWeights[n]);
 	}
+	float *v = (float *)(decoded + dec->decFmt.posoff);
 	Vec3ByMatrix43(v, pos, skinMatrix);
 }
 
 void VertexDecoder::Step_PosFloatMorphSkin(const VertexDecoder *dec, const u8 *ptr, u8 *decoded) {
-	float *v = (float *)(decoded + dec->decFmt.posoff);
 	float pos[3]{};
 	const int morphcount = dec->morphcount;
 	for (int n = 0; n < morphcount; n++) {
@@ -913,6 +918,7 @@ void VertexDecoder::Step_PosFloatMorphSkin(const VertexDecoder *dec, const u8 *p
 		for (int j = 0; j < 3; j++)
 			pos[j] += fv[j] * gstate_c.morphWeights[n];
 	}
+	float *v = (float *)(decoded + dec->decFmt.posoff);
 	Vec3ByMatrix43(v, pos, skinMatrix);
 }
 


### PR DESCRIPTION
Morph still falls back to the C++ vertex decoder (instead of jitting) on many architectures. It has a bug where it accidentally reads from destination while accumulating values.

Reading from the destination can have devastating effects on performance on some architectures (where we decode directly to uncached-but-writecombined video RAM when using Vulkan).

Will help, but not fix, #20171 on some hardware (there's more optimization work that needs doing).