### PR TITLE
x86: build fix

### DIFF
--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -88,7 +88,7 @@ inline u32 __rotl(u32 x, int shift) {
 inline u64 __rotl64(u64 x, unsigned int shift){
 #if defined(_MSC_VER)
 	return _rotl64(x, shift);
-#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+#elif PPSSPP_ARCH(AMD64)
 	return __rolq(x, shift);
 #else
 	unsigned int n = shift % 64;
@@ -111,7 +111,7 @@ inline u32 __rotr(u32 x, int shift) {
 inline u64 __rotr64(u64 x, unsigned int shift){
 #if defined(_MSC_VER)
 	return _rotr64(x, shift);
-#elif (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
+#elif PPSSPP_ARCH(AMD64)
 	return __rorq(x, shift);
 #else
 	unsigned int n = shift % 64;


### PR DESCRIPTION
The libretro android-x86 and linux-i686 builds have been failing since 1061304b9f9be438c5bfef47fa50c513e6e2bf91