### PR TITLE
JIT/IRJit: Delete an old "function preloading" experiment

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -387,7 +387,6 @@ static const ConfigSetting cpuSettings[] = {
 	ConfigSetting("FunctionReplacements", &g_Config.bFuncReplacements, true, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, CfgFlag::DEFAULT),
 	ConfigSetting("HideStateWarnings", &g_Config.bHideStateWarnings, false, CfgFlag::DEFAULT),
-	ConfigSetting("PreloadFunctions", &g_Config.bPreloadFunctions, false, CfgFlag::PER_GAME),
 	ConfigSetting("JitDisableFlags", &g_Config.uJitDisableFlags, (uint32_t)0, CfgFlag::PER_GAME),
 	ConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0, CfgFlag::PER_GAME | CfgFlag::REPORT),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -115,7 +115,6 @@ public:
 	bool bFuncReplacements;
 	bool bHideSlowWarnings;
 	bool bHideStateWarnings;
-	bool bPreloadFunctions;
 	uint32_t uJitDisableFlags;
 
 	bool bDisableHTTPS;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -661,9 +661,6 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 		// TODO: There's some double lookup going on here (we already did the lookup in GetHLEFunc above).
 		WriteHLESyscall(func.moduleName, func.nid, func.stubAddr);
 		currentMIPS->InvalidateICache(func.stubAddr, 8);
-		if (g_Config.bPreloadFunctions) {
-			MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
-		}
 		return;
 	}
 
@@ -682,9 +679,6 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 				}
 				WriteFuncStub(func.stubAddr, it->symAddr);
 				currentMIPS->InvalidateICache(func.stubAddr, 8);
-				if (g_Config.bPreloadFunctions) {
-					MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
-				}
 				return;
 			}
 		}
@@ -725,9 +719,6 @@ void ExportFuncSymbol(const FuncSymbolExport &func) {
 				INFO_LOG(Log::Loader, "Resolving function %s/%08x", func.moduleName, func.nid);
 				WriteFuncStub(it->stubAddr, func.symAddr);
 				currentMIPS->InvalidateICache(it->stubAddr, 8);
-				if (g_Config.bPreloadFunctions) {
-					MIPSAnalyst::PrecompileFunction(it->stubAddr, 8);
-				}
 			}
 		}
 	}
@@ -1543,8 +1534,6 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 		// use module_start_func instead of entry_addr if entry_addr is 0
 		if (module->nm.entry_addr == 0)
 			module->nm.entry_addr = module->nm.module_start_func;
-
-		MIPSAnalyst::PrecompileFunctions();
 	} else {
 		module->nm.entry_addr = -1;
 	}

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -747,7 +747,6 @@ static void __KernelWriteFakeSysCall(u32 nid, u32 *ptr, u32 &pos)
 	*ptr = pos;
 	pos += 8;
 	WriteHLESyscall("FakeSysCalls", nid, *ptr);
-	MIPSAnalyst::PrecompileFunction(*ptr, 8);
 }
 
 u32 HLEMipsCallReturnAddress() {

--- a/Core/MIPS/ARM64/Arm64IRJit.cpp
+++ b/Core/MIPS/ARM64/Arm64IRJit.cpp
@@ -65,7 +65,7 @@ static void NoBlockExits() {
 	_assert_msg_(false, "Never exited block, invalid IR?");
 }
 
-bool Arm64JitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) {
+bool Arm64JitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num) {
 	if (GetSpaceLeft() < 0x800)
 		return false;
 

--- a/Core/MIPS/ARM64/Arm64IRJit.h
+++ b/Core/MIPS/ARM64/Arm64IRJit.h
@@ -40,7 +40,7 @@ public:
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
 	void GenerateFixedCode(MIPSState *mipsState) override;
-	bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
+	bool CompileBlock(IRBlockCache *irBlockCache, int block_num) override;
 	void ClearAllBlocks() override;
 	void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) override;
 

