### PR TITLE
Atrac code cleanup, logging and comment fixes

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -40,6 +40,8 @@ enum class Log {
 	HLE,
 	JIT,
 	Loader,
+	Mpeg,
+	Atrac,
 	ME,
 	MemMap,
 	SasMix,

--- a/Common/Log/LogManager.cpp
+++ b/Common/Log/LogManager.cpp
@@ -216,12 +216,12 @@ void LogManager::SaveConfig(Section *section) {
 	}
 }
 
-void LogManager::LoadConfig(const Section *section, bool debugDefaults) {
+void LogManager::LoadConfig(const Section *section) {
 	for (int i = 0; i < (int)Log::NUMBER_OF_LOGS; i++) {
 		bool enabled = false;
 		int level = 0;
 		section->Get((std::string(g_logTypeNames[i]) + "Enabled"), &enabled, true);
-		section->Get((std::string(g_logTypeNames[i]) + "Level"), &level, (int)(debugDefaults ? LogLevel::LDEBUG : LogLevel::LERROR));
+		section->Get((std::string(g_logTypeNames[i]) + "Level"), &level, (int)LogLevel::LERROR);
 		g_log[i].enabled = enabled;
 		g_log[i].level = (LogLevel)level;
 	}

--- a/Common/Log/LogManager.cpp
+++ b/Common/Log/LogManager.cpp
@@ -79,7 +79,9 @@ static const char * const g_logTypeNames[] = {
 	"HLE",
 	"JIT",
 	"LOADER",
-	"ME",  // Media Engine
+	"MPEG",
+	"ATRAC",
+	"ME",  // Rest of the media Engine
 	"MEMMAP",
 	"SASMIX",
 	"SAVESTATE",

--- a/Common/Log/LogManager.h
+++ b/Common/Log/LogManager.h
@@ -153,7 +153,7 @@ public:
 	const Path &GetLogFilePath() const { return logFilename_; }
 
 	void SaveConfig(Section *section);
-	void LoadConfig(const Section *section, bool debugDefaults);
+	void LoadConfig(const Section *section);
 
 	static const char *GetLogTypeName(Log type);
 

--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -72,7 +72,7 @@ bool RequestManager::MakeSystemRequest(SystemRequestType type, RequesterToken to
 		callbackMap_[requestId] = { callback, failedCallback, token };
 	}
 
-	DEBUG_LOG(Log::System, "Making system request %s: id %d", RequestTypeAsString(type), requestId);
+	VERBOSE_LOG(Log::System, "Making system request %s: id %d", RequestTypeAsString(type), requestId);
 	std::string p1(param1);
 	std::string p2(param2);
 	// TODO: Convert to string_view

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1217,11 +1217,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	Section *log = iniFile.GetOrCreateSection(logSectionName);
 
-	bool debugDefaults = false;
-#ifdef _DEBUG
-	debugDefaults = true;
-#endif
-	g_logManager.LoadConfig(log, debugDefaults);
+	g_logManager.LoadConfig(log);
 
 	Section *recent = iniFile.GetOrCreateSection("Recent");
 	recent->Get("MaxRecent", &iMaxRecent, 60);

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -225,11 +225,11 @@ void Atrac::WriteContextToPSPMem() {
 }
 
 void Track::DebugLog() const {
-	DEBUG_LOG(Log::ME, "ATRAC analyzed: %s channels: %d filesize: %d bitrate: %d kbps jointStereo: %d",
+	DEBUG_LOG(Log::Atrac, "ATRAC analyzed: %s channels: %d filesize: %d bitrate: %d kbps jointStereo: %d",
 		codecType == PSP_CODEC_AT3 ? "AT3" : "AT3Plus", channels, fileSize, bitrate / 1024, jointStereo);
-	DEBUG_LOG(Log::ME, "dataoff: %d firstSampleOffset: %d endSample: %d", dataByteOffset, firstSampleOffset, endSample);
-	DEBUG_LOG(Log::ME, "loopStartSample: %d loopEndSample: %d", loopStartSample, loopEndSample);
-	DEBUG_LOG(Log::ME, "sampleSize: %d (%03x", bytesPerFrame, bytesPerFrame);
+	DEBUG_LOG(Log::Atrac, "dataoff: %d firstSampleOffset: %d endSample: %d", dataByteOffset, firstSampleOffset, endSample);
+	DEBUG_LOG(Log::Atrac, "loopStartSample: %d loopEndSample: %d", loopStartSample, loopEndSample);
+	DEBUG_LOG(Log::Atrac, "sampleSize: %d (%03x", bytesPerFrame, bytesPerFrame);
 }
 
 int Atrac::GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample) const {
@@ -291,7 +291,7 @@ void Atrac::CalculateStreamInfo(u32 *outReadOffset) {
 
 		// If you don't think this should be here, remove it.  It's just a temporary safety check.
 		if (first_.offset + first_.writableBytes > bufferMaxSize_) {
-			ERROR_LOG_REPORT(Log::ME, "Somehow calculated too many writable bytes: %d + %d > %d", first_.offset, first_.writableBytes, bufferMaxSize_);
+			ERROR_LOG_REPORT(Log::Atrac, "Somehow calculated too many writable bytes: %d + %d > %d", first_.offset, first_.writableBytes, bufferMaxSize_);
 			first_.offset = 0;
 			first_.writableBytes = bufferMaxSize_;
 		}
@@ -417,7 +417,7 @@ int Atrac::SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize,
 	first_._filesize_dontuse = track_.fileSize;
 
 	if (outputChannels != track_.channels) {
-		WARN_LOG(Log::ME, "Atrac::SetData: outputChannels %d doesn't match track_.channels %d", outputChannels, track_.channels);
+		WARN_LOG(Log::Atrac, "Atrac::SetData: outputChannels %d doesn't match track_.channels %d", outputChannels, track_.channels);
 	}
 
 	first_.addr = buffer;
@@ -438,7 +438,7 @@ int Atrac::SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize,
 	if (track_.codecType != PSP_CODEC_AT3 && track_.codecType != PSP_CODEC_AT3PLUS) {
 		// Shouldn't have gotten here, Analyze() checks this.
 		bufferState_ = ATRAC_STATUS_NO_DATA;
-		ERROR_LOG(Log::ME, "unexpected codec type %d in set data", track_.codecType);
+		ERROR_LOG(Log::Atrac, "unexpected codec type %d in set data", track_.codecType);
 		return SCE_ERROR_ATRAC_UNKNOWN_FORMAT;
 	}
 
@@ -467,7 +467,7 @@ int Atrac::SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize,
 		Memory::Memcpy(dataBuf_, buffer, copybytes, "AtracSetData");
 	}
 	CreateDecoder(track.codecType, track.bytesPerFrame, track.channels);
-	INFO_LOG(Log::ME, "Atrac::SetData (buffer=%08x, readSize=%d, bufferSize=%d): %s %s (%d channels) audio", buffer, readSize, bufferSize, codecName, channelName, track_.channels);
+	INFO_LOG(Log::Atrac, "Atrac::SetData (buffer=%08x, readSize=%d, bufferSize=%d): %s %s (%d channels) audio", buffer, readSize, bufferSize, codecName, channelName, track_.channels);
 
 	if (track_.channels == 2 && outputChannels == 1) {
 		// We still do all the tasks, we just return this error.
@@ -979,9 +979,9 @@ void Atrac::NotifyGetContextAddress() {
 		context_ = kernelMemory.Alloc(contextSize, false, StringFromFormat("AtracCtx/%d", atracID_).c_str());
 		if (context_.IsValid())
 			Memory::Memset(context_.ptr, 0, contextSize, "AtracContextClear");
-		WARN_LOG(Log::ME, "%08x=_sceAtracGetContextAddress(%i): allocated new context", context_.ptr, atracID_);
+		WARN_LOG(Log::Atrac, "%08x=_sceAtracGetContextAddress(%i): allocated new context", context_.ptr, atracID_);
 	} else {
-		WARN_LOG(Log::ME, "%08x=_sceAtracGetContextAddress(%i)", context_.ptr, atracID_);
+		WARN_LOG(Log::Atrac, "%08x=_sceAtracGetContextAddress(%i)", context_.ptr, atracID_);
 	}
 	WriteContextToPSPMem();
 }

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -124,18 +124,18 @@ public:
 	virtual int BytesPerFrame() const = 0;
 	virtual int SamplesPerFrame() const = 0;
 
-	virtual void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) = 0;
+	virtual void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) = 0;  // This should be const, but the legacy impl stops it (it's wrong).
 	virtual int AddStreamData(u32 bytesToAdd) = 0;
 	virtual int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) = 0;
-	virtual int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample, bool *delay) = 0;
+	virtual int GetBufferInfoForResetting(AtracResetBufferInfo *bufferInfo, int sample, bool *delay) = 0;  // NOTE: Not const! This can cause SkipFrames!
 	virtual int SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) = 0;
 
