### PR TITLE
[ImDebugger] Enable Memory Search in the ImMemView Widget

### DIFF
--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -287,11 +287,13 @@ void ImMemView::ProcessKeyboardShortcuts(bool focused) {
 			return;
 			*/
 		}
+		/*
 		if (ImGui::IsKeyPressed(ImGuiKey_F)) {
-			search(false);
-		}
-		if (ImGui::IsKeyPressed(ImGuiKey_C)) {
-			search(true);
+			initSearch();
+			memSearch_.status = search(false);
+		}*/
+		if (ImGui::IsKeyPressed(ImGuiKey_N)) {
+			continueSearch();
 		}
 	} else {
 		if (ImGui::IsKeyPressed(ImGuiKey_DownArrow)) {
@@ -993,7 +995,7 @@ void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &
 	static MemorySearchType type[4]={BITS_8};
 	ImGui::Combo("type", reinterpret_cast<int*>(&type[index]), searchtypes, IM_ARRAYSIZE(searchtypes));
 	static char str[4][512];
-	ImGui::InputText("data: ", &(str[index][0]), IM_ARRAYSIZE(str[index]));
+	ImGui::InputText("data", &(str[index][0]), IM_ARRAYSIZE(str[index]));
 
 	if(ImGui::Button("Search")) {
 		memView_.initSearch(str[index], type[index]);

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -44,17 +44,19 @@ public:
 	void setHighlightType(MemBlockFlags flags);
 
 	void toggleDrawZeroDark(bool toggle);
-
+	void doSearch();
 	const std::string &StatusMessage() const {
 		return statusMessage_;
 	}
 
 private:
+	enum etypes  {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT, STRING, STRING_16,  BYTESEQ};
 	void ProcessKeyboardShortcuts(bool focused);
 
-	bool ParseSearchString(const std::string &query, bool asHex, std::vector<uint8_t> &data);
+	bool ParseSearchString(const char* query, int mode);
 	void updateStatusBarText();
-	void search(bool continueSearch);
+	enum SearchStatus {SEARCH_PSP_NOT_INIT=-1, SEARCH_INITIAL, SEARCH_OK, SEARCH_NOTFOUND, SEARCH_CANCEL};
+	SearchStatus search(bool continueSearch);
 
 	enum class GotoMode {
 		RESET,
@@ -70,6 +72,18 @@ private:
 	void ScrollCursor(int bytes, GotoMode mdoe);
 	void PopupMenu();
 
+	struct MemorySearch{
+		// keep search related variables grouped
+		std::vector<u8> data;
+		uint8_t* fast_data;
+		size_t fast_size;
+		u32 searchAddress;
+		u32 matchAddress;
+		u32 segmentStart;
+		u32 segmentEnd;
+		bool searching;
+		SearchStatus status;
+	} memSearch_;
 	static wchar_t szClassName[];
 	MIPSDebugInterface *debugger_ = nullptr;
 
@@ -112,13 +126,6 @@ private:
 	int visibleRows_ = 0;
 
 	bool drawZeroDark_ = false;
-
-	// Last used search query, used when continuing a search.
-	std::string searchQuery_;
-	// Address of last match when continuing search.
-	uint32_t matchAddress_ = 0xFFFFFFFF;
-	// Whether a search is in progress.
-	bool searching_ = false;
 
 	std::string statusMessage_;
 };

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -19,7 +19,7 @@ enum CommonToggles {
 };
 
 enum MemorySearchStatus {SEARCH_PSP_NOT_INIT=-1, SEARCH_INITIAL, SEARCH_OK, SEARCH_NOTFOUND, SEARCH_CANCEL};
-enum MemorySearchType {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT, STRING, STRING_16,  BYTESEQ};
+enum MemorySearchType {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT_32, STRING, STRING_16,  BYTE_SEQ};
 class ImMemView {
 public:
 	ImMemView();

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -18,6 +18,8 @@ enum CommonToggles {
 	Off,
 };
 
+enum MemorySearchStatus {SEARCH_PSP_NOT_INIT=-1, SEARCH_INITIAL, SEARCH_OK, SEARCH_NOTFOUND, SEARCH_CANCEL};
+enum MemorySearchType {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT, STRING, STRING_16,  BYTESEQ};
 class ImMemView {
 public:
 	ImMemView();
@@ -44,19 +46,22 @@ public:
 	void setHighlightType(MemBlockFlags flags);
 
 	void toggleDrawZeroDark(bool toggle);
-	void doSearch();
+	void initSearch(const char* str, MemorySearchType type);
+	void continueSearch();
+	MemorySearchStatus SearchStatus();
+	bool SearchEmpty();
+	uint32_t SearchMatchAddress();
+
 	const std::string &StatusMessage() const {
 		return statusMessage_;
 	}
 
 private:
-	enum etypes  {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT, STRING, STRING_16,  BYTESEQ};
 	void ProcessKeyboardShortcuts(bool focused);
 
-	bool ParseSearchString(const char* query, int mode);
+	bool ParseSearchString(const char* query, MemorySearchType mode);
 	void updateStatusBarText();
-	enum SearchStatus {SEARCH_PSP_NOT_INIT=-1, SEARCH_INITIAL, SEARCH_OK, SEARCH_NOTFOUND, SEARCH_CANCEL};
-	SearchStatus search(bool continueSearch);
+	MemorySearchStatus search(bool continueSearch);
 
 	enum class GotoMode {
 		RESET,
@@ -82,7 +87,7 @@ private:
 		u32 segmentStart;
 		u32 segmentEnd;
 		bool searching;
-		SearchStatus status;
+		MemorySearchStatus status;
 	} memSearch_;
 	static wchar_t szClassName[];
 	MIPSDebugInterface *debugger_ = nullptr;


### PR DESCRIPTION
This PR enables basic support for the search in memory view widget
I used the already existing search code as a base.

It adds a few controls above the hexview rather than using a dialog box

currently the following search are supported:
- int/uint 8/16/32/64
- float
- string
- bytes sequence following this format: "AA BB CC"