--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -334,11 +334,7 @@ void IRFrontend::Comp_Jump(MIPSOpcode op) {
 	// Might be a stubbed address or something?
 	if (!Memory::IsValidAddress(targetAddr)) {
 		// If preloading, flush - this block will likely be fixed later.
-		if (js.preloading) {
-			js.cancel = true;
-		} else {
-			ERROR_LOG(Log::JIT, "Jump to invalid address: %08x", targetAddr);
-		}
+		ERROR_LOG(Log::JIT, "Jump to invalid address: %08x", targetAddr);
 		// TODO: Mark this block dirty or something?  May be indication it will be changed by imports.
 		// Continue so the block gets completed and crashes properly.
 	}

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -239,9 +239,8 @@ MIPSOpcode IRFrontend::GetOffsetInstruction(int offset) {
 	return Memory::Read_Instruction(GetCompilerPC() + 4 * offset);
 }
 
-void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes, bool preload) {
+void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes) {
 	js.cancel = false;
-	js.preloading = preload;
 	js.blockStart = em_address;
 	js.compilerPC = em_address;
 	js.lastContinuedPC = 0;

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -89,7 +89,7 @@ public:
 	void DoState(PointerWrap &p);
 	bool CheckRounding(u32 blockAddress);  // returns true if we need a do-over
 
-	void DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes, bool preload);
+	void DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes);
 
 	void EatPrefix() override {
 		js.EatPrefix();

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -122,7 +122,7 @@ public:
 
 	void Clear();
 	std::vector<int> FindInvalidatedBlockNumbers(u32 address, u32 length);
-	void FinalizeBlock(int blockNum, bool preload = false);
+	void FinalizeBlock(int blockNum);
 	int GetNumBlocks() const override { return (int)blocks_.size(); }
 	int AllocateBlock(int emAddr, u32 origSize, const std::vector<IRInst> &inst);
 	IRBlock *GetBlock(int blockNum) {
@@ -212,7 +212,6 @@ public:
 	void RunLoopUntil(u64 globalticks) override;
 
 	void Compile(u32 em_address) override;	// Compiles a block at current MIPS PC
-	void CompileFunction(u32 start_address, u32 length) override;
 
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) override;
 	// Not using a regular block cache.
@@ -238,8 +237,8 @@ public:
 	void UnlinkBlock(u8 *checkedEntry, u32 originalAddress) override;
 
 protected:
-	bool CompileBlock(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes, bool preload);
-	virtual bool CompileNativeBlock(IRBlockCache *irBlockCache, int block_num, bool preload) { return true; }
+	bool CompileBlock(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes);
+	virtual bool CompileNativeBlock(IRBlockCache *irBlockCache, int block_num) { return true; }
 	virtual void FinalizeNativeBlock(IRBlockCache *irBlockCache, int block_num) {}
 
 	bool compileToNative_;

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -507,8 +507,8 @@ void IRNativeJit::Init(IRNativeBackend &backend) {
 	}
 }
 
-bool IRNativeJit::CompileNativeBlock(IRBlockCache *irblockCache, int block_num, bool preload) {
-	return backend_->CompileBlock(irblockCache, block_num, preload);
+bool IRNativeJit::CompileNativeBlock(IRBlockCache *irblockCache, int block_num) {
+	return backend_->CompileBlock(irblockCache, block_num);
 }
 
 void IRNativeJit::FinalizeNativeBlock(IRBlockCache *irblockCache, int block_num) {

--- a/Core/MIPS/IR/IRNativeCommon.h
+++ b/Core/MIPS/IR/IRNativeCommon.h
@@ -71,7 +71,7 @@ public:
 	int OffsetFromCodePtr(const u8 *ptr);
 
 	virtual void GenerateFixedCode(MIPSState *mipsState) = 0;
-	virtual bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) = 0;
+	virtual bool CompileBlock(IRBlockCache *irBlockCache, int block_num) = 0;
 	virtual void ClearAllBlocks() = 0;
 	virtual void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) = 0;
 	void FinalizeBlock(IRBlockCache *irBlockCache, int block_num, const JitOptions &jo);
@@ -198,7 +198,7 @@ public:
 
 protected:
 	void Init(IRNativeBackend &backend);