-	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) = 0;
+	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) const = 0;
 	virtual int SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) = 0;
 	virtual u32 DecodeData(u8 *outbuf, u32 outbufPtr, int *SamplesNum, int *finish, int *remains) = 0;
 	virtual int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) = 0;
 
-	virtual u32 GetNextSamples() = 0;
+	virtual u32 GetNextSamples() = 0;  // This should be const, but the legacy impl stops it (it's wrong).
 	virtual void InitLowLevel(const Atrac3LowLevelParams &params, int codecType) = 0;
 
 	virtual void CheckForSas() = 0;
@@ -224,9 +224,9 @@ public:
 	// Notify the player that the user has written some new data.
 	int AddStreamData(u32 bytesToAdd) override;
 	int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) override;
-	int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample, bool *delay) override;
+	int GetBufferInfoForResetting(AtracResetBufferInfo *bufferInfo, int sample, bool *delay) override;  // NOTE: Not const! This can cause SkipFrames! (although only in the AtracCtx2)
 	int SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
-	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) override;
+	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) const override;
 	int SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, int *SamplesNum, int *finish, int *remains) override;
 	int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) override;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -578,6 +578,12 @@ static void ComputeStreamBufferDataInfo(const SceAtracIdInfo &info, u32 *writePt
 	const int loopStartFileOffset = ComputeFileOffset(info, info.loopStart);
 	const int loopEndFileOffset = ComputeLoopEndFileOffset(info, info.loopEnd);
 
+	if (spaceLeftInBuffer < 0) {
+		// Most likely, the file was truncated.
+		WARN_LOG(Log::Atrac, "File corruption detected: spaceLeftInBuffer < 0: %d. Stumbling along.", spaceLeftInBuffer);
+		spaceLeftInBuffer = 0;
+	}
+
 	switch (info.state) {
 	case ATRAC_STATUS_STREAMED_WITHOUT_LOOP:
 	{

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -8,9 +8,7 @@ class Atrac2 : public AtracBase {
 public:
 	// The default values are only used during save state load, in which case they get restored by DoState.
 	Atrac2(u32 contextAddr = 0, int codecType = 0);
-	~Atrac2() {
-		delete[] decodeTemp_;
-	}
+	~Atrac2();
 
 	AtracStatus BufferState() const override {
 		return context_->info.state;
@@ -68,6 +66,8 @@ private:
 	u32 SkipFrames(int *skippedCount);
 	void WrapLastPacket();
 
+	void DumpBufferToFile();
+
 	// Just the current decoded frame, in order to be able to cut off the first part of it
 	// to write the initial partial frame.
 	// Does not need to be saved.
@@ -76,4 +76,7 @@ private:
 	// This is hidden state inside sceSas, really. Not visible in the context.
 	// But it doesn't really matter whether it's here or there.
 	AtracSasStreamState sas_;
+
+	std::vector<u8> dumpBuffer_;  // Used for dumping audio data to files.
+	bool dumped_ = false;  // Whether we already dumped the audio data to a file.
 };

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -31,10 +31,10 @@ public:
 	int CodecType() const override { return context_->info.codec; }
 
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
-	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) override;
+	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) const override;
 	int AddStreamData(u32 bytesToAdd) override;
 	int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) override;
-	int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample, bool *delay) override;
+	int GetBufferInfoForResetting(AtracResetBufferInfo *bufferInfo, int sample, bool *delay) override;
 	int SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	int SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	bool HasSecondBuffer() const override;
