### PR TITLE
Fix the background image selector on MacOS and Linux (with pfd)

### DIFF
--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -23,10 +23,34 @@ RequestManager g_requestManager;
 
 const char *RequestTypeAsString(SystemRequestType type) {
 	switch (type) {
-	case SystemRequestType::INPUT_TEXT_MODAL: return "INPUT_TEXT_MODAL";
 	case SystemRequestType::BROWSE_FOR_IMAGE: return "BROWSE_FOR_IMAGE";
 	case SystemRequestType::BROWSE_FOR_FILE: return "BROWSE_FOR_FILE";
 	case SystemRequestType::BROWSE_FOR_FOLDER: return "BROWSE_FOR_FOLDER";
+	case SystemRequestType::BROWSE_FOR_FILE_SAVE: return "BROWSE_FOR_FILE_SAVE";
+	case SystemRequestType::INPUT_TEXT_MODAL: return "INPUT_TEXT_MODAL";
+	case SystemRequestType::ASK_USERNAME_PASSWORD: return "ASK_USERNAME_PASSWORD";
+	case SystemRequestType::EXIT_APP: return "EXIT_APP";
+	case SystemRequestType::RESTART_APP: return "RESTART_APP";
+	case SystemRequestType::RECREATE_ACTIVITY: return "RECREATE_ACTIVITY";
+	case SystemRequestType::COPY_TO_CLIPBOARD: return "COPY_TO_CLIPBOARD";
+	case SystemRequestType::SHARE_TEXT: return "SHARE_TEXT";
+	case SystemRequestType::SET_WINDOW_TITLE: return "SET_WINDOW_TITLE";
+	case SystemRequestType::TOGGLE_FULLSCREEN_STATE: return "TOGGLE_FULLSCREEN_STATE";
+	case SystemRequestType::GRAPHICS_BACKEND_FAILED_ALERT: return "GRAPHICS_BACKEND_FAILED_ALERT";
+	case SystemRequestType::CREATE_GAME_SHORTCUT: return "CREATE_GAME_SHORTCUT";
+	case SystemRequestType::SHOW_FILE_IN_FOLDER: return "SHOW_FILE_IN_FOLDER";
+	case SystemRequestType::SEND_DEBUG_OUTPUT: return "SEND_DEBUG_OUTPUT";
+	case SystemRequestType::SEND_DEBUG_SCREENSHOT: return "SEND_DEBUG_SCREENSHOT";
+	case SystemRequestType::NOTIFY_UI_EVENT: return "NOTIFY_UI_EVENT";
+	case SystemRequestType::SET_KEEP_SCREEN_BRIGHT: return "SET_KEEP_SCREEN_BRIGHT";
+	case SystemRequestType::CAMERA_COMMAND: return "CAMERA_COMMAND";
+	case SystemRequestType::GPS_COMMAND: return "GPS_COMMAND";
+	case SystemRequestType::INFRARED_COMMAND: return "INFRARED_COMMAND";
+	case SystemRequestType::MICROPHONE_COMMAND: return "MICROPHONE_COMMAND";
+	case SystemRequestType::RUN_CALLBACK_IN_WNDPROC: return "RUN_CALLBACK_IN_WNDPROC";
+	case SystemRequestType::MOVE_TO_TRASH: return "MOVE_TO_TRASH";
+	case SystemRequestType::IAP_RESTORE_PURCHASES: return "IAP_RESTORE_PURCHASES";
+	case SystemRequestType::IAP_MAKE_PURCHASE: return "IAP_MAKE_PURCHASE";
 	default: return "N/A";
 	}
 }
@@ -48,7 +72,7 @@ bool RequestManager::MakeSystemRequest(SystemRequestType type, RequesterToken to
 		callbackMap_[requestId] = { callback, failedCallback, token };
 	}
 
-	VERBOSE_LOG(Log::System, "Making system request %s: id %d", RequestTypeAsString(type), requestId);
+	INFO_LOG(Log::System, "Making system request %s: id %d", RequestTypeAsString(type), requestId);
 	std::string p1(param1);
 	std::string p2(param2);
 	// TODO: Convert to string_view

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -329,6 +329,19 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		DarwinFileSystemServices::presentDirectoryPanel(callback, /* allowFiles = */ true, /* allowDirectories = */ false, fileType);
 		return true;
 	}
