### PR TITLE
Add option to allow speed control while connected

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -963,6 +963,7 @@ static const ConfigSetting networkSettings[] = {
 	ConfigSetting("InfrastructureUsername", &g_Config.sInfrastructureUsername, &DefaultInfrastructureUsername, CfgFlag::PER_GAME),
 	ConfigSetting("InfrastructureAutoDNS", &g_Config.bInfrastructureAutoDNS, true, CfgFlag::PER_GAME),
 	ConfigSetting("AllowSavestateWhileConnected", &g_Config.bAllowSavestateWhileConnected, false, CfgFlag::DONT_SAVE),
+	ConfigSetting("AllowSpeedControlWhileConnected", &g_Config.bAllowSpeedControlWhileConnected, false, CfgFlag::PER_GAME),
 	ConfigSetting("DontDownloadInfraJson", &g_Config.bDontDownloadInfraJson, false, CfgFlag::DONT_SAVE),
 
 	ConfigSetting("EnableNetworkChat", &g_Config.bEnableNetworkChat, false, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -487,6 +487,7 @@ public:
 	std::string sInfrastructureUsername;  // Username used for Infrastructure play. Different restrictions.
 	bool bInfrastructureAutoDNS;
 	bool bAllowSavestateWhileConnected;  // Developer option, ini-only. No normal users need this, it's always wrong to save/load state when online.
+	bool bAllowSpeedControlWhileConnected;  // Useful in some games but not recommended.
 
 	bool bEnableWlan;
 	std::map<std::string, std::string> mHostToAlias;  // Local DNS database stored in ini file
@@ -623,8 +624,6 @@ public:
 	const Path FindConfigFile(const std::string &baseFilename, bool *exists);
 
 	void UpdateIniLocation(const char *iniFileName = nullptr, const char *controllerIniFilename = nullptr);
-
-	void DismissUpgrade();
 
 	void ResetControlLayout();
 

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -147,7 +147,7 @@ bool NetworkWarnUserIfOnlineAndCantSavestate() {
 }
 
 bool NetworkWarnUserIfOnlineAndCantSpeed() {
-	if (IsNetworkConnected()) {
+	if (IsNetworkConnected() && !g_Config.bAllowSpeedControlWhileConnected) {
 		auto nw = GetI18NCategory(I18NCat::NETWORKING);
 		g_OSD.Show(OSDType::MESSAGE_INFO, nw->T("Speed controls are not available when online"), 3.0f, "speedonline");
 		return true;

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,33 +19,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -88,15 +88,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "heck"
@@ -149,9 +149,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Tools/langtool/src/main.rs
+++ b/Tools/langtool/src/main.rs
@@ -247,7 +247,7 @@ fn main() {
     if let Command::ImportSingle {
         filename,
         section,
-        key,
+        key: _,
     } = &opt.cmd
     {
         if let Ok(single_ini) = IniFile::parse(filename) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1025,6 +1025,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	networkingSettings->Add(new PopupSliderChoice(&g_Config.iPortOffset, 0, 60000, 10000, n->T("Port offset", "Port offset (0 = PSP compatibility)"), 100, screenManager()));
 	networkingSettings->Add(new PopupSliderChoice(&g_Config.iMinTimeout, 0, 15000, 0, n->T("Minimum Timeout", "Minimum Timeout (override in ms, 0 = default)"), 50, screenManager()))->SetFormat(di->T("%d ms"));
 	networkingSettings->Add(new CheckBox(&g_Config.bForcedFirstConnect, n->T("Forced First Connect", "Forced First Connect (faster Connect)")));
+	networkingSettings->Add(new CheckBox(&g_Config.bAllowSpeedControlWhileConnected, n->T("Allow speed control while connected (not recommended)")));
 }
 
 void GameSettingsScreen::CreateToolsSettings(UI::ViewGroup *tools) {

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -936,6 +936,7 @@ WhatsThis = ?ما هذا
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = تلقائي
 Autoconfigure = Autoconfigure

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -894,6 +894,7 @@ Display Portrait Reversed = Display Portrait Reversed
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Аўта
 Autoconfigure = Аўтаканфігураванне

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -923,6 +923,7 @@ WhatsThis = Was ist das?
 [Networking]
 AdHoc server = Ad-hoc-Server
 AdhocServer Failed to Bind Port = Ad-hoc-Server konnte Port nicht binden
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Daten von unbekanntem Port
 Auto = Autom.
 Autoconfigure = Autokonfigurieren

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -918,6 +918,7 @@ Display Portrait Reversed = Display Portrait Reversed
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -929,6 +929,7 @@ WhatsThis = ¿Qué es esto?
 [Networking]
 AdHoc server = Servidor Ad-Hoc
 AdhocServer Failed to Bind Port = El servidor Ad-Hoc no pudo vincular el puerto
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Datos de puerto desconocido
 Auto = Automático
 Autoconfigure = Autoconfigurar

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -928,6 +928,7 @@ WhatsThis = ¿Que es esto?
 [Networking]
 AdHoc server = Servidor Adhoc
 AdhocServer Failed to Bind Port = Servidor Adhoc falló al unir puerto.
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Datos de puerto desconocido
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -928,6 +928,7 @@ WhatsThis = این چیست؟
 [Networking]
 AdHoc server = سرور ادهاک
 AdhocServer Failed to Bind Port = اتصال به سرور ادهاک ناموفق بود
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = خودکار
 Autoconfigure = Autoconfigure

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -928,6 +928,7 @@ WhatsThis = Mikä tämä on?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Automaattinen
 Autoconfigure = Autoconfigure

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Serveur ad hoc
 AdhocServer Failed to Bind Port = Échec de liaison du port par le serveur ad hoc
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Automatique
 Autoconfigure = Autoconfigure

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -925,6 +925,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc szerver
 AdhocServer Failed to Bind Port = Az ad hoc szervernek nem sikerült a porthoz kötés
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: ismeretlen portról származó adat
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -928,6 +928,7 @@ WhatsThis = Apa ini?
 [Networking]
 AdHoc server = Server Ad Hoc
 AdhocServer Failed to Bind Port = Server Ad Hoc gagal memuat port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data dari port tidak dikenal
 Auto = Otomatis
 Autoconfigure = Konfigurasi otomatis

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -896,6 +896,7 @@ Wlan = WLAN
 [Networking]
 AdHoc server = Server Ad hoc
 AdhocServer Failed to Bind Port = Il server Ad hoc non è riuscito a collegarsi alla porta
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Dati da porta sconosciuta
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -895,6 +895,7 @@ Wlan = WLAN
 [Networking]
 AdHoc server = アドホックサーバー
 AdhocServer Failed to Bind Port = アドホックサーバーがポートのバインドに失敗しました
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: 不明なポートからのデータ
 Auto = 自動
 Autoconfigure = DNSの自動構成

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -895,6 +895,7 @@ Display Portrait Reversed = 세로방향 반전 표시
 [Networking]
 AdHoc server = Ad hoc 서버
 AdhocServer Failed to Bind Port = Ad Hoc 서버가 포트 바인딩 실패함
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: 알 수 없는 포트의 데이터
 Auto = 자동
 Autoconfigure = 자동구성

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -909,6 +909,7 @@ Display Portrait Reversed = Display Portrait Reversed
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -932,6 +932,7 @@ WhatsThis = A co to?
 [Networking]
 AdHoc server = Serwer Ad-Hoc
 AdhocServer Failed to Bind Port = Błąd przy przypisywaniu portu na serwerze Ad-Hoc
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Dane z nieznanego portu
 Auto = Automatycznie
 Autoconfigure = Autoconfigure

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -919,6 +919,7 @@ Display Portrait Reversed = Exibir Retrato Revertido
 [Networking]
 AdHoc Server = Servidor Ad-hoc
 AdhocServer Failed to Bind Port = O servidor Ad-hoc falhou em se associar com a porta
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Dados de uma Porta Desconhecida
 Auto = Auto
 Autoconfigure = Auto-configurar

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -919,6 +919,7 @@ Display Portrait Reversed = Exibir Retrato Invertido
 [Networking]
 AdHoc server = Servidor Ad-hoc
 AdhocServer Failed to Bind Port = O servidor Ad-hoc falhou a conectar-se à porta.
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Dados de uma Porta Desconhecida.
 Auto = Automático
 Autoconfigure = Autoconfigure

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -929,6 +929,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -894,6 +894,7 @@ Wlan = WLAN
 [Networking]
 AdHoc server = Ad-hoc сервер
 AdhocServer Failed to Bind Port = Не удалось привязать порт ad-hoc сервера
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Данные от неизвестного порта
 Auto = Авто
 Autoconfigure = Автонастройка

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -896,6 +896,7 @@ Wlan = WLAN
 [Networking]
 AdHoc server = Ad hoc-server
 AdhocServer Failed to Bind Port = Ad hoc-server misslyckades binda till port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: data från okänd port
 Auto = Automatisk
 Autoconfigure = Autokonfigurera

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -929,6 +929,7 @@ WhatsThis = Ano ito?
 [Networking]
 AdHoc server = Ad hoc na server
 AdhocServer Failed to Bind Port = Nabigo ang ad hoc server na i-bind ang port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data mula sa Hindi Kilalang Port
 Auto = Awto
 Autoconfigure = Autoconfigure

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -951,6 +951,7 @@ WhatsThis = นี่คืออะไร?
 [Networking]
 AdHoc server = เซิร์ฟเวอร์ Adhoc
 AdhocServer Failed to Bind Port = เซิร์ฟเวอร์ Adhoc ล้มเหลวในการเชื่อมโยงพอร์ต
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: ข้อมูลมาจากพอร์ตที่ไม่รู้จัก
 Auto = อัตโนมัติ
 Autoconfigure = กำหนดค่าอัตโนมัติ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -930,6 +930,7 @@ WhatsThis = Bu nedir?
 [Networking]
 AdHoc server = Ad hoc sunucusu
 AdhocServer Failed to Bind Port = Ad hoc sunucusu portu bağlayamadı
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Bilinmeyen Porttan Veri
 Auto = Otomatik
 Autoconfigure = Autoconfigure

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -927,6 +927,7 @@ WhatsThis = Що це?
 [Networking]
 AdHoc server = Ad hoc сервер
 AdhocServer Failed to Bind Port = Ad hoc серверу не вдалося прив’язати порт
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Дані з невідомого порту
 Auto = Авто
 Autoconfigure = Автоналаштування

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -928,6 +928,7 @@ WhatsThis = What's this?
 [Networking]
 AdHoc server = Ad hoc server
 AdhocServer Failed to Bind Port = Ad hoc server failed to bind port
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM: Data from Unknown Port
 Auto = Auto
 Autoconfigure = Autoconfigure

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -928,6 +928,7 @@ WhatsThis = 为什么要设置？
 [Networking]
 AdHoc server = Ad Hoc服务器
 AdhocServer Failed to Bind Port = 无法绑定Ad Hoc服务器端口
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM：来自未知端口的数据
 Auto = 自动
 Autoconfigure = Autoconfigure

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -895,6 +895,7 @@ Display Portrait Reversed = 顯示器直向反轉
 [Networking]
 AdHoc server = 臨機操作伺服器
 AdhocServer Failed to Bind Port = 臨機操作伺服器無法繫結連接埠
+Allow speed control while connected (not recommended) = Allow speed control while connected (not recommended)
 AM: Data from Unknown Port = AM：來自不明連接埠的資料
 Auto = 自動
 Autoconfigure = Autoconfigure


### PR DESCRIPTION
It's pretty easy to cheat this anyway by using an old PPSSPP version, and some people seem to want this for PSO raids or something.

I put it at the bottom of network settings and added "(not recommended)" to emphasize that it's, well, not recommended.