### PR TITLE
Try to fix the unittest on Windows

### DIFF
--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -281,7 +281,10 @@ inline OpArg MRegSum(X64Reg base, X64Reg offset)
 template <typename T>
 inline bool Accessible(const T *t1, const T *t2) {
 	ptrdiff_t diff = (const uint8_t *)t1 - (const uint8_t *)t2;
-	return diff > -0x7FFFFFE0 && diff < 0x7FFFFFE0;
+	if (diff < 0) {
+		diff = -diff;
+	}
+	return diff < (ptrdiff_t)0x7FFFFFE0;
 }
 
 template <typename T>

--- a/GPU/D3D11/D3D11Util.cpp
+++ b/GPU/D3D11/D3D11Util.cpp
@@ -28,7 +28,7 @@ std::vector<uint8_t> CompileShaderToBytecodeD3D11(const char *code, size_t codeS
 	HRESULT result = ptr_D3DCompile(code, codeSize, nullptr, nullptr, nullptr, "main", target, flags, 0, &compiledCode, &errorMsgs);
 	std::string errors;
 	if (errorMsgs) {
-		errors = std::string((const char *)errorMsgs->GetBufferPointer(), errorMsgs->GetBufferSize());
+		errors = std::string((const char *)errorMsgs->GetBufferPointer(), errorMsgs->GetBufferSize() > 1 ? (errorMsgs->GetBufferSize() - 1) : 0);
 		std::string numberedCode = LineNumberString(code);
 		if (SUCCEEDED(result)) {
 			std::vector<std::string_view> lines;
@@ -45,9 +45,9 @@ std::vector<uint8_t> CompileShaderToBytecodeD3D11(const char *code, size_t codeS
 			}
 		} else {
 			ERROR_LOG(Log::G3D, "%s: %s\n\n%s", "errors", errors.c_str(), numberedCode.c_str());
+			OutputDebugStringA(errors.c_str());
+			OutputDebugStringA(numberedCode.c_str());
 		}
-		OutputDebugStringA(errors.c_str());
-		OutputDebugStringA(numberedCode.c_str());
 	}
 	if (compiledCode) {
 		// Success!

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -149,7 +149,7 @@ RegCache::Reg PixelJitCache::GetColorOff(const PixelFuncID &id) {
 
 			// Now add the pointer for the color buffer.
 			if (loadDepthOff) {
-				_assert_(Accessible(&fb.data, &depthbuf.data));
+				_assert_msg_(Accessible(&fb.data, &depthbuf.data), "fb.data and depthbuf.data too far apart: %p %p (fb=%08x d=%08x)", fb.data, depthbuf.data, gstate.getFrameBufAddress(), gstate.getDepthBufAddress());
 				depthTemp = regCache_.Alloc(RegCache::GEN_DEPTH_OFF);
 				if (RipAccessible(&fb.data) && RipAccessible(&depthbuf.data)) {
 					MOV(PTRBITS, R(argYReg), M(&fb.data));

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1028,7 +1028,12 @@ void SoftGPU::Execute_FramebufPtr(u32 op, u32 diff) {
 	// We assume fb.data won't change while we're drawing.
 	if (diff) {
 		drawEngine_->transformUnit.Flush(this, "framebuf");
-		fb.data = Memory::GetPointerWrite(gstate.getFrameBufAddress());
+		if (gstate.getFrameBufAddress() != 0) {
+			_dbg_assert_msg_(Memory::IsValidAddress(gstate.getFrameBufAddress()), "Invalid framebuffer address %08x", gstate.getFrameBufAddress());
+			fb.data = Memory::GetPointerWriteUnchecked(gstate.getFrameBufAddress());
+		} else {
+			fb.data = nullptr;
+		}
 	}
 }
 
@@ -1049,7 +1054,12 @@ void SoftGPU::Execute_ZbufPtr(u32 op, u32 diff) {
 		drawEngine_->transformUnit.Flush(this, "depthbuf");
 		// For the pointer, ignore memory mirrors.  This also gives some buffer for draws that go outside.
 		// TODO: Confirm how wrapping is handled in drawing.  Adjust if we ever handle VRAM mirrors more accurately.
-		depthbuf.data = Memory::GetPointerWrite(gstate.getDepthBufAddress() & 0x041FFFF0);
+		if (gstate.getDepthBufAddress() != 0) {
+			_dbg_assert_msg_(Memory::IsValidAddress(gstate.getDepthBufAddress()), "Invalid depthbuffer address %08x", gstate.getDepthBufAddress());
+			depthbuf.data = Memory::GetPointerWriteUnchecked(gstate.getDepthBufAddress() & 0x041FFFF0);
+		} else {
+			depthbuf.data = nullptr;
+		}
 	}
 }
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1028,12 +1028,7 @@ void SoftGPU::Execute_FramebufPtr(u32 op, u32 diff) {
 	// We assume fb.data won't change while we're drawing.
 	if (diff) {
 		drawEngine_->transformUnit.Flush(this, "framebuf");
-		if (gstate.getFrameBufAddress() != 0) {
-			_dbg_assert_msg_(Memory::IsValidAddress(gstate.getFrameBufAddress()), "Invalid framebuffer address %08x", gstate.getFrameBufAddress());
-			fb.data = Memory::GetPointerWriteUnchecked(gstate.getFrameBufAddress());
-		} else {
-			fb.data = nullptr;
-		}
+		fb.data = Memory::GetPointerWriteUnchecked(gstate.getFrameBufAddress());
 	}
 }
 
@@ -1054,12 +1049,7 @@ void SoftGPU::Execute_ZbufPtr(u32 op, u32 diff) {
 		drawEngine_->transformUnit.Flush(this, "depthbuf");
 		// For the pointer, ignore memory mirrors.  This also gives some buffer for draws that go outside.
 		// TODO: Confirm how wrapping is handled in drawing.  Adjust if we ever handle VRAM mirrors more accurately.
-		if (gstate.getDepthBufAddress() != 0) {
-			_dbg_assert_msg_(Memory::IsValidAddress(gstate.getDepthBufAddress()), "Invalid depthbuffer address %08x", gstate.getDepthBufAddress());
-			depthbuf.data = Memory::GetPointerWriteUnchecked(gstate.getDepthBufAddress() & 0x041FFFF0);
-		} else {
-			depthbuf.data = nullptr;
-		}
+		depthbuf.data = Memory::GetPointerWrite(gstate.getDepthBufAddress() & 0x041FFFF0);
 	}
 }
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -55,6 +55,7 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Buffer.h"
 #include "Common/File/Path.h"
+#include "Common/Log/LogManager.h"
 #include "Common/Math/SIMDHeaders.h"
 #include "Common/Math/CrossSIMD.h"
 // Get some more instructions for testing
@@ -1311,6 +1312,7 @@ int main(int argc, const char *argv[]) {
 	cpu_info.bVFPv3 = true;
 	cpu_info.bVFPv4 = true;
 	g_Config.bEnableLogging = true;
+	g_logManager.DisableOutput(LogOutput::DebugString);  // not really needed
 
 	bool allTests = false;
 	TestFunc testFunc = nullptr;
@@ -1329,7 +1331,8 @@ int main(int argc, const char *argv[]) {
 	if (allTests) {
 		int passes = 0;
 		int fails = 0;
-		for (auto f : availableTests) {
+		for (const auto &f : availableTests) {
+			printf("\n**** Running test %s ****\n", f.name);
 			if (f.func()) {
 				++passes;
 			} else {
@@ -1344,7 +1347,7 @@ int main(int argc, const char *argv[]) {
 			printf("%d tests failed!\n", fails);
 			return 2;
 		}
-	} else if (testFunc == nullptr) {
+	} else if (!testFunc) {
 		fprintf(stderr, "You may select a test to run by passing an argument, either \"all\" or one or more of the below.\n");
 		fprintf(stderr, "\n");
 		fprintf(stderr, "Available tests:\n");


### PR DESCRIPTION
We've been getting strange errors lately, but I can't reproduce locally. So I'll be posting commits to try to fix it here. First off, improve the logging so we can see which test it is.

OK, turns out a pointer distance function was busted. Hm, wonder what else it broke...