### PR TITLE
A few CI improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -25,9 +25,8 @@ env:
   SDL_AUDIODRIVER: "dummy" #"disk"
   #SDL_VIDEODRIVER: "dummy"
   #BUILD_CONFIGURATION: Release #RelWithDebInfo
-  
-jobs:
 
+jobs:
   build:
     name: Building AppImage
     strategy:
@@ -38,10 +37,10 @@ jobs:
           id: x86_64
         - os: ubuntu-24.04-arm
           id: aarch64
-        
+
     runs-on: '${{ matrix.os }}'
     container: ghcr.io/pkgforge-dev/archlinux:latest
-    
+
     steps:
       - uses: actions/checkout@v1 # v2+ seems to have submodules issue with the archlinux container
         with:
@@ -57,14 +56,14 @@ jobs:
           # Fix dubious ownership issue when running git describe inside a container
           git config --global --add safe.directory "$PWD" # Alternatively, chown -R $(id -u):$(id -g) $PWD
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
-          
+
       - name: Fetch upstream tags # required for git describe to return a valid version and to preevnt androidGitVersion from crashing on a new fork
         if: ${{ steps.valid-tags.outputs.count == '0' }}
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
           git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
-          
+
       #- name: Setup ccache # Doesn't support archlinux container?
       #  uses: hendrikmuhs/ccache-action@v1.2
       #  with:
@@ -94,11 +93,11 @@ jobs:
           else
           	PKG_TYPE='aarch64.pkg.tar.xz'
           fi
-          
+
           LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
           LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
           OPUS_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/opus-nano-$PKG_TYPE"
-          
+
           echo "Installing build dependencies..."
           echo "---------------------------------------------------------------"
           pacman -Syu --noconfirm \
@@ -136,19 +135,19 @@ jobs:
           if [[ "$ARCH" == "x86_64" ]]; then
             pacman -Syu --noconfirm vulkan-intel
           fi
-          
+
           echo "Installing debloated pckages..."
           echo "---------------------------------------------------------------"
           wget --retry-connrefused --tries=30 "$LLVM_URL" -O   ./llvm-libs.pkg.tar.zst
           wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2.pkg.tar.zst
           wget --retry-connrefused --tries=30 "$OPUS_URL" -O   ./opus-nano.pkg.tar.zst
-          
+
           pacman -U --noconfirm ./*.pkg.tar.zst
           rm -f ./*.pkg.tar.zst
-          
+
           echo "All done!"
           echo "---------------------------------------------------------------"
-      
+
       - name: Build Release
         id: version
         env:
@@ -171,10 +170,10 @@ jobs:
 
           gcc --version
           g++ --version
-          
+
           #clang --version
           #clang++ --version
-          
+
           # Build ppsspp
           #./b.sh --release --no-sdl2 --no-png
           mkdir -p build
@@ -192,7 +191,7 @@ jobs:
 
           # Test for missing modules
           ldd ./build/PPSSPPSDL
-          
+
           # Create AppImage package
           echo "Creating AppImage..."
           chmod +x ./build/PPSSPPSDL
@@ -217,19 +216,18 @@ jobs:
           if [ -e ./PPSSPP*.zsync ]; then
             cp ./PPSSPP*.zsync artifacts/
           fi
-            
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: linux-${{ steps.version.outputs.tag }}-${{ matrix.id }} AppImage
           path: artifacts/
-          
+
       - name: Upload release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             artifacts/*.AppImage
             artifacts/*.AppImage.zsync
-        

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    name: Building AppImage
+    name: build (${{ matrix.id }})
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,7 @@ jobs:
         - os: ubuntu-24.04-arm
           id: aarch64
 
-    runs-on: '${{ matrix.os }}'
+    runs-on: ${{ matrix.os }}
     container: ghcr.io/pkgforge-dev/archlinux:latest
 
     steps:
@@ -58,7 +58,7 @@ jobs:
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version and to preevnt androidGitVersion from crashing on a new fork
-        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        if: steps.valid-tags.outputs.count == '0'
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
@@ -162,7 +162,6 @@ jobs:
           echo "Building..."
           uname -m
           echo "tag=$(git describe --always --tags)" >> $GITHUB_OUTPUT
-          echo "isTag=${{ startsWith(github.ref, 'refs/tags/') }}" >> $GITHUB_OUTPUT
 
           # Export ccache env var(s)
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
@@ -196,15 +195,15 @@ jobs:
           echo "Creating AppImage..."
           chmod +x ./build/PPSSPPSDL
           chmod +x ./scripts/makeappimage_64-bit.sh
-          VERSION=$([ "${{ steps.version.outputs.isTag }}" == "true" ] && echo "${GITHUB_REF##*/}" || echo "${{ steps.version.outputs.tag }}")
+          VERSION=$([[ ${GITHUB_REF_TYPE} == tag ]] && echo "$GITHUB_REF_NAME" || echo "${{ steps.version.outputs.tag }}")
           echo "Version = $VERSION"
           ./scripts/makeappimage_64-bit.sh "$VERSION"
 
       - name: Prepare artifacts
         run: |
           find . -name "PPSSPPSDL"
