### PR TITLE
On Windows 11, start defaulting to Vulkan.

### DIFF
--- a/Common/OSVersion.cpp
+++ b/Common/OSVersion.cpp
@@ -109,6 +109,10 @@ bool IsWin8OrHigher() {
 	return DoesVersionMatchWindows(6, 2, 0, 0, 0, true);
 }
 
+bool IsWin11OrHigher() {
+	return DoesVersionMatchWindows(10, 0, 0, 0, 22000, true);
+}
+
 std::string GetWindowsVersion() {
 	std::vector<std::pair<std::string, WindowsReleaseInfo>> windowsReleases = {
 		/* { "Preview text", { major, minor, spMajor, spMinor, build, greater } }, */

--- a/Common/OSVersion.h
+++ b/Common/OSVersion.h
@@ -8,6 +8,7 @@
 bool IsVistaOrHigher();
 bool IsWin7OrHigher();
 bool IsWin8OrHigher();
+bool IsWin11OrHigher();
 bool DoesVersionMatchWindows(uint32_t major, uint32_t minor, uint32_t spMajor, uint32_t spMinor, uint32_t build, bool acceptGreater);
 bool GetVersionFromKernel32(uint32_t& major, uint32_t& minor, uint32_t& build);
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -456,7 +456,11 @@ static int DefaultGPUBackend() {
 	}
 
 #if PPSSPP_PLATFORM(WINDOWS)
-	// If no Vulkan, use Direct3D 11 on Windows 8+ (most importantly 10.)
+	// On Win11, there's a good chance Vulkan will work by default.
+	if (IsWin11OrHigher()) {
+		return (int)GPUBackend::VULKAN;
+	}
+	// On older Windows, to be safe, use Direct3D 11.
 	if (IsWin8OrHigher()) {
 		return (int)GPUBackend::DIRECT3D11;
 	}

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -264,6 +264,7 @@ void D3D11Context::Shutdown() {
 	// Important that we release before we unload the DLL, otherwise we may crash on shutdown.
 	bbRenderTargetTex_ = nullptr;
 	bbRenderTargetView_ = nullptr;
+	swapChain_ = nullptr;
 	context1_ = nullptr;
 	context_ = nullptr;
 	device1_ = nullptr;


### PR DESCRIPTION
It's time to try it. Vulkan is better supported in PPSSPP than D3D11. We previously defaulted to D3D11 because it's less likely to fail, but I'm not sure that's the case anymore. So, on Windows 11 and newer we'll now default to Vulkan.

Also fix one remaining cause of shutdown crashes with D3D11.