### PR TITLE
Atrac3 (non-plus): Fix some details

### DIFF
--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -934,7 +934,7 @@ int Atrac2::SetData(const Track &track, u32 bufferAddr, u32 readSize, u32 buffer
 	info.curFileOff = track.dataByteOffset;
 	info.streamOff = track.dataByteOffset;
 	info.streamDataByte = readSize - info.dataOff;
-	info.fileDataEnd = track.fileSize;
+	info.fileDataEnd = track.dataByteOffset + track.waveDataSize;
 	info.decodePos = info.firstValidSample;
 	info.numSkipFrames = info.firstValidSample / info.SamplesPerFrame();
 	// NOTE: we do not write into secondBuffer/secondBufferByte! they linger...

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -919,7 +919,12 @@ int Atrac2::SetData(const Track &track, u32 bufferAddr, u32 readSize, u32 buffer
 	info.buffer = bufferAddr;
 	info.bufferByte = bufferSize;
 	info.firstValidSample = track.FirstSampleOffsetFull();
-	info.endSample = track.endSample + info.firstValidSample;
+	if (track.codecType == PSP_CODEC_AT3) {
+		// NOTE: There's something weird going on with AT3 (non-plus) files.
+		info.firstValidSample += track.SamplesPerFrame();
+	}
+
+	info.endSample = track.endSample + track.FirstSampleOffsetFull();
 	if (track.loopStartSample != 0xFFFFFFFF) {
 		info.loopStart = track.loopStartSample;
 		info.loopEnd = track.loopEndSample;
@@ -930,7 +935,7 @@ int Atrac2::SetData(const Track &track, u32 bufferAddr, u32 readSize, u32 buffer
 	info.streamOff = track.dataByteOffset;
 	info.streamDataByte = readSize - info.dataOff;
 	info.fileDataEnd = track.fileSize;
-	info.decodePos = track.FirstSampleOffsetFull();
+	info.decodePos = info.firstValidSample;
 	info.numSkipFrames = info.firstValidSample / info.SamplesPerFrame();
 	// NOTE: we do not write into secondBuffer/secondBufferByte! they linger...
 

--- a/Core/Util/AtracTrack.cpp
+++ b/Core/Util/AtracTrack.cpp
@@ -213,6 +213,7 @@ int AnalyzeAtracTrack(const u8 *buffer, u32 size, Track *track, std::string *err
 				WARN_LOG(Log::ME, "Atrac data chunk extends beyond riff chunk");
 				track->fileSize = offset + chunkSize;
 			}
+			track->waveDataSize = dataChunkSize;
 		}
 		break;
 		}
@@ -319,5 +320,6 @@ int AnalyzeAA3Track(const u8 *buffer, u32 size, u32 fileSize, Track *track, std:
 		track->endSample = ((track->fileSize - track->dataByteOffset) / track->bytesPerFrame) * track->SamplesPerFrame();
 	}
 	track->endSample -= 1;
+	track->waveDataSize = track->fileSize - track->dataByteOffset;  // No other way to determine this in the AA3 format?
 	return 0;
 }

--- a/Core/Util/AtracTrack.h
+++ b/Core/Util/AtracTrack.h
@@ -54,6 +54,8 @@ struct Track {
 	// Does not take firstSampleOffset into account.
 	int endSample = -1;
 
+	int waveDataSize = 0;
+
 	// NOTE: The below CAN be written.
 	// Loop configuration. The PSP only supports one loop but we store them all.
 	std::vector<AtracLoopInfo> loopinfo;


### PR DESCRIPTION
With this, hardware testing of Atrac3 (non-plus) audio passes. This also fixes some issues reported with modded games, where some external tools are encoding Atrac3 files with a bad first packet, which gets ignored on the hardware.