### PR TITLE
Switch to a fork of glslang with an include fix for gcc 15

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/Kingcom/armips.git
 [submodule "ext/glslang"]
 	path = ext/glslang
-	url = https://github.com/KhronosGroup/glslang.git
+	url = https://github.com/hrydgard/glslang.git
 [submodule "ext/SPIRV-Cross"]
 	path = ext/SPIRV-Cross
 	url = https://github.com/KhronosGroup/SPIRV-Cross.git


### PR DESCRIPTION
See #20399 and #19952

glslang annoyingly started using std::filesystem (just a little bit) but we aren't ready to require it, both because of Mac and Android, so we can't update to latest. Instead do the include fix on the currently used version.

For this purpose I created a new branch in the hrydgard/glslang repo, fork-1.19. Note to self - never delete it!