### PR TITLE
Fix another texture replacement crash

### DIFF
--- a/Common/File/VFS/DirectoryReader.cpp
+++ b/Common/File/VFS/DirectoryReader.cpp
@@ -97,10 +97,14 @@ size_t DirectoryReader::Read(VFSOpenFile *vfsOpenFile, void *buffer, size_t leng
 
 void DirectoryReader::CloseFile(VFSOpenFile *vfsOpenFile) {
 	DirectoryReaderOpenFile *openFile = (DirectoryReaderOpenFile *)vfsOpenFile;
+	_dbg_assert_(openFile);
+	if (!openFile) {
+		return;
+	}
 	_dbg_assert_(openFile->file != nullptr);
 	if (openFile->file) {
 		fclose(openFile->file);
+		openFile->file = nullptr;
 	}
-	openFile->file = nullptr;
 	delete openFile;
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -214,6 +214,14 @@ static float DefaultUISaturation() {
 	return IsVREnabled() ? 1.5f : 1.0f;
 }
 
+static int DefaultUIScaleFactor() {
+#if PPSSPP_PLATFORM(WINDOWS)
+	return -1;
+#else
+	return 0;
+#endif
+}
+
 static const ConfigSetting generalSettings[] = {
 	ConfigSetting("FirstRun", &g_Config.bFirstRun, true, CfgFlag::DEFAULT),
 	ConfigSetting("RunCount", &g_Config.iRunCount, 0, CfgFlag::DEFAULT),
@@ -337,7 +345,7 @@ static const ConfigSetting generalSettings[] = {
 
 	ConfigSetting("ShowGPOLEDs", &g_Config.bShowGPOLEDs, false, CfgFlag::PER_GAME),
 
-	ConfigSetting("UIScaleFactor", &g_Config.iUIScaleFactor, false, CfgFlag::DEFAULT),
+	ConfigSetting("UIScaleFactor", &g_Config.iUIScaleFactor, &DefaultUIScaleFactor, CfgFlag::DEFAULT),
 
 	ConfigSetting("VulkanDisableImplicitLayers", &g_Config.bVulkanDisableImplicitLayers, false, CfgFlag::DEFAULT),
 };

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -681,7 +681,6 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 		out.resize(level.w * level.h * 4);
 		if (!png_image_finish_read(&png, nullptr, &out[0], level.w * 4, nullptr)) {
 			ERROR_LOG(Log::TexReplacement, "Could not load texture replacement: %s - %s", filename.c_str(), png.message);
-			vfs_->CloseFile(openFile);
 			out.resize(0);
 			return LoadLevelResult::LOAD_ERROR;
 		}

--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -64,6 +64,8 @@ struct SurfaceInfo {
 			if (tess_u > 2) tess_u = HALF_CEIL(tess_u);
 			if (tess_v > 2) tess_v = HALF_CEIL(tess_v);
 			break;
+		default:
+			break;
 		}
 	}
 };


### PR DESCRIPTION
Only happens with broken pngs, but I got one in the crash reports.

Fix a compiler warning too.