### PR TITLE
Remove left-behind ampersand merging from atlas text-drawing codepath

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -518,9 +518,6 @@ void DrawBuffer::MeasureText(FontID font, std::string_view text, float *w, float
 			continue;
 		} else if (cval == '\t') {
 			cval = ' ';
-		} else if (cval == '&' && utf.peek() != '&') {
-			// Ignore lone ampersands
-			continue;
 		}
 		const AtlasChar *c = atlasfont->getChar(cval);
 		if (c) {
@@ -659,9 +656,6 @@ void DrawBuffer::DrawText(FontID font, std::string_view text, float x, float y, 
 			continue;
 		} else if (cval == '\t') {
 			cval = ' ';
-		} else if (cval == '&' && utf.peek() != '&') {
-			// Ignore lone ampersands
-			continue;
 		}
 		const AtlasChar *ch = atlasfont->getChar(cval);
 		if (!ch)


### PR DESCRIPTION
See #20402

Also bumps our glslang fork with another buildfix.