@@ -62,7 +62,7 @@ public:
 
 private:
 	u32 DecodeInternal(u32 outbufAddr, int *SamplesNum, int *finish);
-	void GetResetBufferInfoInternal(AtracResetBufferInfo *bufferInfo, int sample);
+	void GetResetBufferInfoInternal(AtracResetBufferInfo *bufferInfo, int sample) const;
 	u32 ResetPlayPositionInternal(int seekPos, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf);
 
 	u32 SkipFrames(int *skippedCount);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -144,7 +144,7 @@ int __AtracMaxContexts() {
 void __AtracNotifyLoadModule(int version, u32 crc, u32 bssAddr, int bssSize) {
 	atracLibVersion = version;
 	atracLibCrc = crc;
-	INFO_LOG(Log::ME, "Atrac module loaded: atracLibVersion 0x%0x, atracLibcrc %x, bss: %x (%x bytes)", atracLibVersion, atracLibCrc, bssAddr, bssSize);
+	INFO_LOG(Log::Atrac, "Atrac module loaded: atracLibVersion 0x%0x, atracLibcrc %x, bss: %x (%x bytes)", atracLibVersion, atracLibCrc, bssAddr, bssSize);
 	g_atracBSS = bssAddr;
 	g_atracMaxContexts = atracLibVersion <= 0x101 ? 4 : 6;  // Need to figure out where the cutoff is.
 	_dbg_assert_(bssSize >= g_atracMaxContexts * sizeof(SceAtracContext));
@@ -155,7 +155,7 @@ void __AtracNotifyLoadModule(int version, u32 crc, u32 bssAddr, int bssSize) {
 void __AtracNotifyUnloadModule() {
 	atracLibVersion = 0;
 	atracLibCrc = 0;
-	INFO_LOG(Log::ME, "Atrac module unloaded.");
+	INFO_LOG(Log::Atrac, "Atrac module unloaded.");
 	g_atracBSS = 0;
 	g_atracMaxContexts = 6;  // TODO: We should make this zero here.
 	NotifyMemInfo(MemBlockFlags::FREE, g_atracBSS, g_atracMaxContexts * sizeof(SceAtracContext), "AtracContext");
@@ -256,15 +256,15 @@ static int UnregisterAndDeleteAtrac(int atracID) {
 // Useful to initialize a context for low level decode.
 static u32 sceAtracGetAtracID(int codecType) {
 	if (codecType != PSP_CODEC_AT3 && codecType != PSP_CODEC_AT3PLUS) {
-		return hleReportError(Log::ME, SCE_ERROR_ATRAC_INVALID_CODECTYPE, "invalid codecType");
+		return hleReportError(Log::Atrac, SCE_ERROR_ATRAC_INVALID_CODECTYPE, "invalid codecType");
 	}
 
 	int atracID = AllocAndRegisterAtrac(codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
-	return hleLogInfo(Log::ME, atracID);
+	return hleLogInfo(Log::Atrac, atracID);
 }
 
 static int AtracValidateData(const AtracBase *atrac) {
@@ -299,18 +299,18 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 	AtracBase *atrac = getAtrac(atracID);
 	int err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (atrac->BufferState() == ATRAC_STATUS_ALL_DATA_LOADED) {
 		// Let's avoid spurious warnings.  Some games call this with 0 which is pretty harmless.
 		if (bytesToAdd == 0)
-			return hleLogDebug(Log::ME, SCE_ERROR_ATRAC_ALL_DATA_LOADED, "stream entirely loaded");
-		return hleLogWarning(Log::ME, SCE_ERROR_ATRAC_ALL_DATA_LOADED, "stream entirely loaded");
+			return hleLogDebug(Log::Atrac, SCE_ERROR_ATRAC_ALL_DATA_LOADED, "stream entirely loaded");
+		return hleLogWarning(Log::Atrac, SCE_ERROR_ATRAC_ALL_DATA_LOADED, "stream entirely loaded");
 	}
 
 	int ret = atrac->AddStreamData(bytesToAdd);
-	return hleLogDebugOrError(Log::ME, ret);
+	return hleLogDebugOrError(Log::Atrac, ret);
 }
 
 // Note that outAddr being null is completely valid here, used to skip data.
@@ -318,11 +318,11 @@ static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (outAddr & 1) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ALIGNMENT);
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ALIGNMENT);
 	}
 
 	int numSamplesWritten = 0;
@@ -330,7 +330,7 @@ static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 
 	int remains = 0;
 	if (outAddr != 0 && !Memory::IsValidAddress(outAddr)) {
 		// Dunno what error code to return here, but we have to bail in this case to avoid crashing PPSSPP.
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_SIZE_TOO_SMALL);
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_SIZE_TOO_SMALL);
 	}
 
 	u8 *outPtr = outAddr ? Memory::GetPointerWrite(outAddr) : nullptr;
@@ -345,7 +345,7 @@ static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 
 		if (ret == 0 && Memory::IsValidAddress(remainAddr))
 			Memory::WriteUnchecked_U32(remains, remainAddr);
 	}
