### PR TITLE
Make the check for framebuffer copy targets slightly more lenient for tiny copies.

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2070,9 +2070,9 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 		if (!ignoreDstBuffer && dst >= vfb_address && (dst + size <= vfb_address + vfb_size || dst == vfb_address)) {
 			const u32 offset = dst - vfb_address;
 			const u32 yOffset = offset / vfb_byteStride;
-			if ((offset % vfb_byteStride) == 0 && (size == vfb_byteWidth || (size % vfb_byteStride) == 0)) {
+			if ((offset % vfb_byteStride) == 0 && (size <= vfb_byteWidth || (size % vfb_byteStride) == 0)) {
 				dstCandidate.y = yOffset;
-				dstCandidate.h = (size == vfb_byteWidth) ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
+				dstCandidate.h = (size <= vfb_byteWidth) ? 1 : std::min((u32)size / vfb_byteStride, (u32)vfb->height);
 				dstCandidates.push_back(dstCandidate);
 			}
 		}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1164,6 +1164,9 @@ ULES01510 = true
 # Activision Hits Remixed
 ULES00640 = true
 ULUS10186 = true
+# Fortix (#20436)
+NPUZ00016 = true
+NPEZ00096 = true
 
 [MemstickFixedFree]
 # Assassin's Creed : Bloodlines - issue #12761


### PR DESCRIPTION
Prevents a lot of duplicate framebuffer textures to be created (the game is doing something really stupid).

- Fixes #20556