-	bool CompileNativeBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
+	bool CompileNativeBlock(IRBlockCache *irBlockCache, int block_num) override;
 	void FinalizeNativeBlock(IRBlockCache *irBlockCache, int block_num) override;
 
 	IRNativeBackend *backend_ = nullptr;

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -136,7 +136,6 @@ namespace MIPSComp {
 		virtual void DoState(PointerWrap &p) = 0;
 		virtual void RunLoopUntil(u64 globalticks) = 0;
 		virtual void Compile(u32 em_address) = 0;
-		virtual void CompileFunction(u32 start_address, u32 length) { }
 		virtual void ClearCache() = 0;
 		virtual void UpdateFCR31() = 0;
 		virtual MIPSOpcode GetOriginalOp(MIPSOpcode op) = 0;

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -68,7 +68,6 @@ namespace MIPSComp {
 		int numInstructions;
 		bool compiling;	// TODO: get rid of this in favor of using analysis results to determine end of block
 		bool hadBreakpoints;
-		bool preloading = false;
 		JitBlock *curBlock;
 
 		u8 hasSetRounding = 0;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -906,33 +906,6 @@ skip:
 		}
 	}
 
-	void PrecompileFunction(u32 startAddr, u32 length) {
-		// Direct calls to this ignore the bPreloadFunctions flag, since it's just for stubs.
-		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-		if (MIPSComp::jit) {
-			MIPSComp::jit->CompileFunction(startAddr, length);
-		}
-	}
-
-	void PrecompileFunctions() {
-		if (!g_Config.bPreloadFunctions) {
-			return;
-		}
-		std::lock_guard<std::recursive_mutex> guard(functions_lock);
-
-		// TODO: Load from cache file if available instead.
-
-		double st = time_now_d();
-		for (auto iter = functions.begin(), end = functions.end(); iter != end; iter++) {
-			const AnalyzedFunction &f = *iter;
-
-			PrecompileFunction(f.start, f.end - f.start + 4);
-		}
-		double et = time_now_d();
-
-		NOTICE_LOG(Log::JIT, "Precompiled %d MIPS functions in %0.2f milliseconds", (int)functions.size(), (et - st) * 1000.0);
-	}
-
 	static const char *DefaultFunctionName(char buffer[256], u32 startAddr) {
 		snprintf(buffer, 256, "z_un_%08x", startAddr);
 		return buffer;

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -97,7 +97,6 @@ namespace MIPSAnalyst {
 
 	void Reset();
 
-	bool IsRegisterUsed(u32 reg, u32 addr);
 	// This will not only create a database of "AnalyzedFunction" structs, it also
 	// will insert all the functions it finds into the symbol map, if insertSymbols is true.
 
@@ -108,8 +107,6 @@ namespace MIPSAnalyst {
 	bool ScanForFunctions(u32 startAddr, u32 endAddr, bool insertSymbols);
 	void FinalizeScan(bool insertSymbols);
 	void ForgetFunctions(u32 startAddr, u32 endAddr);
-	void PrecompileFunctions();
-	void PrecompileFunction(u32 startAddr, u32 length);
 
 	void SetHashMapFilename(const std::string& filename = "");
 	void LoadBuiltinHashMap();

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -56,7 +56,7 @@ static void NoBlockExits() {
 	_assert_msg_(false, "Never exited block, invalid IR?");
 }
 
-bool RiscVJitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) {
+bool RiscVJitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num) {
 	if (GetSpaceLeft() < 0x800)
 		return false;
 

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -36,7 +36,7 @@ public:
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
 	void GenerateFixedCode(MIPSState *mipsState) override;
-	bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
+	bool CompileBlock(IRBlockCache *irBlockCache, int block_num) override;
 	void ClearAllBlocks() override;
 	void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) override;
 

--- a/Core/MIPS/x86/X64IRJit.cpp
+++ b/Core/MIPS/x86/X64IRJit.cpp
@@ -55,7 +55,7 @@ static void NoBlockExits() {
 	_assert_msg_(false, "Never exited block, invalid IR?");
 }
 
-bool X64JitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) {
+bool X64JitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num) {
 	if (GetSpaceLeft() < 0x800)
 		return false;
 

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -52,7 +52,7 @@ public:
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
 	void GenerateFixedCode(MIPSState *mipsState) override;
-	bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
+	bool CompileBlock(IRBlockCache *irBlockCache, int block_num) override;
 	void ClearAllBlocks() override;
 	void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) override;
 


### PR DESCRIPTION
This caused some confusion while trying to debug #20502. One part of this was accidentally enabled, generating some strange jit blocks.