-	DEBUG_LOG(Log::ME, "%08x=sceAtracDecodeData(%i, %08x, %08x[%08x], %08x[%08x], %08x[%d])", ret, atracID, outAddr,
+	DEBUG_LOG(Log::Atrac, "%08x=sceAtracDecodeData(%i, %08x, %08x[%08x], %08x[%08x], %08x[%d])", ret, atracID, outAddr,
 		numSamplesAddr, numSamplesWritten,
 		finishFlagAddr, finish,
 		remainAddr, remains);
@@ -364,7 +364,7 @@ static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 
 
 static u32 sceAtracReleaseResources() {
 	// In the real implementation, this just calls sceAudioCodecReleaseEDRAM if any has been allocated.
-	return hleLogDebug(Log::ME, 0);
+	return hleLogDebug(Log::Atrac, 0);
 }
 
 // Obtains information about what needs to be in the buffer to seek (or "reset")
@@ -375,11 +375,11 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (!bufferInfo.IsValid()) {
-		return hleLogError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid buffer, should crash");
+		return hleLogError(Log::Atrac, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid buffer, should crash");
 	}
 
 	// Note: If we error here, it's because of the internal SkipFrames.
@@ -387,9 +387,9 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 	bool delay = false;
 	int ret = atrac->GetResetBufferInfo(bufferInfo, sample, &delay);
 	if (delay) {
-		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "getreset_frameskip", 300);
+		return hleDelayResult(hleLogDebugOrError(Log::Atrac, ret), "getreset_frameskip", 300);
 	} else {
-		return hleLogDebugOrError(Log::ME, ret);
+		return hleLogDebugOrError(Log::Atrac, ret);
 	}
 }
 
@@ -397,15 +397,15 @@ static u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	int bitrate = atrac->Bitrate();
 	if (Memory::IsValidAddress(outBitrateAddr)) {
 		Memory::WriteUnchecked_U32(atrac->Bitrate(), outBitrateAddr);
-		return hleLogDebug(Log::ME, 0);
+		return hleLogDebug(Log::Atrac, 0);
 	} else {
-		return hleLogError(Log::ME, 0, "invalid address");
+		return hleLogError(Log::Atrac, 0, "invalid address");
 	}
 }
 
@@ -413,14 +413,14 @@ static u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (Memory::IsValidAddress(channelAddr)){
 		Memory::WriteUnchecked_U32(atrac->Channels(), channelAddr);
-		return hleLogDebug(Log::ME, 0);
+		return hleLogDebug(Log::Atrac, 0);
 	} else {
-		return hleLogError(Log::ME, 0, "invalid address");
+		return hleLogError(Log::Atrac, 0, "invalid address");
 	}
 }
 
@@ -428,7 +428,7 @@ static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (Memory::IsValidAddress(loopNumAddr)) {
@@ -438,9 +438,9 @@ static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 	if (Memory::IsValidAddress(statusAddr)) {
 		const int loopStatus = atrac->LoopStatus();
 		Memory::WriteUnchecked_U32(loopStatus, statusAddr);
-		return hleLogDebug(Log::ME, 0);
+		return hleLogDebug(Log::Atrac, 0);
 	} else {
-		return hleLogError(Log::ME, 0, "invalid address");
+		return hleLogError(Log::Atrac, 0, "invalid address");
 	}
 }
 
@@ -448,7 +448,7 @@ static u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	const u32 errorCode = atrac->GetInternalCodecError();
@@ -457,9 +457,9 @@ static u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
 	}
 
 	if (errorCode) {
-		return hleLogWarning(Log::ME, 0, "code: %08x", errorCode);
+		return hleLogWarning(Log::Atrac, 0, "code: %08x", errorCode);
 	} else {
-		return hleLogDebug(Log::ME, 0);
+		return hleLogDebug(Log::Atrac, 0);
 	}
 }
 
@@ -467,14 +467,14 @@ static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (Memory::IsValidAddress(maxSamplesAddr)) {
 		Memory::WriteUnchecked_U32(atrac->SamplesPerFrame(), maxSamplesAddr);
-		return hleLogDebug(Log::ME, 0);
+		return hleLogDebug(Log::Atrac, 0);
 	} else {
-		return hleLogError(Log::ME, 0, "invalid address");
+		return hleLogError(Log::Atrac, 0, "invalid address");
 	}
 }
 
@@ -482,11 +482,11 @@ static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (!Memory::IsValidAddress(outposAddr)) {
-		return hleLogError(Log::ME, 0, "invalid address");
+		return hleLogError(Log::Atrac, 0, "invalid address");
 	}
 
 	int pos = 0;
@@ -494,28 +494,28 @@ static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	if (ret < 0) {
 		if (ret == SCE_ERROR_ATRAC_ALL_DATA_DECODED) {
 			// Benign.
-			return hleLogDebug(Log::ME, ret);
+			return hleLogDebug(Log::Atrac, ret);
 		} else {
-			return hleLogError(Log::ME, ret);
+			return hleLogError(Log::Atrac, ret);
 		}
 	}
 
 	Memory::WriteUnchecked_U32(pos, outposAddr);
-	return hleLogDebug(Log::ME, 0);
+	return hleLogDebug(Log::Atrac, 0);
 }
 
 static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	int numSamples = atrac->GetNextSamples();
 	if (Memory::IsValidAddress(outNAddr)) {
 		Memory::WriteUnchecked_U32(numSamples, outNAddr);
 	}
-	return hleLogDebug(Log::ME, 0, "%d samples left", numSamples);
+	return hleLogDebug(Log::Atrac, 0, "%d samples left", numSamples);
 }
 
 // Obtains the number of frames remaining in the buffer which can be decoded.
