### PR TITLE
gradle: Stop requiring JDK 17, this causes annoying problems in new installations of Android Studio

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,11 +48,6 @@ android {
 
 	compileSdk 35
 	ndkVersion "21.4.7075529"
-	java {
-		toolchain {
-			languageVersion = JavaLanguageVersion.of(17)
-		}
-	}
 	defaultConfig {
 		/*
 		configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.2'
+        classpath 'com.android.tools.build:gradle:8.9.3'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
-android.ndk.suppressMinSdkVersionError=21


### PR DESCRIPTION
Also bump to the latest version and remove an unnecessary line.