+	case SystemRequestType::BROWSE_FOR_IMAGE:
+	{
+		DarwinDirectoryPanelCallback callback = [requestId] (bool success, Path path) {
+			if (success) {
+				g_requestManager.PostSystemSuccess(requestId, path.c_str());
+			} else {
+				g_requestManager.PostSystemFailure(requestId);
+			}
+		};
+		BrowseFileType fileType = BrowseFileType::IMAGE;
+		DarwinFileSystemServices::presentDirectoryPanel(callback, /* allowFiles = */ true, /* allowDirectories = */ false, fileType);
+		return true;
+	}
 	case SystemRequestType::BROWSE_FOR_FOLDER:
 	{
 		DarwinDirectoryPanelCallback callback = [requestId] (bool success, Path path) {
@@ -342,6 +355,20 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		return true;
 	}
 #else
+	case SystemRequestType::BROWSE_FOR_IMAGE:
+	{
+		// TODO: Add non-blocking support.
+		const std::string &title = param1;
+		std::vector<std::string> filters;
+		InitializeFilters(filters, BrowseFileType::IMAGE);
+		std::vector<std::string> result = pfd::open_file(title, "", filters).result();
+		if (!result.empty()) {
+			g_requestManager.PostSystemSuccess(requestId, result[0]);
+		} else {
+			g_requestManager.PostSystemFailure(requestId);
+		}
+		return true;
+	}
 	case SystemRequestType::BROWSE_FOR_FILE:
 	case SystemRequestType::BROWSE_FOR_FILE_SAVE:
 	{
@@ -453,7 +480,11 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		}
 		return true;
 	}
+	case SystemRequestType::SET_KEEP_SCREEN_BRIGHT:
+		INFO_LOG(Log::UI, "SET_KEEP_SCREEN_BRIGHT not implemented.");
+		return true;
 	default:
+		INFO_LOG(Log::UI, "Unhandled system request %s", RequestTypeAsString(type));
 		return false;
 	}
 }

--- a/UI/DeveloperToolsScreen.cpp
+++ b/UI/DeveloperToolsScreen.cpp
@@ -157,8 +157,8 @@ void DeveloperToolsScreen::CreateGeneralTab(UI::LinearLayout *list) {
 	list->Add(new ItemHeader(sy->T("General")));
 
 	list->Add(new CheckBox(&g_Config.bEnableLogging, dev->T("Enable Logging")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoggingChanged);
-	list->Add(new CheckBox(&g_Config.bEnableFileLogging, dev->T("Log to file")))->SetEnabledPtr(&g_Config.bEnableLogging);
 	list->Add(new Choice(dev->T("Logging Channels")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLogConfig);
+	list->Add(new CheckBox(&g_Config.bEnableFileLogging, dev->T("Log to file")))->SetEnabledPtr(&g_Config.bEnableLogging);
 	list->Add(new CheckBox(&g_Config.bLogFrameDrops, dev->T("Log Dropped Frame Statistics")));
 	if (GetGPUBackend() == GPUBackend::VULKAN) {
 		list->Add(new CheckBox(&g_Config.bGpuLogProfiler, dev->T("GPU log profiler")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1517,6 +1517,7 @@ UI::EventReturn GameSettingsScreen::OnChangeBackground(UI::EventParams &e) {
 	const Path bgJpg = GetSysDirectory(DIRECTORY_SYSTEM) / "background.jpg";
 
 	if (File::Exists(bgPng) || File::Exists(bgJpg)) {
+		INFO_LOG(Log::UI, "Clearing background image.");
 		// The button is in clear mode.
 		File::Delete(bgPng);
 		File::Delete(bgJpg);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1121,7 +1121,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	uiScale->SetZeroLabel(sy->T("Off"));
 	uiScale->OnChange.Add([](UI::EventParams &e) {
 		const float dpiMul = UIScaleFactorToMultiplier(g_Config.iUIScaleFactor);
-		g_display.Recalculate(-1, -1, -1, dpiMul, dpiMul);
+		g_display.Recalculate(-1, -1, -1, -1, dpiMul);
 		NativeResized();
 		return UI::EVENT_DONE;
 	});


### PR DESCRIPTION
Forgot that the platform backends need changes too, after I split out image file selection from the other types.

Also logging improvements for unhandled requests.

Additionally, changing DPI on the system tab resulted in strange stretching until you resize the window on some platforms. Fix that.