@@ -524,17 +524,17 @@ static u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (!Memory::IsValidAddress(remainAddr)) {
 		// Would crash.
-		return hleReportError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid remainingFrames pointer");
+		return hleReportError(Log::Atrac, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid remainingFrames pointer");
 	}
 
 	u32 remaining = atrac->RemainingFrames();
 	Memory::WriteUnchecked_U32(remaining, remainAddr);
-	return hleLogDebug(Log::ME, 0);
+	return hleLogDebug(Log::Atrac, 0);
 }
 
 static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desiredSizeAddr) {
@@ -544,20 +544,20 @@ static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desi
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	if (!fileOffset.IsValid() || !desiredSize.IsValid()) {
 		// Would crash.
-		return hleReportError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid addresses");
+		return hleReportError(Log::Atrac, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid addresses");
 	}
 
 	int result = atrac->GetSecondBufferInfo(fileOffset, desiredSize);
 	switch (result) {
 	case (int)SCE_ERROR_ATRAC_SECOND_BUFFER_NOT_NEEDED:
-		return hleLogDebug(Log::ME, result);
+		return hleLogDebug(Log::Atrac, result);
 	default:
-		return hleLogDebugOrError(Log::ME, result);
+		return hleLogDebugOrError(Log::Atrac, result);
 	}
 }
 
@@ -565,7 +565,7 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	int endSample = -1;
@@ -573,7 +573,7 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 	int loopEnd = -1;
 	int retval = atrac->GetSoundSample(&endSample, &loopStart, &loopEnd);
 	if (retval < 0) {
-		return hleLogError(Log::ME, retval);
+		return hleLogError(Log::Atrac, retval);
 	}
 	if (Memory::IsValidAddress(outEndSampleAddr)) {
 		Memory::WriteUnchecked_U32(endSample, outEndSampleAddr);
@@ -584,7 +584,7 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 	if (Memory::IsValidAddress(outLoopEndSampleAddr)) {
 		Memory::WriteUnchecked_U32(loopEnd, outLoopEndSampleAddr);
 	}
-	return hleLogDebug(Log::ME, retval);
+	return hleLogDebug(Log::Atrac, retval);
 }
 
 // Games call this function to get some info for add more stream data,
@@ -594,7 +594,7 @@ static u32 sceAtracGetStreamDataInfo(int atracID, u32 writePtrAddr, u32 writable
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	u32 writePtr;
@@ -609,19 +609,19 @@ static u32 sceAtracGetStreamDataInfo(int atracID, u32 writePtrAddr, u32 writable
 	if (Memory::IsValidAddress(readOffsetAddr))
 		Memory::WriteUnchecked_U32(readOffset, readOffsetAddr);
 
-	return hleLogDebug(Log::ME, 0);
+	return hleLogDebug(Log::Atrac, 0);
 }
 
 static u32 sceAtracReleaseAtracID(int atracID) {
 	int result = UnregisterAndDeleteAtrac(atracID);
 	if (result < 0) {
 		if (atracID >= 0) {
-			return hleLogError(Log::ME, result, "did not exist");
+			return hleLogError(Log::Atrac, result, "did not exist");
 		} else {
-			return hleLogWarning(Log::ME, result, "did not exist");
+			return hleLogWarning(Log::Atrac, result, "did not exist");
 		}
 	}
-	return hleLogDebug(Log::ME, result);
+	return hleLogDebug(Log::Atrac, result);
 }
 
 // This is called when a game wants to seek (or "reset") to a specific position in the audio data.
@@ -631,16 +631,16 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	bool delay = false;
 	int res = atrac->ResetPlayPosition(sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf, &delay);
 	if (res < 0) {
 		if (delay) {
-			return hleDelayResult(hleLogError(Log::ME, res), "reset play pos", 200);
+			return hleDelayResult(hleLogError(Log::Atrac, res), "reset play pos", 200);
 		} else {
-			return hleLogError(Log::ME, res);
+			return hleLogError(Log::Atrac, res);
 		}
 	}
 
@@ -651,74 +651,74 @@ static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 b
 	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidateManaged here.
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "invalid atrac ID");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ATRACID, "invalid atrac ID");
 	}
 
 	if (readSize > bufferSize) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), readSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 	if (track.codecType != atracContextTypes[atracID]) {
 		// TODO: Should this not change the buffer size?
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
 	}
 
 	ret = atrac->SetData(track, buffer, readSize, bufferSize, 2);
 	if (ret < 0) {
 		// Must not delay.
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 
 	// not sure the real delay time
-	return hleDelayResult(hleLogDebug(Log::ME, ret), "atrac set data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, ret), "atrac set data", 100);
 }
 
 static u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
-	return hleLogDebugOrError(Log::ME, atrac->SetSecondBuffer(secondBuffer, secondBufferSize));
+	return hleLogDebugOrError(Log::Atrac, atrac->SetSecondBuffer(secondBuffer, secondBufferSize));
 }
 
 static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), bufferSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 	if (track.codecType != atracContextTypes[atracID]) {
 		// TODO: Should this not change the buffer size?
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
 	}
 
 	ret = atrac->SetData(track, buffer, bufferSize, bufferSize, 2);
 	if (ret < 0) {
 		// Must not delay.
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 
-	return hleDelayResult(hleLogDebug(Log::ME, ret), "atrac set data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, ret), "atrac set data", 100);
 }
 
 static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 	// A large value happens in Tales of VS, and isn't handled somewhere properly as a u32.
 	// It's impossible for it to be that big anyway, so cap it.
 	if (bufferSize < 0) {
-		WARN_LOG(Log::ME, "sceAtracSetDataAndGetID(%08x, %08x): negative bufferSize", buffer, bufferSize);
+		WARN_LOG(Log::Atrac, "sceAtracSetDataAndGetID(%08x, %08x): negative bufferSize", buffer, bufferSize);
 		bufferSize = 0x10000000;
 	}
 
@@ -728,51 +728,51 @@ static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 	// This is needed in Tomb Raider Legend (#20145).
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), bufferSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	int atracID = AllocAndRegisterAtrac(track.codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
 	ret = atracContexts[atracID]->SetData(track, buffer, bufferSize, bufferSize, 2);
 	if (ret < 0) {
 		UnregisterAndDeleteAtrac(atracID);
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 
-	return hleDelayResult(hleLogDebug(Log::ME, atracID), "atrac set data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, atracID), "atrac set data", 100);
 }
 
 static int sceAtracSetHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize) {
 	if (readSize > bufferSize) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), readSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	int atracID = AllocAndRegisterAtrac(track.codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
 	ret = atracContexts[atracID]->SetData(track, buffer, readSize, bufferSize, 2);
 	if (ret < 0) {
 		UnregisterAndDeleteAtrac(atracID);
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 
-	return hleDelayResult(hleLogDebug(Log::ME, atracID), "atrac set data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, atracID), "atrac set data", 100);
 }
 
 static u32 sceAtracStartEntry() {
-	ERROR_LOG_REPORT(Log::ME, "UNIMPL sceAtracStartEntry()");
+	ERROR_LOG_REPORT(Log::Atrac, "UNIMPL sceAtracStartEntry()");
 	return 0;
 }
 
@@ -780,21 +780,21 @@ static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	int ret = atrac->SetLoopNum(loopNum);
 	if (ret == SCE_ERROR_ATRAC_NO_LOOP_INFORMATION && (loopNum == -1 || loopNum == 0)) {
 		// Not really an issue
-		return hleLogDebug(Log::ME, ret);
+		return hleLogDebug(Log::Atrac, ret);
 	}
-	return hleLogDebugOrError(Log::ME, ret);
+	return hleLogDebugOrError(Log::Atrac, ret);
 }
 
 static int sceAtracReinit(int at3Count, int at3plusCount) {
 	for (int i = 0; i < PSP_MAX_ATRAC_IDS; ++i) {
 		if (atracContexts[i] != nullptr) {
-			return hleReportError(Log::ME, SCE_KERNEL_ERROR_BUSY, "cannot reinit while IDs in use");
+			return hleReportError(Log::Atrac, SCE_KERNEL_ERROR_BUSY, "cannot reinit while IDs in use");
 		}
 	}
 
@@ -805,7 +805,7 @@ static int sceAtracReinit(int at3Count, int at3plusCount) {
 	// This seems to deinit things.  Mostly, it cause a reschedule on next deinit (but -1, -1 does not.)
 	if (at3Count == 0 && at3plusCount == 0) {
 		atracInited = false;
-		return hleDelayResult(hleLogInfo(Log::ME, 0, "deinit"), "atrac reinit", 200);
+		return hleDelayResult(hleLogInfo(Log::Atrac, 0, "deinit"), "atrac reinit", 200);
 	}
 
 	// First, ATRAC3+.  These IDs seem to cost double (probably memory.)
@@ -827,10 +827,10 @@ static int sceAtracReinit(int at3Count, int at3plusCount) {
 	int result = space >= 0 ? 0 : (int)SCE_KERNEL_ERROR_OUT_OF_MEMORY;
 	if (atracInited || next == 0) {
 		atracInited = true;
-		return hleLogInfo(Log::ME, result);
+		return hleLogInfo(Log::Atrac, result);
 	} else {
 		atracInited = true;
-		return hleDelayResult(hleLogInfo(Log::ME, result), "atrac reinit", 400);
+		return hleDelayResult(hleLogInfo(Log::Atrac, result), "atrac reinit", 400);
 	}
 }
 
@@ -838,13 +838,13 @@ static int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 	if (Memory::IsValidAddress(outputChanPtr)) {
 		Memory::WriteUnchecked_U32(atrac->GetOutputChannels(), outputChanPtr);
-		return hleLogDebug(Log::ME, 0);
+		return hleLogDebug(Log::Atrac, 0);
 	} else {
-		return hleLogError(Log::ME, 0, "invalid address");
+		return hleLogError(Log::Atrac, 0, "invalid address");
 	}
 }
 
@@ -852,37 +852,37 @@ static int sceAtracIsSecondBufferNeeded(int atracID) {
 	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
-		return hleLogError(Log::ME, err);
+		return hleLogError(Log::Atrac, err);
 	}
 
 	// Note that this returns true whether the buffer is already set or not.
 	int needed = atrac->BufferState() == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER ? 1 : 0;
-	return hleLogDebug(Log::ME, needed);
+	return hleLogDebug(Log::Atrac, needed);
 }
 
 static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
 	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidate* here.
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
 	}
 	if (readSize > bufferSize) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), readSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	ret = atrac->SetData(track, buffer, readSize, bufferSize, 1);
 	if (ret < 0 && ret != SCE_ERROR_ATRAC_NOT_MONO) {
 		// Must not delay.
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
+	return hleDelayResult(hleLogDebugOrError(Log::Atrac, ret), "atrac set data mono", 100);
 }
 
 // Note: This doesn't seem to be part of any available libatrac3plus library.
