### PR TITLE
[ImMemView] Copy Paste feature

### DIFF
--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -351,6 +351,18 @@ void ImMemView::EditMemory(int newNibble) {
 	ScrollCursor(1, GotoMode::RESET);
 }
 
+void ImMemView::CopyToByteClipboard() {
+	byteClipboard_.clear();
+	uint32_t size = selectRangeEnd_ - selectRangeStart_;
+	byteClipboard_.resize(size);
+	Memory::MemcpyUnchecked(byteClipboard_.data(), curAddress_, size);
+}
+
+void ImMemView::PasteFromByteClipboard() {
+	if (editableMemory_)
+		Memory::MemcpyUnchecked(curAddress_, byteClipboard_.data(), byteClipboard_.size());
+}
+
 void ImMemView::toggleEditableMemory(bool toggle) {
 	editableMemory_ = toggle;
 }
@@ -426,7 +438,14 @@ void ImMemView::PopupMenu() {
 			break;
 		}
 		*/
-
+		ImGui::SeparatorText("Internal clipboard");
+		if (ImGui::MenuItem("Copy bytes")) {
+			CopyToByteClipboard();
+		}
+		if (ImGui::MenuItem("Paste bytes")) {
+			PasteFromByteClipboard();
+		}
+		ImGui::SeparatorText("System clipboard");
 		if (ImGui::MenuItem("Copy value (8-bit)")) {
 			size_t tempSize = 3 * selectedSize + 1;
 			char *temp = new char[tempSize];
@@ -524,7 +543,7 @@ void ImMemView::PopupMenu() {
 			snprintf(temp, sizeof(temp), "0x%08X", curAddress_);
 			System_CopyStringToClipboard(temp);
 		}
-
+		ImGui::SeparatorText("Misc");
 		if (ImGui::MenuItem("Goto in disasm")) {
 			/*
 			if (disasmWindow) {

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -92,6 +92,10 @@ private:
 		MemorySearchStatus status;
 	} memSearch_;
 
+	std::vector<u8> byteClipboard_;
+	void CopyToByteClipboard();
+	void PasteFromByteClipboard();
+
 	static wchar_t szClassName[];
 	MIPSDebugInterface *debugger_ = nullptr;
 


### PR DESCRIPTION
Currently, we can only copy selected bytes into the system clipboard as string, this PR adds the option to copy and paste to/from an internal Byte Clipboard.

It also adds ImGui::TextSeparator elements in the right click contextual menu to separate categories.
___
![image_ppsspp3](https://github.com/user-attachments/assets/08f2d3c8-47d2-48dc-aafc-6fd9eebdfafe)
