### PR TITLE
enhance MMPX algorithm part 2

### DIFF
--- a/assets/shaders/tex_mmpx.csh
+++ b/assets/shaders/tex_mmpx.csh
@@ -7,19 +7,23 @@
    by Morgan McGuire and Mara Gagiu.
 */
 
-// Performs 2x upscaling.
+// Performs 2x upscaling
 
 #define ABGR8 uint
 
 // If we took an image as input, we could use a sampler to do the clamping. But we decode
 // low-bpp texture data directly, so...
+
 ABGR8 src(int x, int y) {
     return readColoru(uvec2(clamp(x, 0, params.width - 1), clamp(y, 0, params.height - 1)));
 }
 
 uint luma(ABGR8 C) {
-    uint alpha = (C & 0xFF000000u) >> 24;
-    return (((C & 0x00FF0000u) >> 16) + ((C & 0x0000FF00u) >> 8) + (C & 0x000000FFu)) + (255u - alpha) * 3;
+    uint alpha = (C >> 24) & 0xFFu;  // Simplified bit operations
+    if (alpha == 0u) return 1530u;   // Ensure fully transparent pixels return max value 1530
+    uint rgbSum = ((C >> 16) & 0xFFu) + ((C >> 8) & 0xFFu) + (C & 0xFFu);
+    float factor = 1.0f + (255.0f - alpha) * 0.00392157f; // Division by 255 alternative
+    return uint(rgbSum * factor);
 }
 
 bool all_eq2(ABGR8 B, ABGR8 A0, ABGR8 A1) {
@@ -46,22 +50,30 @@ bool none_eq4(ABGR8 B, ABGR8 A0, ABGR8 A1, ABGR8 A2, ABGR8 A3) {
     return B != A0 && B != A1 && B != A2 && B != A3;
 }
 
-// Calculate the RGB distance between two ABGR8 colors
-float rgb_distance(ABGR8 a, ABGR8 b)
-{
+// Two-stage weak blending (blend/no-blend)
+ABGR8 admix2d(ABGR8 a, ABGR8 d) {
     vec4 ca = unpackUnorm4x8(a);
-    vec4 cb = unpackUnorm4x8(b);
-    return distance(ca.rgb, cb.rgb);
-}
-
-// Calculate the normalized luminance difference between two ABGR8 colors. In practice, luma values range from 0.001 to 0.9998.
-float luma_distance(ABGR8 a, ABGR8 b)
-{
-    return abs(luma(a) - luma(b)) * 0.000653594f;  // Multiplicative substitute for division by (255 * 6);
+    vec4 cd = unpackUnorm4x8(d);
+    float rgbDist = dot(ca - cd, ca - cd);
+    if (dot(ca, ca) < 0.01) return d; // Return d for pure black
+    
+    vec4 result;
+    if (rgbDist < 1.0) {
+        // Close colors: Linear blend RGB and Alpha
+        result = (ca + cd) * 0.5;
+    } else {
+        // Distant colors: Return b
+        result = cd;
+    }
+    
+    // Repack
+    return packUnorm4x8(result);
 }
 
 /*=============================================================================
-Auxiliary function for 4-pixel cross determination: Scores the number of matches at specific positions in the pattern. Three pattern conditions must be met to achieve 6 points.
+Helper function for 4-pixel cross pattern detection: Scores matches at 
+morphologically significant positions. Requires 6 points to pass.
+
                 ┌───┬───┬───┐                ┌───┬───┬───┐
                 │ A │ B │ C │                │ A │ B │ 1 │
                 ├───┼───┼───┤                ├───┼───┼───┤
@@ -72,86 +84,84 @@ Auxiliary function for 4-pixel cross determination: Scores the number of matches
 =============================================================================*/
 
 bool countPatternMatches(ABGR8 LA, ABGR8 LB, ABGR8 L1, ABGR8 L2, ABGR8 L3, ABGR8 L4, ABGR8 L5) {
-
-    int score1 = 0; // Diagonal pattern 1
-    int score2 = 0; // Diagonal pattern 2
+    int score1 = 0; // Diagonal pattern 1 (╲)
+    int score2 = 0; // Diagonal pattern 2 (╱)
     int score3 = 0; // Horizontal/vertical line pattern
     int scoreBonus = 0;
-    
-    // Jointly determine the perceptual difference between two pixels using RGB distance and luminance distance
-    float pixelDist = rgb_distance(LA, LB)*0.356822 + luma_distance(LA, LB)*0.382; // Proportions follow the golden ratio
 
-    // Add details for very similar colors, reduce details for highly different colors (font edges)
-    if (pixelDist < 0.12) { // Colors are quite similar
+    vec4 ca = unpackUnorm4x8(LA);
+    vec4 cb = unpackUnorm4x8(LB);
+    // Use dot product instead of Euclidean distance to save sqrt cost
+    float rgbDist = dot(ca - cb, ca - cb);
+
+    // Enhance detail for very similar colors, reduce for high-contrast edges
+    if (rgbDist < 0.06386) { // two golden sections
         scoreBonus += 1;
-    } else if (pixelDist > 0.9) { // High contrast (e.g., black and white)
+    } else if (rgbDist > 2.18847) { // High-contrast threshold (two golden sections)
         scoreBonus -= 1;
     } 
 
-    // Diagonals use a penalty system: deduct points for crosses, add back if conditions are met  
-    // 1. Diagonal pattern ╲ (Condition: B = 2 or 4)
+    // Diagonal pattern 1 (╲): Penalty system
     if (LB == L2 || LB == L4) {
-        score1 -= int(LB == L2 && LA == L1) * 1;    	// A-1 and B-2 form a cross: deduct points
-        score1 -= int(LB == L4 && LA == L5) * 1;   		// A-5 and B-4 form a cross: deduct points
-
-        // Add points if the following triangular patterns are satisfied (canceling previous cross deductions)		
-        score1 += int(LB == L1 && L1 == L2) * 1;   		// B-1-2 form a triangle: add points
-        score1 += int(LB == L4 && L4 == L5) * 1;   		// B-4-5 form a triangle: add points
-        score1 += int(L2 == L3 && L3 == L4) * 1;   		// 2-3-4 form a triangle: add points
+        score1 -= int(LB == L2 && LA == L1) * 1;  // Penalize A-1, B-2 crossing
+        score1 -= int(LB == L4 && LA == L5) * 1;  // Penalize A-5, B-4 crossing
+        
+        // Compensate with triangle patterns
+        score1 += int(LB == L1 && L1 == L2) * 1;  // B-1-2 triangle
+        score1 += int(LB == L4 && L4 == L5) * 1;  // B-4-5 triangle
+        score1 += int(L2 == L3 && L3 == L4) * 1;  // 2-3-4 triangle
         
         score1 += scoreBonus + 6;
     } 
 
-    // 2. Diagonal pattern ╱ (Condition: A = 1 or 5)
+    // Diagonal pattern 2 (╱): Penalty system
     if (LA == L1 || LA == L5) {
-        score2 -= int(LB == L2 && LA == L1) * 1;    	// A-1 and B-2 cross: deduct points
-        score2 -= int(LB == L4 && LA == L5) * 1;   		// A-5 and B-4 cross: deduct points
-        score2 -= int(LA == L3) * 1;    					// A-3 forms a cross: deduct points				
-
-        // Add points if the following triangular patterns are satisfied (canceling previous cross deductions)
-        score2 += int(LB == L1 && L1 == L2) * 1;   		// B-1-2 form a triangle: add points
-        score2 += int(LB == L4 && L4 == L5) * 1;   		// B-4-5 form a triangle: add points
-        score2 += int(L2 == L3 && L3 == L4) * 1;   		// 2-3-4 form a triangle: add points
+        score2 -= int(LB == L2 && LA == L1) * 1;  // Penalize A-1, B-2 crossing
+        score2 -= int(LB == L4 && LA == L5) * 1;  // Penalize A-5, B-4 crossing
+        score2 -= int(LA == L3) * 1;              // Penalize A-3 crossing
+        
+        // Compensate with triangle patterns
+        score2 += int(LB == L1 && L1 == L2) * 1;  // B-1-2 triangle
+        score2 += int(LB == L4 && L4 == L5) * 1;  // B-4-5 triangle
+        score2 += int(L2 == L3 && L3 == L4) * 1;  // 2-3-4 triangle
     
         score2 += scoreBonus + 6;
     } 
 
-    // 3. Horizontal/vertical line patterns (Condition: horizontal continuity) use a scoring system; pass only if conditions are met
+    // Horizontal/vertical line pattern: Reward system
     if (LA == L2 || LB == L1 || LA == L4 || LB == L5 || (L1 == L2 && L2 == L3) || (L3 == L4 && L4 == L5)) {
-        score3 += int(LA == L2);    	// A matches 2	+1
-        score3 += int(LB == L1);    	// B matches 1	+1
-        score3 += int(L3 == L4);    	// 3 matches 4	+1
-        score3 += int(L4 == L5);    	// 4 matches 5	+1
-        score3 += int(L3 == L4 && L4 == L5) ; // 3-4-5 continuous
+        score3 += int(LA == L2);     // +1: A matches 2
+        score3 += int(LB == L1);     // +1: B matches 1
+        score3 += int(L3 == L4);     // +1: 3 matches 4
+        score3 += int(L4 == L5);     // +1: 4 matches 5
+        score3 += int(L3 == L4 && L4 == L5); // +1: 3-4-5 continuity
 
-        score3 += int(LB == L5);    	// B matches 5	+1
-        score3 += int(LA == L4);    	// A matches 4	+1
-        score3 += int(L2 == L3);    	// 2 matches 3	+1
-        score3 += int(L1 == L2);    	// 1 matches 2	+1
-        score3 += int(L1 == L2 && L2 == L3) ; // 1-2-3 continuous
+        score3 += int(LB == L5);     // +1: B matches 5
+        score3 += int(LA == L4);     // +1: A matches 4
+        score3 += int(L2 == L3);     // +1: 2 matches 3
+        score3 += int(L1 == L2);     // +1: 1 matches 2
+        score3 += int(L1 == L2 && L2 == L3); // +1: 1-2-3 continuity
 
-        // A x 4 square	
+        // 2x2 uniform block bonus
         score3 += int(LA == L2 && L2 == L3 && L3 == L4) * 2;
 
-        // Patch for the above rule to avoid bubble-like cross patterns in large grids. Some games use single-side patterns, so bilateral checks are preferred (work in progress)
-        score3 -= int(LB == L1 && L1 == L5 && LA == L2 && L2 == L4)*3 ; 
-
-        score3 -= int(LA == L1 && LA == L5) ; // Deduct points if L1 and L5 are both A to avoid excessive scoring and diagonal pattern misidentification
+        // Patch for grid artifacts
+        score3 -= int(LB == L1 && L1 == L5 && LA == L2 && L2 == L4) * 3; 
+        score3 -= int(LA == L1 && LA == L5); // Penalize diagonal conflict
         
-        // Bonus points
-        score3 += scoreBonus;	// Experience: Even with very similar colors, avoid over-scoring to prevent bubbles in Z-shaped crosses
+        score3 += scoreBonus; // Conservative bonus
     } 
 
-    // Take the maximum of the 3 scores
+    // Take maximum score
     int score = max(max(score1, score2), score3);
-    
-    return score < 6; // Requires a minimum of 6 points
+    return score < 6; // Require 6 points to pass
 }
 
 void applyScaling(uvec2 xy) {
     int srcX = int(xy.x);
     int srcY = int(xy.y);
 
+    // Sample 3x3 neighborhood
     ABGR8 A = src(srcX - 1, srcY - 1), B = src(srcX, srcY - 1), C = src(srcX + 1, srcY - 1);
     ABGR8 D = src(srcX - 1, srcY + 0), E = src(srcX, srcY + 0), F = src(srcX + 1, srcY + 0);
     ABGR8 G = src(srcX - 1, srcY + 1), H = src(srcX, srcY + 1), I = src(srcX + 1, srcY + 1);
@@ -159,39 +169,25 @@ void applyScaling(uvec2 xy) {
     ABGR8 J = E, K = E, L = E, M = E;
 
     if (((A ^ E) | (B ^ E) | (C ^ E) | (D ^ E) | (F ^ E) | (G ^ E) | (H ^ E) | (I ^ E)) != 0u) {
+        // Sample extended neighborhood
         ABGR8 P = src(srcX, srcY - 2), S = src(srcX, srcY + 2);
         ABGR8 Q = src(srcX - 2, srcY), R = src(srcX + 2, srcY);
         ABGR8 Bl = luma(B), Dl = luma(D), El = luma(E), Fl = luma(F), Hl = luma(H);
 
-
-        // Default output (to avoid code duplication)
+        // Default output (centered)
         ivec2 destXY = ivec2(xy) * 2;
-        ABGR8 defaultColor = E;
-        writeColorf(destXY, unpackUnorm4x8(defaultColor));
-        writeColorf(destXY + ivec2(1, 0), unpackUnorm4x8(defaultColor));
-        writeColorf(destXY + ivec2(0, 1), unpackUnorm4x8(defaultColor));
-        writeColorf(destXY + ivec2(1, 1), unpackUnorm4x8(defaultColor));
+        vec4 centerColor = unpackUnorm4x8(E);
+        writeColorf(destXY, centerColor);
+        writeColorf(destXY + ivec2(1, 0), centerColor);
+        writeColorf(destXY + ivec2(0, 1), centerColor);
+        writeColorf(destXY + ivec2(1, 1), centerColor);
 
-        // Check for "convex" shapes to avoid single-pixel spikes on long straight edges
-        if (A == B && B == C && E == H && A != D && C != F && rgb_distance(D, F) < 0.2 && rgb_distance(B, E) > 0.6) return;
-
-        if (A == D && D == G && E == F && A != B && G != H && rgb_distance(B, H) < 0.2 && rgb_distance(D, E) > 0.6) return;
-
-        if (C == F && F == I && E == D && B != C && H != I && rgb_distance(B, H) < 0.2 && rgb_distance(E, F) > 0.6) return;
-
-        if (G == H && H == I && B == E && D != G && F != I && rgb_distance(D, F) < 0.2 && rgb_distance(E, H) > 0.6) return;
-
-
-        // Check each 4-pixel cross in "田" (field) shape and pass five surrounding pixels for pattern judgment
+        // 4-pixel grid pattern detection
         if (A == E && B == D && A != B && countPatternMatches(A, B, C, F, I, H, G)) return;
-
         if (C == E && B == F && C != B && countPatternMatches(C, B, A, D, G, H, I)) return;
-
         if (G == E && D == H && G != H && countPatternMatches(G, H, I, F, C, B, A)) return;
-
         if (I == E && F == H && I != H && countPatternMatches(I, H, G, D, A, B, C)) return;
        
-
         // Original MMPX logic
 
         // 1:1 slope rules
@@ -205,10 +201,12 @@ void applyScaling(uvec2 xy) {
         if ((E != D && all_eq4(E, A, G, F, R) && all_eq2(D, B, H)) && (D != src(srcX - 3, srcY))) J = L = D;
         if ((E != H && all_eq4(E, G, I, B, P) && all_eq2(H, D, F)) && (H != src(srcX, srcY + 3))) L = M = H;
         if ((E != B && all_eq4(E, A, C, H, S) && all_eq2(B, D, F)) && (B != src(srcX, srcY - 3))) J = K = B;
-        if (Bl < El && all_eq4(E, G, H, I, S) && none_eq4(E, A, D, C, F)) J = K = B;
-        if (Hl < El && all_eq4(E, A, B, C, P) && none_eq4(E, D, G, I, F)) L = M = H;
-        if (Fl < El && all_eq4(E, A, D, G, Q) && none_eq4(E, B, C, I, H)) K = M = F;
-        if (Dl < El && all_eq4(E, C, F, I, R) && none_eq4(E, B, A, G, H)) J = L = D;
+
+        // Weak blending for edge artifacts
+        if (Bl < El && all_eq4(E, G, H, I, S) && none_eq4(E, A, D, C, F)) {J=admix2d(B,J); K=admix2d(B,K);}
+        if (Hl < El && all_eq4(E, A, B, C, P) && none_eq4(E, D, G, I, F)) {L=admix2d(H,L); M=admix2d(H,M);}
+        if (Fl < El && all_eq4(E, A, D, G, Q) && none_eq4(E, B, C, I, H)) {K=admix2d(F,K); M=admix2d(F,M);}
+        if (Dl < El && all_eq4(E, C, F, I, R) && none_eq4(E, B, A, G, H)) {J=admix2d(D,J); L=admix2d(D,L);}
 
         // 2:1 slope rules
         if (H != B) {
@@ -221,7 +219,7 @@ void applyScaling(uvec2 xy) {
                 if (all_eq3(B, A, F, R) && none_eq2(B, D, src(srcX + 2, srcY + 1))) J = K;
                 if (all_eq3(B, C, D, Q) && none_eq2(B, F, src(srcX - 2, srcY + 1))) K = J;
             }
-        } // H !== B
+        }
 
         if (F != D) {
             if (D != I && D != E && D != C) {
@@ -233,10 +231,10 @@ void applyScaling(uvec2 xy) {
                 if (all_eq3(F, C, H, S) && none_eq2(F, B, src(srcX - 1, srcY + 2))) K = M;
                 if (all_eq3(F, I, B, P) && none_eq2(F, H, src(srcX - 1, srcY - 2))) M = K;
             }
-        } // F !== D
-    } // not constant
+        }
+    }
 
-    // Write four pixels at once.
+    // Write 2x2 upscaled block
     ivec2 destXY = ivec2(xy) * 2;
     writeColorf(destXY, unpackUnorm4x8(J));
     writeColorf(destXY + ivec2(1, 0), unpackUnorm4x8(K));


### PR DESCRIPTION
Fix luma function to ensureluma increases linearly with alpha value Use conditional weak blending instead of pixel copying to reduce image glitchesartifacts on straight lines Reduce algorithm overhead. Improve the judgment logic 
Improved the distance judgment between two pixes by changing the Euclidean formula to dot sets to reduce hardware overhead. Improved some comments to make them easier to read.

LittleBigPlanet (Asia) (En,Zh,Ko)
master:
![flag old_cr](https://github.com/user-attachments/assets/2ce35cd7-e8a1-4d22-898f-d9d592de4982)
pr:
![flag new_cr](https://github.com/user-attachments/assets/a66d5bb7-b65f-4e22-a333-ea0e318211d7)

MediEvil - Resurrection (USA)
master:
![medi old](https://github.com/user-attachments/assets/9b3d774f-75d5-4c83-8e2b-1aba6a5de468)
pr:

![medi new](https://github.com/user-attachments/assets/bca04045-9206-40d9-9d0c-fcc0ecabdbde)
