### PR TITLE
SasAudio: Don't reset the decoder on SetVoice if all params are the same

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -343,14 +343,20 @@ static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loo
 	}
 
 	u32 prevVagAddr = v.vagAddr;
-	v.type = VOICETYPE_VAG;
+	bool reset = false;
+	if (v.type != VOICETYPE_VAG || v.vagAddr != vagAddr || v.vagSize != size || v.loop != loop) {
+		v.type = VOICETYPE_VAG;
+		reset = true;
+	}
 	v.vagAddr = vagAddr;  // Real VAG header is 0x30 bytes behind the vagAddr
 	v.vagSize = size;
 	v.loop = loop != 0;
 	if (v.on) {
 		v.playing = true;
 	}
-	v.vag.Start(vagAddr, size, loop != 0);
+	if (reset) {
+		v.vag.Start(vagAddr, size, loop != 0);
+	}
 	return hleNoLog(0);
 }
 


### PR DESCRIPTION
Should fix #20507

This seems to work fine with all the games I've tried, but might be too risky to sneak into 1.19.2.