### PR TITLE
Don't allow exiting the app (and a few more actions) while a game is booting

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1161,6 +1161,9 @@ UCJS18012 = true
 # WWE All Stars
 ULUS10544 = true
 ULES01510 = true
+# Activision Hits Remixed
+ULES00640 = true
+ULUS10186 = true
 
 [MemstickFixedFree]
 # Assassin's Creed : Bloodlines - issue #12761


### PR DESCRIPTION
Creates nasty race conditions.

Plus, a minor compat.ini update.
