### PR TITLE
OpenXR - Make FakeReflections shader compatible with nonVR screens

### DIFF
--- a/Common/GPU/ShaderTranslation.cpp
+++ b/Common/GPU/ShaderTranslation.cpp
@@ -82,6 +82,7 @@ cbuffer data : register(b0) {
 	float4 u_timeDelta;
 	float4 u_setting;
 	float u_video;
+	float u_vr;
 };
 )";
 
@@ -99,6 +100,7 @@ layout (std140, set = 0, binding = 0) uniform Data {
 	vec4 u_timeDelta;
 	vec4 u_setting;
 	float u_video;
+	float u_vr;
 };
 )";
 

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -240,6 +240,7 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 	uniforms->timeDelta[2] = time[2] - previousUniforms_.time[2];
 	uniforms->timeDelta[3] = time[3] != previousUniforms_.time[3] ? 1.0f : 0.0f;
 	uniforms->video = hasVideo_ ? 1.0f : 0.0f;
+	uniforms->vr = IsVREnabled() && IsBigScreenVRMode() ? 1.0f : 0.0f;
 
 	// The shader translator tacks this onto our shaders, if we don't set it they render garbage.
 	uniforms->gl_HalfPixel[0] = u_pixel_delta * 0.5f;
@@ -367,6 +368,7 @@ bool PresentationCommon::CompilePostShader(const ShaderInfo *shaderInfo, Draw::P
 		{ "u_timeDelta", 4, 4, UniformType::FLOAT4, offsetof(PostShaderUniforms, timeDelta) },
 		{ "u_setting", 5, 5, UniformType::FLOAT4, offsetof(PostShaderUniforms, setting) },
 		{ "u_video", 6, 6, UniformType::FLOAT1, offsetof(PostShaderUniforms, video) },
+		{ "u_vr", 7, 7, UniformType::FLOAT1, offsetof(PostShaderUniforms, vr) },
 	} };
 
 	Draw::Pipeline *pipeline = CreatePipeline({ vs, fs }, true, &postShaderDesc);

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -35,6 +35,7 @@ struct PostShaderUniforms {
 	float timeDelta[4];
 	float setting[4];
 	float video; float pad[3];
+	float vr;
 	// Used on Direct3D9.
 	float gl_HalfPixel[4];
 };

--- a/assets/shaders/fakereflections.fsh
+++ b/assets/shaders/fakereflections.fsh
@@ -8,9 +8,10 @@ precision mediump int;
 #endif
 
 uniform sampler2D sampler0;
-varying vec2 v_texcoord0;	
+varying vec2 v_texcoord0;
 
 uniform vec4 u_setting;
+uniform float u_vr;
 
 void main()
 {
@@ -19,15 +20,18 @@ void main()
   float gray = (color.r + color.g + color.b) / 3.0;
   float saturation = (abs(color.r - gray) + abs(color.g - gray) + abs(color.b - gray)) / 3.0;
 
+  //the effect is dependent on size of the viewport, u_vr is 1 when it is rendered in VR
+  float scale = 1.0 + u_vr;
+
   //persistent random offset to hide that the reflection is wrong
-  float rndx = mod(v_texcoord0.x + gray, 0.03) + mod(v_texcoord0.y + saturation, 0.05);
-  float rndy = mod(v_texcoord0.y + saturation, 0.03) + mod(v_texcoord0.x + gray, 0.05);
+  float rndx = mod(v_texcoord0.x + gray, 0.03 * scale) + mod(v_texcoord0.y + saturation, 0.05 * scale);
+  float rndy = mod(v_texcoord0.y + saturation, 0.03 * scale) + mod(v_texcoord0.x + gray, 0.05 * scale);
 
   //show the effect mainly on the bottom part of the screen
   float step = (max(gray, saturation) + 0.1) * v_texcoord0.y;
 
   //the fake reflection is just a watered copy of the frame moved slightly lower
-  vec3 reflection = texture2D(sampler0, v_texcoord0 + vec2(rndx, rndy - min(v_texcoord0.y, 0.25)) * step).rgb;
+  vec3 reflection = texture2D(sampler0, v_texcoord0 + vec2(rndx, rndy - min(v_texcoord0.y, 0.25) * scale) * step).rgb;
 
   //apply parameters and mix the colors
   reflection *= 4.0 * (1.0 - gray) * u_setting.x;


### PR DESCRIPTION
When I introduced FakeReflections shader, I didn't notice it works only in VR. This PR fixes that.