### PR TITLE
Add some small debug counters that can be sent out through the assert message on Android

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -136,9 +136,19 @@ __attribute__((format(printf, 5, 6)))
 #endif
 ;
 
+// These allow us to get a small amount of information into assert messages.
+// They can have a value between 0 and 15.
+enum class DebugCounter {
+	APP_BOOT = 0,
+	GAME_BOOT = 0,
+	GAME_SHUTDOWN = 0,
+};
+
 bool HitAnyAsserts();
 void ResetHitAnyAsserts();
 void SetExtraAssertInfo(const char *info);
+void SetDebugValue(DebugCounter counter, int value);
+void IncrementDebugCounter(DebugCounter counter);
 typedef void (*AssertNoCallbackFunc)(const char *message, void *userdata);
 void SetAssertCancelCallback(AssertNoCallbackFunc callback, void *userdata);
 void SetCleanExitOnAssert();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -546,6 +546,8 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 		return false;
 	}
 
+	IncrementDebugCounter(DebugCounter::GAME_BOOT);
+
 	g_bootState = BootState::Booting;
 
 	GraphicsContext *temp = g_CoreParameter.graphicsContext;
@@ -678,6 +680,7 @@ void PSP_Shutdown(bool success) {
 
 	// Do nothing if we never inited.
 	if (g_bootState == BootState::Off) {
+		ERROR_LOG(Log::Loader, "Unexpected PSP_Shutdown");
 		return;
 	}
 
@@ -710,6 +713,8 @@ void PSP_Shutdown(bool success) {
 	if (success) {
 		g_bootState = BootState::Off;
 	}
+
+	IncrementDebugCounter(DebugCounter::GAME_SHUTDOWN);
 }
 
 BootState PSP_Reboot(std::string *error_string) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1022,6 +1022,13 @@ void SystemInfoScreen::CreateInternalsTab(UI::ViewGroup *internals) {
 	internals->Add(new ItemHeader(ac->T("Notifications")));
 	internals->Add(new PopupMultiChoice(&g_Config.iAchievementsLeaderboardTrackerPos, ac->T("Leaderboard tracker"), positions, 0, ARRAY_SIZE(positions), I18NCat::DIALOG, screenManager()))->SetEnabledPtr(&g_Config.bAchievementsEnable);
 
+#ifdef _DEBUG
+	// Untranslated string because this is debug mode only, only for PPSSPP developers.
+	internals->Add(new Choice("Assert"))->OnClick.Add([=](UI::EventParams &) {
+		_dbg_assert_msg_(false, "Test assert message");
+		return UI::EVENT_DONE;
+	});
+#endif
 #if PPSSPP_PLATFORM(ANDROID)
 	internals->Add(new Choice(si->T("Exception")))->OnClick.Add([&](UI::EventParams &) {
 		System_Notify(SystemNotification::TEST_JAVA_EXCEPTION);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -350,6 +350,8 @@ static void ClearFailedGPUBackends() {
 void NativeInit(int argc, const char *argv[], const char *savegame_dir, const char *external_dir, const char *cache_dir) {
 	net::Init();  // This needs to happen before we load the config. So on Windows we also run it in Main. It's fine to call multiple times.
 
+	IncrementDebugCounter(DebugCounter::APP_BOOT);
+
 	// Probably an excessive timeout. it only causes delays on shutdown, though.
 	__UPnPInit(2000);
 


### PR DESCRIPTION
To get some extra info when looking at assert crash dumps on Google Play crash reporting.