@@ -892,23 +892,23 @@ static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidate* here.
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), bufferSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	ret = atrac->SetData(track, buffer, bufferSize, bufferSize, 1);
 	if (ret < 0 && ret != SCE_ERROR_ATRAC_NOT_MONO) {
 		// Must not delay.
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 	// It's OK if this fails, at least with NO_MONO...
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
+	return hleDelayResult(hleLogDebugOrError(Log::Atrac, ret), "atrac set data mono", 100);
 }
 
 // Note: This doesn't seem to be part of any available libatrac3plus library.
@@ -918,53 +918,53 @@ static int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), bufferSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	if (track.channels != 1) {
-		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
+		return hleReportError(Log::Atrac, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	}
 
 	int atracID = AllocAndRegisterAtrac(track.codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
 	ret = atracContexts[atracID]->SetData(track, buffer, bufferSize, bufferSize, 1);
 	if (ret < 0 && ret != SCE_ERROR_ATRAC_NOT_MONO) {
 		UnregisterAndDeleteAtrac(atracID);
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
-	return hleDelayResult(hleLogDebugOrError(Log::ME, atracID), "atrac set data", 100);
+	return hleDelayResult(hleLogDebugOrError(Log::Atrac, atracID), "atrac set data", 100);
 }
 
 static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize) {
 	if (readSize > bufferSize) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), readSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	if (track.channels != 1) {
-		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
+		return hleReportError(Log::Atrac, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	}
 
 	int atracID = AllocAndRegisterAtrac(track.codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
 	ret = atracContexts[atracID]->SetData(track, buffer, readSize, bufferSize, 1);
 	if (ret < 0 && ret != SCE_ERROR_ATRAC_NOT_MONO) {
 		UnregisterAndDeleteAtrac(atracID);
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
-	return hleDelayResult(hleLogDebug(Log::ME, atracID), "atrac set data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, atracID), "atrac set data", 100);
 }
 
 static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, u32 metadataSizeAddr) {
@@ -972,47 +972,47 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), bufferSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	int atracID = AllocAndRegisterAtrac(track.codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
 	ret = atracContexts[atracID]->SetData(track, buffer, bufferSize, bufferSize, 2);
 	if (ret < 0) {
 		UnregisterAndDeleteAtrac(atracID);
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 
-	return hleDelayResult(hleLogDebug(Log::ME, atracID), "atrac set aa3 data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, atracID), "atrac set aa3 data", 100);
 }
 
 static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize, u32 fileSize) {
 	if (readSize > bufferSize) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_INCORRECT_READ_SIZE, "read size too large");
 	}
 
 	Track track;
 	std::string error;
 	int ret = AnalyzeAtracTrack(Memory::GetPointerOrNull(buffer), readSize, &track, &error);
 	if (ret < 0) {
-		return hleLogError(Log::ME, ret, "%s", error.c_str());
+		return hleLogError(Log::Atrac, ret, "%s", error.c_str());
 	}
 
 	int atracID = AllocAndRegisterAtrac(track.codecType);
 	if (atracID < 0) {
-		return hleLogError(Log::ME, atracID, "no free ID");
+		return hleLogError(Log::Atrac, atracID, "no free ID");
 	}
 
 	ret = atracContexts[atracID]->SetData(track, buffer, readSize, bufferSize, 2);
 	if (ret < 0) {
 		UnregisterAndDeleteAtrac(atracID);
-		return hleLogError(Log::ME, ret);
+		return hleLogError(Log::Atrac, ret);
 	}
 
-	return hleDelayResult(hleLogDebug(Log::ME, atracID), "atrac set data", 100);
+	return hleDelayResult(hleLogDebug(Log::Atrac, atracID), "atrac set data", 100);
 }
 
 // TODO: Should see if these are stored contiguously in memory somewhere, or if there really are
@@ -1020,23 +1020,23 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 static u32 _sceAtracGetContextAddress(int atracID) {
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return hleLogError(Log::ME, 0, "bad atrac id");
+		return hleLogError(Log::Atrac, 0, "bad atrac id");
 	}
 
 	// Only the old context needs this. The new one will always have a context pointer.
 	atrac->NotifyGetContextAddress();
-	return hleLogDebug(Log::ME, atrac->context_.ptr);
+	return hleLogDebug(Log::Atrac, atrac->context_.ptr);
 }
 
 static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
 	}
 
 	if (!Memory::IsValidRange(paramsAddr, 12)) {
 		// The real library will probably just crash here.
-		return hleReportError(Log::ME, 0, "invalid pointers");
+		return hleReportError(Log::Atrac, 0, "invalid pointers");
 	}
 
 	auto params = PSPPointer<Atrac3LowLevelParams>::Create(paramsAddr);
