### PR TITLE
Create Windows release on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,22 @@ jobs:
         name: Windows ${{ matrix.platform }} build
         path: ppsspp/
 
+    - name: Create release
+      if: github.ref_type == 'tag'
+      working-directory: ${{ env.GITHUB_WORKSPACE }}
+      run: |
+        rm ppsspp/PPSSPPHeadless*
+        rm ppsspp/UnitTest*
+        rm ppsspp/*.pdb
+        mkdir releases
+        Compress-Archive -Path "ppsspp/*" -Update -DestinationPath "releases/PPSSPP-${{ github.ref_name }}-Windows-${{ matrix.platform }}.zip"
+
+    - name: Upload release
+      uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+      if: github.ref_type == 'tag'
+      with:
+        files: releases/*.zip
+
   build-uwp:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,25 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
 
+    - name: Fetch tags
+      # This is required for git describe --always to work for git-version.cpp.
+      run: git fetch --deepen=15000 --no-recurse-submodules --tags || exit 0
+
+    - name: Create git-version.cpp for Windows # Not sure why the one at git-version-gen.cmd couldn't get the version properly.
+      #if: github.ref_type == 'tag'
+      run: |
+        $GIT_VERSION=git describe --always --tags
+        echo "Test GitVer = ${{ github.ref_name }} / $GIT_VERSION / ${GITHUB_REF_NAME}"
+        echo "const char *PPSSPP_GIT_VERSION = `"$GIT_VERSION`";" > git-version.cpp
+        echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
+        
+        # Generate Windows/win-version.h too.
+        $WIN_VERSION_COMMA=$GIT_VERSION -replace '^v', '' -replace '-g[0-9a-f]+$', '' -replace '[-\.]', ','
+        echo "Test WinVer = $WIN_VERSION_COMMA"
+        echo "#define PPSSPP_WIN_VERSION_STRING `"$GIT_VERSION`"" > Windows/win-version.h
+        echo "#define PPSSPP_WIN_VERSION_COMMA $WIN_VERSION_COMMA" >> Windows/win-version.h
+        echo "#define PPSSPP_WIN_VERSION_NO_UPDATE 1" >> Windows/win-version.h
+        
     - name: Build Windows
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: msbuild /m /p:TrackFileAccess=false /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=${{ matrix.platform }} Windows/PPSSPP.sln


### PR DESCRIPTION
Since we have macOS and Linux release at https://github.com/hrydgard/ppsspp/releases
Windows users might get jealous LOL, so here it is, though only 64-bit build are available.

Example of release page: https://github.com/ANR2MERefork/ppsspp/releases/tag/v1.4.2

However, there seems to be version issue on Windows artifacts, which carried on to the released zip (since i use the same binaries with artifacts)
![image](https://github.com/user-attachments/assets/4d6a8d8a-3b21-461e-b6f8-57cd66c33fc4)
It only shows the hash without version. 
Did we have a missing `git-version.cpp` on Windows?

PS: I tried to create the `git-version.cpp` (on a different branch) similar to the one for macOS, but the build steps became failing, ~~so i'm not sure how to fix the version.~~

Edit: looks like the script need to be adjusted for powershell, and need to fetch the tags first for the version to shows correctly.