### PR TITLE
Some cleanups

### DIFF
--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -46,28 +46,6 @@
 #define Crash() {kill(getpid(), SIGINT);}
 #endif
 
-inline u32 __rotl(u32 x, int shift) {
-	shift &= 31;
-	if (!shift) return x;
-	return (x << shift) | (x >> (32 - shift));
-}
-
-inline u64 __rotl64(u64 x, unsigned int shift){
-	unsigned int n = shift % 64;
-	return (x << n) | (x >> (64 - n));
-}
-
-inline u32 __rotr(u32 x, int shift) {
-    shift &= 31;
-    if (!shift) return x;
-    return (x >> shift) | (x << (32 - shift));
-}
-
-inline u64 __rotr64(u64 x, unsigned int shift){
-	unsigned int n = shift % 64;
-	return (x >> n) | (x << (64 - n));
-}
-
 #else // WIN32
 
 // Function Cross-Compatibility
@@ -78,10 +56,6 @@ inline u64 __rotr64(u64 x, unsigned int shift){
 
 #ifndef __MINGW32__
 #define unlink _unlink
-#define __rotl _rotl
-#define __rotl64 _rotl64
-#define __rotr _rotr
-#define __rotr64 _rotr64
 #endif
 
 // 64 bit offsets for windows
@@ -92,3 +66,55 @@ inline u64 __rotr64(u64 x, unsigned int shift){
 #endif
 	#define Crash() {__debugbreak();}
 #endif // WIN32 ndef
+
+#if defined(_MSC_VER)
+#include <cstdlib>
+#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+#include <x86intrin.h>
+#endif
+
+inline u32 __rotl(u32 x, int shift) {
+#if defined(_MSC_VER)
+	return _rotl(x, shift);
+#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+	return __rold(x, shift);
+#else
+	shift &= 31;
+	if (!shift) return x;
+	return (x << shift) | (x >> (32 - shift));
+#endif
+}
+
+inline u64 __rotl64(u64 x, unsigned int shift){
+#if defined(_MSC_VER)
+	return _rotl64(x, shift);
+#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+	return __rolq(x, shift);
+#else
+	unsigned int n = shift % 64;
+	return (x << n) | (x >> (64 - n));
+#endif
+}
+
+inline u32 __rotr(u32 x, int shift) {
+#if defined(_MSC_VER)
+	return _rotr(x, shift);
+#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+	return __rord(x, shift);
+#else
+    shift &= 31;
+    if (!shift) return x;
+    return (x >> shift) | (x << (32 - shift));
+#endif
+}
+
+inline u64 __rotr64(u64 x, unsigned int shift){
+#if defined(_MSC_VER)
+	return _rotr64(x, shift);
+#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+	return __rorq(x, shift);
+#else
+	unsigned int n = shift % 64;
+	return (x >> n) | (x << (64 - n));
+#endif
+}

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -715,11 +715,7 @@ namespace MIPSInt
 			}
 			else if (_RS == 1) //rotr
 			{
-#ifdef __MINGW32__
-				R(rd) = _rotr(R(rt), sa);
-#else
 				R(rd) = __rotr(R(rt), sa);
-#endif
 				break;
 			}
 			else
@@ -735,11 +731,7 @@ namespace MIPSInt
 			}
 			else if (_FD == 1) // rotrv
 			{
-#ifdef __MINGW32__
-				R(rd) = _rotr(R(rt), R(rs));
-#else
 				R(rd) = __rotr(R(rt), R(rs));
-#endif
 				break;
 			}
 			else goto wrong;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -499,7 +499,7 @@ bool SavedataBrowser::ByFilename(const UI::View *v1, const UI::View *v2) {
 	const SavedataButton *b1 = static_cast<const SavedataButton *>(v1);
 	const SavedataButton *b2 = static_cast<const SavedataButton *>(v2);
 
-	return strcmp(b1->GamePath().c_str(), b2->GamePath().c_str()) < 0;
+	return b1->GamePath() < b2->GamePath();
 }
 
 void SavedataBrowser::PrepSize(UI::View *v) {
@@ -517,7 +517,7 @@ bool SavedataBrowser::BySize(const UI::View *v1, const UI::View *v2) {
 		return true;
 	else if (size1 < size2)
 		return false;
-	return strcmp(b1->GamePath().c_str(), b2->GamePath().c_str()) < 0;
+	return b1->GamePath() < b2->GamePath();
 }
 
 void SavedataBrowser::PrepDate(UI::View *v) {
@@ -535,7 +535,7 @@ bool SavedataBrowser::ByDate(const UI::View *v1, const UI::View *v2) {
 		return true;
 	if (time1 < time2)
 		return false;
-	return strcmp(b1->GamePath().c_str(), b2->GamePath().c_str()) < 0;
+	return b1->GamePath() < b2->GamePath();
 }
 
 void SavedataBrowser::Refresh() {

--- a/UWP/UWPHelpers/StorageManager.cpp
+++ b/UWP/UWPHelpers/StorageManager.cpp
@@ -259,7 +259,7 @@ bool IsRootForAccessibleItems(Path path, std::list<std::string>& subRoot, bool b
 			if (!endsWith(sub, ":")) {
 				bool alreadyAdded = false;
 				for each (auto sItem in subRoot) {
-					if (!strcmp(sItem.c_str(), sub.c_str())) {
+					if (sItem == sub) {
 						alreadyAdded = true;
 						break;
 					}


### PR DESCRIPTION
1. I replaced `strcmp` with `==`.
1. When I ported to msys2 I used some ugly `ifdef`s in `Core/MIPS/MIPSInt.cpp`. I replaced the macros with inline functions.