-          find . -name "PPSSPP*.AppImage" -exec chmod +x  {} \;
-          find . -name "PPSSPP*.AppBundle" -exec chmod +x  {} \;
+          find . -name "PPSSPP*.AppImage" -exec chmod +x '{}' \;
+          find . -name "PPSSPP*.AppBundle" -exec chmod +x '{}' \;
           find . -name "PPSSPP*.zsync"
           mkdir artifacts
           if [ -e ./PPSSPP*.AppImage ]; then
@@ -225,7 +224,7 @@ jobs:
 
       - name: Upload release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.ref_type == 'tag'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         submodules: recursive
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
 
     - name: Build Windows
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -76,7 +76,7 @@ jobs:
         submodules: recursive
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
 
     - name: Build UWP
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -203,13 +203,14 @@ jobs:
         git fetch --deepen=15000 --no-recurse-submodules --tags || exit 0
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005 # v4.3.0
       if: matrix.extra == 'qt'
       with:
         cache: true
         version: 5.15.2
 
-    - uses: nttld/setup-ndk@v1
+    - name: Setup Android NDK
+      uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
       if: matrix.extra == 'android'
       id: setup-ndk
       with:
@@ -229,7 +230,7 @@ jobs:
         echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
       # Disable ccache on macos for now, it's become buggy for some reason.
       if: matrix.id != 'macos'
       with:
@@ -299,7 +300,7 @@ jobs:
         mv PPSSPPSDL.zip PPSSPPSDL-macOS-${GITHUB_REF##*/}.zip || exit 1
 
     - name: Upload macOS release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
       if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS' && matrix.extra == 'test'
       with:
         files: ppsspp/*.zip
@@ -383,8 +384,8 @@ jobs:
         chown -R $(id -u):$(id -g) $PWD
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-    
+      uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
+
     - name: Compile ffmpeg
       run: |
         cd ffmpeg && ./linux_x86-64.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
       run: python test.py -g --graphics=software
 
   build:
+    name: build (${{ matrix.id }})
     strategy:
       fail-fast: false
       matrix:
@@ -219,14 +220,14 @@ jobs:
     - name: Install Linux dependencies
       if: runner.os == 'Linux' && matrix.extra != 'android'
       run: |
-        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
+        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
         sudo apt-get update -y -qq
         sudo apt-get install libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev libsdl2-ttf-dev libfontconfig1-dev
 
     - name: Create macOS git-version.cpp for tagged release
-      if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS' && matrix.extra == 'test'
+      if: github.ref_type == 'tag' && runner.os == 'macOS' && matrix.extra == 'test'
       run: |
-        echo "const char *PPSSPP_GIT_VERSION = \"${GITHUB_REF##*/}\";" > git-version.cpp
+        echo "const char *PPSSPP_GIT_VERSION = \"${GITHUB_REF_NAME}\";" > git-version.cpp
         echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
 
     - name: Setup ccache
