### PR TITLE
Fix crash on second logo in Tony Hawk's Underground 2

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1244,6 +1244,13 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 
 	modinfo = (const PspModuleInfo *)Memory::GetPointerUnchecked(modinfoaddr);
 
+	// OK, even if it's an ELF module, it might be one we shouldn't fully load and execute!
+	// This is seen with mpeg.prx in Tony Hawk's Underground 2, see #20568.
+	if (ShouldHLEModule(modinfo->name)) {
+		// We load it, but at least we don't run any part of it.
+		module->isFake = true;
+	}
+
 	module->nm.nsegment = reader.GetNumSegments();
 	module->nm.attribute = modinfo->moduleAttrs;
 	module->nm.version[0] = modinfo->moduleVersion & 0xFF;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2074,7 +2074,7 @@ static u32 sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 retu
 			module->nm.status = MODULE_STATUS_STARTING;
 			module->waitingThreads.push_back(mwt);
 		}
-		return hleLogInfo(Log::sceModule, ret);
+		return hleLogInfo(Log::sceModule, ret, "'%.*s'", (int)sizeof(module->nm.name), module->nm.name);
 	}
 }
 


### PR DESCRIPTION
Strangely, this game loads an unencrypted `mpeg.prx`. In #20196 , I changed the mechanism for determining with modules to HLE, for development and debugging purposes. I missed this case there - after that change, we only checked encrypted modules for whether we should HLE them or not.

This fixes that.