### PR TITLE
Add workaround for scePsmf LLE not working with Dragon's Lair

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -150,6 +150,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "UseFFMPEGFindStreamInfo", &flags_.UseFFMPEGFindStreamInfo);
 	CheckSetting(iniFile, gameID, "SoftwareRasterDepth", &flags_.SoftwareRasterDepth);
 	CheckSetting(iniFile, gameID, "DisableHLESceFont", &flags_.DisableHLESceFont);
+	CheckSetting(iniFile, gameID, "ForceHLEPsmf", &flags_.ForceHLEPsmf);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -113,6 +113,7 @@ struct CompatFlags {
 	bool UseFFMPEGFindStreamInfo;
 	bool SoftwareRasterDepth;
 	bool DisableHLESceFont;
+	bool ForceHLEPsmf;
 };
 
 struct VRCompat {

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -202,6 +202,9 @@ static DisableHLEFlags GetDisableHLEFlags() {
 	if (PSP_CoreParameter().compat.flags().DisableHLESceFont) {
 		flags |= DisableHLEFlags::sceFont;
 	}
+	if (PSP_CoreParameter().compat.flags().ForceHLEPsmf) {
+		flags &= ~(DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer);
+	}
 
 	flags &= ~(DisableHLEFlags)g_Config.iForceEnableHLE;
 	return flags;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1923,3 +1923,8 @@ UCKS45164 = true
 UCES01184 = true
 UCUS98668 = true
 UCJP00174 = true
+
+[ForceHLEPsmf]
+# See issue #20467
+NPUH10105 = true
+NPEH00122 = true


### PR DESCRIPTION
See #20467 

This is just a temporary workaround, until we can make sceMpeg accurate enough to work here.