@@ -267,10 +268,10 @@ jobs:
         elif [ -e build*/PPSSPPSDL.app ]; then
           cp -a build*/PPSSPPSDL.app ppsspp/
           # GitHub Actions zipping kills symlinks and permissions.
-          cd ppsspp
+          pushd ppsspp
           zip -qry PPSSPPSDL.zip PPSSPPSDL.app
           rm -rf PPSSPPSDL.app
-          cd -
+          popd
         elif [ -e build*/PPSSPPSDL ]; then
           cp build*/PPSSPPSDL ppsspp/
           cp -r assets ppsspp/assets
@@ -294,14 +295,13 @@ jobs:
         path: ppsspp/
 
     - name: Create macOS release
-      if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS' && matrix.extra == 'test'
-      run: |
-        cd ppsspp || exit 1
-        mv PPSSPPSDL.zip PPSSPPSDL-macOS-${GITHUB_REF##*/}.zip || exit 1
+      if: github.ref_type == 'tag' && runner.os == 'macOS' && matrix.extra == 'test'
+      working-directory: ppsspp
+      run: mv PPSSPPSDL.zip PPSSPPSDL-macOS-${GITHUB_REF_NAME}.zip
 
     - name: Upload macOS release
       uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
-      if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS' && matrix.extra == 'test'
+      if: github.ref_type == 'tag' && runner.os == 'macOS' && matrix.extra == 'test'
       with:
         files: ppsspp/*.zip
         body: >
@@ -333,7 +333,7 @@ jobs:
     - name: Install Linux dependencies
       if: runner.os == 'Linux'
       run: |
-        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
+        sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) main universe restricted multiverse"
         sudo apt-get update -y -qq
         sudo apt-get install libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev libsdl2-ttf-dev libfontconfig1-dev
 
@@ -365,7 +365,7 @@ jobs:
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: python test.py -g --graphics=software
 
-  build_test_headless_alpine:
+  test-headless-alpine:
     runs-on: ubuntu-latest
     container: 
       image: alpine:latest

--- a/.github/workflows/generateDockerLayer.yml
+++ b/.github/workflows/generateDockerLayer.yml
@@ -5,33 +5,31 @@ on:
     branches:
       - master
     tags:
-      - v*
+      - "v*.*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
-  
-    steps:
-    - uses: actions/checkout@v4
 
-    - name: Extract DOCKER_TAG using tag name
-      if: startsWith(github.ref, 'refs/tags/')
+    steps:
+    - name: Generate Docker image metadata
+      id: metadata
       run: |
-        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
-    
-    - name: Use default DOCKER_TAG
-      if: startsWith(github.ref, 'refs/tags/') != true
-      run: |
-        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-      
-    - name: Login to Github registry
+        if [[ ${GITHUB_REF_TYPE} == tag ]]; then
+          echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+        else
+          echo "tag=latest" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Login to GitHub registry
       uses: docker/login-action@v3
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: ghcr.io
-    
-    - uses: docker/build-push-action@v6
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
       with:
         push: true
-        tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
+        tags: ghcr.io/${{ github.repository }}:${{ steps.metadata.outputs.tag }}

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -34,7 +34,7 @@ jobs:
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version and to preevnt androidGitVersion from crashing on a new fork
-        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        if: steps.valid-tags.outputs.count == '0'
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -57,7 +57,7 @@ jobs:
           find . -name "Version.txt"
           
       - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@main
+        uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
         with:
           key: ios
           create-symlink: true

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -31,7 +31,7 @@ jobs:
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
-        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        if: steps.valid-tags.outputs.count == '0'
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
@@ -50,18 +50,18 @@ jobs:
           mkdir build-ios/PPSSPP.app
           echo $(echo $GIT_VERSION | cut -c 2-) > build-ios/PPSSPP.app/Version.txt
           # Testing values ...
-          echo "Content of [GITHUB_REF##*/] = ${GITHUB_REF##*/}"
+          echo "Content of [GITHUB_REF_NAME] = ${GITHUB_REF_NAME}"
           echo "count=${{steps.valid-tags.outputs.count}}"
           echo $(echo $GIT_VERSION | cut -c 2-)
           # Testing file location ...
           find . -name "Version.txt"
-          
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@63069e3931dedbf3b63792097479563182fe70d1 # v1.2.18
         with:
           key: ios
           create-symlink: true
-      
+
       - name: Execute build
         env:
           CC: clang
@@ -85,10 +85,10 @@ jobs:
             mkdir ppsspp/Payload
             cp -a build*/PPSSPP.app ppsspp/Payload
             # GitHub Actions zipping kills symlinks and permissions.
-            cd ppsspp
+            pushd ppsspp
             zip -qry PPSSPP.ipa Payload
             rm -rf Payload
-            cd -
+            popd
           fi
 
       - name: Upload artifact

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -48,7 +48,7 @@ jobs:
           echo "count=$(git tag -l 'v[0-9]*' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT # $env:GITHUB_OUTPUT on pwsh
           
       - name: Fetch upstream tags # required for git describe to return a valid version on a new fork
-        if: ${{ steps.valid-tags.outputs.count == '0' }}
+        if: steps.valid-tags.outputs.count == '0'
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
@@ -84,7 +84,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           INCLUDE_SYMBOLS: ${{ github.event.inputs.buildConfiguration == 'Debug' && 'true' || 'false' }}
-        if: ${{ github.event.inputs.buildPlatform != 'Bundle' }}
+        if: github.event.inputs.buildPlatform != 'Bundle'
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
           msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ github.event.inputs.signedPackage }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