@@ -1047,7 +1047,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	const char *codecName = codecType == PSP_CODEC_AT3 ? "atrac3" : "atrac3+";
 	const char *encodedChannelName = params->encodedChannels == 1 ? "mono" : "stereo";
 	const char *outputChannelName = params->outputChannels == 1 ? "mono" : "stereo";
-	return hleLogInfo(Log::ME, 0, "%s %s->%s audio", codecName, encodedChannelName, outputChannelName);
+	return hleLogInfo(Log::Atrac, 0, "%s %s->%s audio", codecName, encodedChannelName, outputChannelName);
 }
 
 static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
@@ -1058,12 +1058,12 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
+		return hleLogError(Log::Atrac, SCE_ERROR_ATRAC_BAD_ATRACID, "bad atrac ID");
 	}
 
 	if (!srcp.IsValid() || !srcConsumed.IsValid() || !outp.IsValid() || !outWritten.IsValid()) {
 		// TODO: Returning zero as code was before.  Needs testing.
-		return hleReportError(Log::ME, 0, "invalid pointers");
+		return hleReportError(Log::Atrac, 0, "invalid pointers");
 	}
 
 	int bytesConsumed = 0;
@@ -1078,7 +1078,7 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 	}
 
 	NotifyMemInfo(MemBlockFlags::WRITE, samplesAddr, bytesWritten, "AtracLowLevelDecode");
-	return hleDelayResult(hleLogDebug(Log::ME, retval), "low level atrac decode data", atracDecodeDelay);
+	return hleDelayResult(hleLogDebug(Log::Atrac, retval), "low level atrac decode data", atracDecodeDelay);
 }
 
 // These three are the external interface used by sceSas' AT3 integration.
@@ -1092,7 +1092,7 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
-		WARN_LOG(Log::ME, "bad atrac ID");
+		WARN_LOG(Log::Atrac, "bad atrac ID");
 	}
 	return atrac->EnqueueForSas(bufPtr, bytesToAdd);
 }
@@ -1100,7 +1100,7 @@ u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 void AtracSasDecodeData(int atracID, u8* outbuf, int *SamplesNum, int *finish) {
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
-		WARN_LOG(Log::ME, "bad atrac ID");
+		WARN_LOG(Log::Atrac, "bad atrac ID");
 	}
 	// NOTE: If streaming, this will write 0xFFFFFFFF to secondBuffer in the context when close to running
 	// out of data. It'll then expect __sceSasConcatenateATRAC3 to concatenate a new buffer, which cannot

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -385,7 +385,7 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 	// Note: If we error here, it's because of the internal SkipFrames.
 	// We delayresult if we skip frames, which indeed can happen.
 	bool delay = false;
