### PR TITLE
mingw-w64 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,10 +437,6 @@ if(NOT MSVC)
 	endif()
 
 	include(CheckSymbolExists)
-	check_symbol_exists(_UCRT "windows.h" UCRT)
-	if (UCRT)
-		link_libraries("$<$<CONFIG:Debug>:ucrtbased>")
-	endif()
 
 	add_compile_definitions("$<$<CONFIG:Debug>:_DEBUG>")
 

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -652,7 +652,9 @@ bool CreateFullPath(const Path &path) {
 	}
 
 	std::vector<std::string_view> parts;
-	SplitString(diff, '/', parts);
+	if (!diff.empty()) {
+		SplitString(diff, '/', parts);
+	}
 
 	// Probably not necessary sanity check, ported from the old code.
 	if (parts.size() > 100) {

--- a/Core/LuaContext.cpp
+++ b/Core/LuaContext.cpp
@@ -134,7 +134,7 @@ void LuaContext::ExecuteConsoleCommand(std::string_view cmd) {
 			sol::error err = result;
 			lines_.push_back(LuaLogLine{ LogLineType::Error, std::string(err.what()) });
 		}
-	} catch (sol::error e) {
+	} catch (const sol::error& e) {
 		ERROR_LOG(Log::System, "Lua exception: %s", e.what());
 		lines_.push_back(LuaLogLine{ LogLineType::Error, std::string(e.what()) });
 	}

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -899,7 +899,7 @@ static void WinMainInit() {
 
 	EnableCrashingOnCrashes();
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && defined(_MSC_VER)
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 	PROFILE_INIT();


### PR DESCRIPTION
Some fixes for mingw-w64 and Windows.

1. `PPSSPPWindows.exe --log=ppsspplog.txt` was creating a directory `ppsspplog.txt` and logging didn't work.
1. `PPSSPPWindows.exe` depended on `ucrtbased.dll` which is part of the Windows SDK.