@@ -93,7 +93,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           INCLUDE_SYMBOLS: ${{ github.event.inputs.buildConfiguration == 'Debug' && 'true' || 'false' }}
-        if: ${{ github.event.inputs.buildPlatform == 'Bundle' }}
+        if: github.event.inputs.buildPlatform == 'Bundle'
         run: |
           echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
           msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=${{ github.event.inputs.signedPackage }} /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -53,10 +53,10 @@ jobs:
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
           git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
-        
+
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
-          
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
+
       #- name: Setup cache # We probably need something like MSBuildCache for MSBuild to be able to use cache properly
       #  id: cache-uwp
       #  uses: actions/cache@v3

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-    name: build
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -21,10 +20,10 @@ jobs:
     - name: Archive
       id: archive
       run: |
-        VERSION=${GITHUB_REF##*/}
+        VERSION=$GITHUB_REF_NAME
         test -z "$VERSION" && VERSION=${{ github.event.release.tag_name }}
         VERSION=$(printf "%s\n" "$VERSION" | sed 's/^v//')
-        PKGNAME="ppsspp-$VERSION"
+        PKGNAME=ppsspp-$VERSION
         mkdir -p /tmp/$PKGNAME
         mv * /tmp/$PKGNAME
         mv /tmp/$PKGNAME .

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -14,12 +14,11 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
-    - name: archive
+    - name: Archive
       id: archive
       run: |
         VERSION=${GITHUB_REF##*/}
@@ -42,8 +41,8 @@ jobs:
         tar cJf $TARBALL $PKGNAME
         echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
 
-    - name: upload tarball
-      uses: softprops/action-gh-release@v1
+    - name: Upload tarball
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
       with:
         files: ${{ steps.archive.outputs.tarball }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The main change here is pinning some third-party actions to a specific commit hash (instead of a floating tag) in order to improve security and prevent supply chain attacks. I tried to keep the changes to a minimum, e.g. I didn't pin actions from docker and microsoft, as I wasn't sure if you agree with this direction, although generally it's best to just pin all third-party actions. If you're concerned about the maintenance burden of keeping the actions up-to-date, I suggest enabling dependabot for the actions ecosystem. I can send another patch with the dependabot config if you like.