### PR TITLE
Disable the Cache full ISO in RAM feature on 32-bit builds

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -765,12 +765,11 @@ case SYSPROP_HAS_FILE_BROWSER:
 	case SYSPROP_CAN_READ_BATTERY_PERCENTAGE:
 		return true;
 	case SYSPROP_ENOUGH_RAM_FOR_FULL_ISO:
-#if defined(MOBILE_DEVICE)
-		return false;
-#else
+#if PPSSPP_ARCH(64BIT) && !defined(MOBILE_DEVICE)
 		return true;
+#else
+		return false;
 #endif
-
 	// hack for testing - do not commit
 	case SYSPROP_USE_IAP:
 		return false;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -413,7 +413,11 @@ bool System_GetPropertyBool(SystemProperty prop) {
 	case SYSPROP_CAN_READ_BATTERY_PERCENTAGE:
 		return true;
 	case SYSPROP_ENOUGH_RAM_FOR_FULL_ISO:
+#if PPSSPP_ARCH(64BIT)
 		return true;
+#else
+		return false;
+#endif
 	default:
 		return false;
 	}


### PR DESCRIPTION
we're super tight on address space as-is on 32-bit, so this just can't be workable.