### PR TITLE
ImMemView: Refined the keyboard shortcuts.

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1043,11 +1043,7 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 					// since SDL does not have a separate
 					// UI thread.
 				}
-				if (ctrl && (k == SDLK_b))
-				{
-					System_PostUIMessage(UIMessage::REQUEST_GAME_RESET);
-					Core_Resume();
-				}
+
 				/*
 				// TODO: Enable this?
 				if (k == SDLK_F11) {

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -1039,7 +1039,7 @@ void ImMemWindow::ProcessKeyboardShortcuts() {
 		selectedSearchType_ = STRING;
 		return;
 	}
-	/*
+
 	if (ImGui::IsKeyPressed(ImGuiKey_B)) {
 		OPEN_SEARCH_FORM();
 		selectedSearchType_ = BITS_8;
@@ -1047,7 +1047,7 @@ void ImMemWindow::ProcessKeyboardShortcuts() {
 		// SDL/SDLMain.cpp
 		return;
 	}
-	*/
+
 	if (ImGui::IsKeyPressed(ImGuiKey_H)) {
 		OPEN_SEARCH_FORM();
 		selectedSearchType_ = BITS_16;

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -31,7 +31,6 @@ public:
 	MIPSDebugInterface *getDebugger() {
 		return debugger_;
 	}
-	std::vector<u32> searchString(const std::string &searchQuery);
 	void Draw(ImDrawList *drawList);
 	// void onVScroll(WPARAM wParam, LPARAM lParam);
 	// void onKeyDown(WPARAM wParam, LPARAM lParam);
@@ -194,7 +193,7 @@ private:
 	enum {
 		INVALID_ADDR = 0xFFFFFFFF,
 	};
-
+	void ProcessKeyboardShortcuts();
 	// Symbol cache
 	std::vector<SymbolEntry> symCache_;
 	bool symsDirty_ = true;
@@ -204,6 +203,11 @@ private:
 	bool drawZeroDark_ = false;
 	bool editableMemory_ = false;
 
+	int searchFormFlags_=0;
+	bool focusSearchValueInput_ = false;
+	MemorySearchType selectedSearchType_ = BITS_8;
+	char searchStr_[512];
+	// store the state of the search form
 	ImMemView memView_;
 	char searchTerm_[64]{};
 


### PR DESCRIPTION
This PR attempts to refine the shortcuts in the ImMemView,
some shortcuts needing to "control the UI" (ie: open the ``ImGui::CollapsingHeader`` that holds the memory search form)
I choose to give the ImMemWindow its own ``ProcessKeyboardShortcuts`` function to handle to following shortcuts:
- Ctrl + b: open a Byte search (note this one is currently disabled since Ctrl + b is already used to restart the Emulation)
- Ctrl + h: open a half-width search
- Ctrl + u: open a full-widht search
- Ctrl + f: open a string search
- Ctrl + x: open a byte sequence search

the following shortcut moved here
- Ctrl + n: go to next search match

This also introduce some behavior changes:
- the search can be also stared by pressing enter in the ``ImGui::InputText widget``.
- each test for a give key, ends with a return statement to avoid  when two or more unrelated keys (tested in the ``ProcessKeyboardShortcuts``) are active on the same frame;