-	int ret = atrac->GetResetBufferInfo(bufferInfo, sample, &delay);
+	int ret = atrac->GetBufferInfoForResetting(bufferInfo, sample, &delay);
 	if (delay) {
 		return hleDelayResult(hleLogDebugOrError(Log::Atrac, ret), "getreset_frameskip", 300);
 	} else {

--- a/Core/HLE/sceReg.cpp
+++ b/Core/HLE/sceReg.cpp
@@ -486,6 +486,8 @@ const KeyValue ROOT[] = {
 	{ "SYSPROFILE", ValueType::DIR, "", ARRAY_SIZE(tree_SYSPROFILE), tree_SYSPROFILE },
 };
 
+// Updater checks for CONFIG/SYSTEM/XMB.
+
 void __RegInit() {
 	g_openRegistryMode = 0;
 	g_handleGen = 1337;
@@ -522,7 +524,7 @@ static const KeyValue *LookupCategory(std::string_view path, int *count) {
 			}
 		}
 		if (!found) {
-			WARN_LOG(Log::sceReg, "Path not found: %.*s", (int)path.size(), path.data());
+			WARN_LOG(Log::sceReg, "LookupCategory: Path not found: %.*s", (int)path.size(), path.data());
 			return nullptr;
 		}
 	}

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -235,6 +235,7 @@ void JitBlockCache::RemoveBlockMap(int block_num) {
 		block_map_.erase(it);
 	} else {
 		// It wasn't in there, or it has the wrong key.  Let's search...
+		// TODO: This is O(n), so O(n^2) when called for every block.
 		for (auto it = block_map_.begin(); it != block_map_.end(); ++it) {
 			if (it->second == (u32)block_num) {
 				block_map_.erase(it);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -295,7 +295,7 @@ static bool CPU_Init(FileLoader *fileLoader, IdentifiedFileType type, std::strin
 			// TODO: Better would be to check that it was loaded successfully.
 			if (!File::Exists(g_CoreParameter.fileToStart / INDEX_FILENAME)) {
 				auto sc = GetI18NCategory(I18NCat::SCREEN);
-				g_OSD.Show(OSDType::MESSAGE_CENTERED_WARNING, sc->T("ExtractedIsoWarning", "Extracted ISOs often don't work.\nPlay the ISO file directly."), g_CoreParameter.fileToStart.ToVisualString(), 7.0f);
+				g_OSD.Show(OSDType::MESSAGE_WARNING, sc->T("ExtractedIsoWarning", "Extracted ISOs often don't work.\nPlay the ISO file directly."), g_CoreParameter.fileToStart.ToVisualString(), 7.0f);
 			} else {
 				INFO_LOG(Log::Loader, "Extracted ISO loaded without warning - %s is present.", INDEX_FILENAME.c_str());
 			}

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -950,7 +950,7 @@ void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, std::string_view nam
 	fwrite(dataPtr, sizeof(u8), lengthToWrite, file);
 	fclose(file);
 
-	INFO_LOG(Log::sceModule, "Successfully wrote %s to %s", DumpFileTypeToString(type), fullPath.c_str());
+	INFO_LOG(Log::sceModule, "Successfully wrote %s to %s", DumpFileTypeToString(type), fullPath.ToVisualString().c_str());
 
 	char *path = new char[strlen(fullPath.c_str()) + 1];
 	strcpy(path, fullPath.c_str());

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1096,6 +1096,14 @@ void DrawMediaDecodersView(ImConfig &cfg, ImControl &control) {
 					ImGui::Checkbox("", mutePtr);
 				}
 				ImGui::TableNextColumn();
+
+				const AtracBase *ctx = __AtracGetCtx(i, &codecType);
+				if (!ctx) {
+					// Nothing more we can display about uninitialized contexts.
+					ImGui::PopID();
+					continue;
+				}
+
 				switch (codecType) {
 				case 0:
 					ImGui::TextUnformatted("-");  // Uninitialized
@@ -1111,12 +1119,6 @@ void DrawMediaDecodersView(ImConfig &cfg, ImControl &control) {
 					break;
 				}
 
-				const AtracBase *ctx = __AtracGetCtx(i, &codecType);
-				if (!ctx) {
-					// Nothing more we can display about uninitialized contexts.
-					ImGui::PopID();
-					continue;
-				}
 				ImGui::TableNextColumn();
 				ImGui::TextUnformatted(AtracStatusToString(ctx->BufferState()));
 				ImGui::TableNextColumn();

--- a/ext/imgui/imgui_impl_platform.cpp
+++ b/ext/imgui/imgui_impl_platform.cpp
@@ -247,6 +247,10 @@ ImGuiKey KeyCodeToImGui(InputKeyCode keyCode) {
 	case NKCODE_EXT_PRINTSCREEN:
 		return ImGuiKey_PrintScreen;
 
+	case NKCODE_EXT_PIPE:
+		// No valid mapping exists.
+		return ImGuiKey_None;
+
 	default:
 		WARN_LOG(Log::System, "Unmapped ImGui keycode conversion from %d", keyCode);
 	 	return ImGuiKey_None;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -506,7 +506,7 @@ int main(int argc, const char* argv[])
 	g_Config.iDumpFileTypes = 0;
 	g_Config.bEnableSound = false;
 	g_Config.bFirstRun = false;
-	g_Config.bIgnoreBadMemAccess = false;
+	g_Config.bIgnoreBadMemAccess = true;  // NOTE: A few tests rely on this, which is BAD: threads/mbx/refer/refer , threads/mbx/send/send, threads/vtimers/interrupt
 	// Never report from tests.
 	g_Config.sReportHost.clear();
 	g_Config.bAutoSaveSymbolMap = false;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -503,9 +503,10 @@ int main(int argc, const char* argv[])
 	coreParameter.pixelHeight = 272;
 	coreParameter.fastForward = true;
 
+	g_Config.iDumpFileTypes = 0;
 	g_Config.bEnableSound = false;
 	g_Config.bFirstRun = false;
-	g_Config.bIgnoreBadMemAccess = true;
+	g_Config.bIgnoreBadMemAccess = false;
 	// Never report from tests.
 	g_Config.sReportHost.clear();
 	g_Config.bAutoSaveSymbolMap = false;
@@ -542,6 +543,7 @@ int main(int argc, const char* argv[])
 	g_Config.internalDataDirectory.clear();
 	g_Config.bUseOldAtrac = oldAtrac;
 	g_Config.iForceEnableHLE = 0xFFFFFFFF;  // Run all modules as HLE. We don't have anything to load in this context.
+	// g_Config.bUseOldAtrac = true;
 
 	Path exePath = File::GetExeDirectory();
 	g_Config.flash0Directory = exePath / "assets/flash0";


### PR DESCRIPTION
Adds new log categories for sceAtrac and sceMpeg for easier log filtering.

Misc cleanup.

This is some changes I made while investigating an Atrac3 (non-plus) failure. The actual fix is separated out and will be submitted in a separate PR after this is in.