### PR TITLE
Net Adhoc common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2252,6 +2252,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HLE/sceNet.h
 	Core/HLE/sceNet_lib.cpp
 	Core/HLE/sceNet_lib.h
+	Core/HLE/NetAdhocCommon.cpp
+	Core/HLE/NetAdhocCommon.h
 	Core/HLE/sceNetAdhoc.cpp
 	Core/HLE/sceNetAdhoc.h
 	Core/HLE/sceNetAdhocMatching.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -627,6 +627,7 @@
     <ClCompile Include="HLE\sceMpeg.cpp" />
     <ClCompile Include="HLE\sceNet.cpp" />
     <ClCompile Include="HLE\sceNet_lib.cpp" />
+    <ClCompile Include="HLE\NetAdhocCommon.cpp" />
     <ClCompile Include="HLE\sceNetAdhoc.cpp" />
     <ClCompile Include="HLE\sceNetAdhocMatching.cpp" />
     <ClCompile Include="HLE\sceNp.cpp" />
@@ -1140,6 +1141,7 @@
     <ClInclude Include="HLE\sceMpeg.h" />
     <ClInclude Include="HLE\sceNet.h" />
     <ClInclude Include="HLE\sceNet_lib.h" />
+    <ClInclude Include="HLE\NetAdhocCommon.h" />
     <ClInclude Include="HLE\sceNetAdhoc.h" />
     <ClInclude Include="HLE\sceNetAdhocMatching.h" />
     <ClInclude Include="HLE\sceNp.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -520,6 +520,9 @@
     <ClCompile Include="HLE\sceHeap.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
+    <ClCompile Include="HLE\NetAdhocCommon.cpp">
+      <Filter>HLE\Libraries</Filter>
+    </ClCompile>
     <ClCompile Include="HLE\sceNetAdhoc.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
@@ -1756,6 +1759,9 @@
       <Filter>HLE\Kernel</Filter>
     </ClInclude>
     <ClInclude Include="HLE\sceHeap.h">
+      <Filter>HLE\Libraries</Filter>
+    </ClInclude>
+    <ClInclude Include="HLE\NetAdhocCommon.h">
       <Filter>HLE\Libraries</Filter>
     </ClInclude>
     <ClInclude Include="HLE\sceNetAdhoc.h">

--- a/Core/HLE/NetAdhocCommon.cpp
+++ b/Core/HLE/NetAdhocCommon.cpp
@@ -33,3 +33,14 @@ void netAdhocValidateLoopMemory() {
             Memory::Memcpy(dummyThreadHackAddr, dummyThreadCode, sizeof(dummyThreadCode));
     }
 }
+
+int netAdhocEnterGameModeTimeout = 15000000; // 15 sec as default timeout, to wait for all players to join
+int adhocDefaultTimeout = 5000000; //2000000 usec // For some unknown reason, sometimes it tooks more than 2 seconds for Adhocctl Init to connect to AdhocServer on localhost (normally only 10 ms), and sometimes it tooks more than 1 seconds for built-in AdhocServer to be ready (normally only 1 ms)
+
+int adhocDefaultDelay = 10000; //10000
+int adhocExtraDelay = 20000; //20000
+int adhocEventPollDelay = 100000; //100000; // Same timings with PSP_ADHOCCTL_RECV_TIMEOUT ?
+int adhocEventDelay = 2000000; //2000000 on real PSP ?
+std::recursive_mutex adhocEvtMtx;
+
+int IsAdhocctlInCB = 0;

--- a/Core/HLE/NetAdhocCommon.cpp
+++ b/Core/HLE/NetAdhocCommon.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2025- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/HLE/NetAdhocCommon.h"

--- a/Core/HLE/NetAdhocCommon.cpp
+++ b/Core/HLE/NetAdhocCommon.cpp
@@ -16,3 +16,20 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Core/HLE/NetAdhocCommon.h"
+
+#include "sceKernelMemory.h"
+#include "Core/MemMapHelpers.h"
+
+u32 dummyThreadHackAddr = 0;
+u32_le dummyThreadCode[3];
+
+
+void netAdhocValidateLoopMemory() {
+    // Allocate Memory if it wasn't valid/allocated after loaded from old SaveState
+    if (!dummyThreadHackAddr || strcmp("dummythreadhack", kernelMemory.GetBlockTag(dummyThreadHackAddr)) != 0) {
+        u32 blockSize = sizeof(dummyThreadCode);
+        dummyThreadHackAddr = kernelMemory.Alloc(blockSize, false, "dummythreadhack");
+        if (dummyThreadHackAddr)
+            Memory::Memcpy(dummyThreadHackAddr, dummyThreadCode, sizeof(dummyThreadCode));
+    }
+}

--- a/Core/HLE/NetAdhocCommon.cpp
+++ b/Core/HLE/NetAdhocCommon.cpp
@@ -35,12 +35,14 @@ void netAdhocValidateLoopMemory() {
 }
 
 int netAdhocEnterGameModeTimeout = 15000000; // 15 sec as default timeout, to wait for all players to join
-int adhocDefaultTimeout = 5000000; //2000000 usec // For some unknown reason, sometimes it tooks more than 2 seconds for Adhocctl Init to connect to AdhocServer on localhost (normally only 10 ms), and sometimes it tooks more than 1 seconds for built-in AdhocServer to be ready (normally only 1 ms)
 
+// TODO: constify
+int adhocDefaultTimeout = 5000000; //2000000 usec // For some unknown reason, sometimes it tooks more than 2 seconds for Adhocctl Init to connect to AdhocServer on localhost (normally only 10 ms), and sometimes it tooks more than 1 seconds for built-in AdhocServer to be ready (normally only 1 ms)
 int adhocDefaultDelay = 10000; //10000
 int adhocExtraDelay = 20000; //20000
 int adhocEventPollDelay = 100000; //100000; // Same timings with PSP_ADHOCCTL_RECV_TIMEOUT ?
 int adhocEventDelay = 2000000; //2000000 on real PSP ?
+
 std::recursive_mutex adhocEvtMtx;
 
 int IsAdhocctlInCB = 0;
@@ -48,3 +50,5 @@ int IsAdhocctlInCB = 0;
 
 u32 matchingThreadHackAddr = 0;
 u32_le matchingThreadCode[3];
+
+bool g_adhocServerConnected = false;

--- a/Core/HLE/NetAdhocCommon.cpp
+++ b/Core/HLE/NetAdhocCommon.cpp
@@ -36,13 +36,6 @@ void netAdhocValidateLoopMemory() {
 
 int netAdhocEnterGameModeTimeout = 15000000; // 15 sec as default timeout, to wait for all players to join
 
-// TODO: constify
-int adhocDefaultTimeout = 5000000; //2000000 usec // For some unknown reason, sometimes it tooks more than 2 seconds for Adhocctl Init to connect to AdhocServer on localhost (normally only 10 ms), and sometimes it tooks more than 1 seconds for built-in AdhocServer to be ready (normally only 1 ms)
-int adhocDefaultDelay = 10000; //10000
-int adhocExtraDelay = 20000; //20000
-int adhocEventPollDelay = 100000; //100000; // Same timings with PSP_ADHOCCTL_RECV_TIMEOUT ?
-int adhocEventDelay = 2000000; //2000000 on real PSP ?
-
 std::recursive_mutex adhocEvtMtx;
 
 int IsAdhocctlInCB = 0;

--- a/Core/HLE/NetAdhocCommon.cpp
+++ b/Core/HLE/NetAdhocCommon.cpp
@@ -44,3 +44,7 @@ int adhocEventDelay = 2000000; //2000000 on real PSP ?
 std::recursive_mutex adhocEvtMtx;
 
 int IsAdhocctlInCB = 0;
+
+
+u32 matchingThreadHackAddr = 0;
+u32_le matchingThreadCode[3];

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -28,11 +28,14 @@ extern u32_le dummyThreadCode[3];
 void netAdhocValidateLoopMemory();
 
 extern int netAdhocEnterGameModeTimeout;
+
+// TODO: constify
 extern int adhocDefaultTimeout; //3000000 usec
 extern int adhocDefaultDelay; //10000
 extern int adhocExtraDelay; //20000
 extern int adhocEventPollDelay; //100000; // Seems to be the same with PSP_ADHOCCTL_RECV_TIMEOUT
 extern int adhocEventDelay; //1000000
+
 extern std::recursive_mutex adhocEvtMtx;
 
 // TODO: this one is broken, perhaps delete it entirely?
@@ -41,3 +44,5 @@ extern int IsAdhocctlInCB;
 
 extern u32 matchingThreadHackAddr;
 extern u32_le matchingThreadCode[3];
+
+extern bool g_adhocServerConnected;

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2025- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -17,3 +17,10 @@
 
 #pragma once
 
+#include "CommonTypes.h"
+#include "Swap.h"
+
+extern u32 dummyThreadHackAddr;
+extern u32_le dummyThreadCode[3];
+
+void netAdhocValidateLoopMemory();

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -29,12 +29,18 @@ void netAdhocValidateLoopMemory();
 
 extern int netAdhocEnterGameModeTimeout;
 
-// TODO: constify
-extern int adhocDefaultTimeout; //3000000 usec
-extern int adhocDefaultDelay; //10000
-extern int adhocExtraDelay; //20000
-extern int adhocEventPollDelay; //100000; // Seems to be the same with PSP_ADHOCCTL_RECV_TIMEOUT
-extern int adhocEventDelay; //1000000
+// Old comments regarding the value of adhocDefaultTimeout:
+// 3000000 usec
+//2000000 usec // For some unknown reason, sometimes it tooks more than 2 seconds for Adhocctl Init to connect to AdhocServer on localhost (normally only 10 ms), and sometimes it tooks more than 1 seconds for built-in AdhocServer to be ready (normally only 1 ms)
+constexpr int adhocDefaultTimeout = 5000000;
+
+constexpr int adhocDefaultDelay = 10000; //10000
+constexpr int adhocExtraDelay = 20000; //20000
+constexpr int adhocEventPollDelay = 100000; //100000; // Seems to be the same with PSP_ADHOCCTL_RECV_TIMEOUT
+
+// Old comments regarding the value of adhocEventDelay:
+//1000000
+constexpr int adhocEventDelay = 2000000; //2000000 on real PSP ?
 
 extern std::recursive_mutex adhocEvtMtx;
 

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -20,7 +20,20 @@
 #include "CommonTypes.h"
 #include "Swap.h"
 
+#include <mutex>
+
 extern u32 dummyThreadHackAddr;
 extern u32_le dummyThreadCode[3];
 
 void netAdhocValidateLoopMemory();
+
+extern int netAdhocEnterGameModeTimeout;
+extern int adhocDefaultTimeout; //3000000 usec
+extern int adhocDefaultDelay; //10000
+extern int adhocExtraDelay; //20000
+extern int adhocEventPollDelay; //100000; // Seems to be the same with PSP_ADHOCCTL_RECV_TIMEOUT
+extern int adhocEventDelay; //1000000
+extern std::recursive_mutex adhocEvtMtx;
+
+// TODO: this one is broken, perhaps delete it entirely?
+extern int IsAdhocctlInCB;

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -37,3 +37,7 @@ extern std::recursive_mutex adhocEvtMtx;
 
 // TODO: this one is broken, perhaps delete it entirely?
 extern int IsAdhocctlInCB;
+
+
+extern u32 matchingThreadHackAddr;
+extern u32_le matchingThreadCode[3];

--- a/Core/HLE/NetAdhocCommon.h
+++ b/Core/HLE/NetAdhocCommon.h
@@ -52,3 +52,5 @@ extern u32 matchingThreadHackAddr;
 extern u32_le matchingThreadCode[3];
 
 extern bool g_adhocServerConnected;
+
+constexpr u32 defaultLastRecvDelta = 10000; //10000 usec worked well for games published by Falcom (ie. Ys vs Sora Kiseki, Vantage Master Portable)

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -52,7 +52,9 @@
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceNetAdhoc.h"
 #include "Core/Instance.h"
-#include "proAdhoc.h" 
+#include "proAdhoc.h"
+
+#include "Core/HLE/NetAdhocCommon.h"
 
 #ifdef _WIN32
 #undef errno

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -63,7 +63,6 @@
 // TODO: Make accessor functions instead, and throw all this state in a struct.
 bool netAdhocInited;
 bool netAdhocctlInited;
-bool g_adhocServerConnected = false;
 
 #define DISCOVER_DURATION_US	2000000 // 2 seconds is probably the normal time it takes for PSP to connect to a group (ie. similar to NetconfigDialog time)
 u64 netAdhocDiscoverStartTime = 0;

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -73,24 +73,14 @@ SceNetAdhocDiscoverParam* netAdhocDiscoverParam = nullptr;
 u32 netAdhocDiscoverBufAddr = 0;
 
 bool netAdhocGameModeEntered = false;
-int netAdhocEnterGameModeTimeout = 15000000; // 15 sec as default timeout, to wait for all players to join
-
-int adhocDefaultTimeout = 5000000; //2000000 usec // For some unknown reason, sometimes it tooks more than 2 seconds for Adhocctl Init to connect to AdhocServer on localhost (normally only 10 ms), and sometimes it tooks more than 1 seconds for built-in AdhocServer to be ready (normally only 1 ms)
-int adhocDefaultDelay = 10000; //10000
-int adhocExtraDelay = 20000; //20000
-int adhocEventPollDelay = 100000; //100000; // Same timings with PSP_ADHOCCTL_RECV_TIMEOUT ?
-int adhocMatchingEventDelay = 30000; //30000
-int adhocEventDelay = 2000000; //2000000 on real PSP ?
 
 constexpr u32 defaultLastRecvDelta = 10000; //10000 usec worked well for games published by Falcom (ie. Ys vs Sora Kiseki, Vantage Master Portable)
 
 SceUID threadAdhocID;
 
-std::recursive_mutex adhocEvtMtx;
+// TODO: move to "sceNetAdhocctl.h/.cpp"
 std::deque<std::pair<u32, u32>> adhocctlEvents;
 std::map<int, AdhocctlHandler> adhocctlHandlers;
-
-int IsAdhocctlInCB = 0;
 
 int adhocctlNotifyEvent = -1;
 int adhocctlStateEvent = -1;

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -78,10 +78,8 @@ constexpr u32 defaultLastRecvDelta = 10000; //10000 usec worked well for games p
 
 SceUID threadAdhocID;
 
-// TODO: move to "sceNetAdhocctl.h/.cpp"
 std::deque<std::pair<u32, u32>> adhocctlEvents;
 std::map<int, AdhocctlHandler> adhocctlHandlers;
-
 int adhocctlNotifyEvent = -1;
 int adhocctlStateEvent = -1;
 int adhocSocketNotifyEvent = -1;
@@ -90,9 +88,6 @@ std::map<u64, AdhocSocketRequest> adhocSocketRequests;
 std::map<u64, AdhocSendTargets> sendTargetPeers;
 
 int gameModeNotifyEvent = -1;
-
-u32 matchingThreadHackAddr = 0;
-u32_le matchingThreadCode[3];
 
 int AcceptPtpSocket(int ptpId, int newsocket, sockaddr_in& peeraddr, SceNetEtherAddr* addr, u16_le* port);
 int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock);

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -73,8 +73,6 @@ u32 netAdhocDiscoverBufAddr = 0;
 
 bool netAdhocGameModeEntered = false;
 
-constexpr u32 defaultLastRecvDelta = 10000; //10000 usec worked well for games published by Falcom (ie. Ys vs Sora Kiseki, Vantage Master Portable)
-
 SceUID threadAdhocID;
 
 std::deque<std::pair<u32, u32>> adhocctlEvents;

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -102,7 +102,6 @@ void Register_sceNetAdhocDiscover();
 void Register_sceNetAdhocctl();
 
 
-u32_le __CreateHLELoop(u32_le* loopAddr, const char* sceFuncName, const char* hleFuncName, const char* tagName = NULL);
 void __NetAdhocInit();
 void __NetAdhocShutdown();
 void __NetAdhocDoState(PointerWrap &p);
@@ -110,6 +109,7 @@ void __UpdateAdhocctlHandlers(u32 flags, u32 error);
 
 bool __NetAdhocConnected();
 
+// TODO: expose these via "sceNetAdhocctl.h"
 // Called from netdialog (and from sceNetApctl)
 // NOTE: use hleCall for sceNet* ones!
 int sceNetAdhocctlGetState(u32 ptrToStatus);
@@ -125,6 +125,7 @@ int sceNetAdhocctlTerm();
 int NetAdhocctl_Term();
 int NetAdhocctl_GetState();
 int NetAdhocctl_Create(const char* groupName);
+
 int NetAdhoc_Term();
 
 // May need to use these from sceNet.cpp
@@ -144,8 +145,7 @@ extern int adhocEventDelay; //1000000
 extern std::recursive_mutex adhocEvtMtx;
 extern int IsAdhocctlInCB;
 
-extern u32 dummyThreadHackAddr;
-extern u32_le dummyThreadCode[3];
+
 extern u32 matchingThreadHackAddr;
 extern u32_le matchingThreadCode[3];
 

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -137,7 +137,7 @@ int NetAdhoc_Term();
 // May need to use these from sceNet.cpp
 extern bool netAdhocInited; // TODO: keep here
 extern bool netAdhocctlInited; // TODO: move to sceNetAdhocctl
-extern bool g_adhocServerConnected;
+
 extern bool netAdhocGameModeEntered;
 extern s32 netAdhocDiscoverStatus; // TODO: maybe move to sceNetAdhocDiscover?
 

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -23,12 +23,6 @@
 #ifdef _MSC_VER
 #pragma pack(push,1)
 #endif
-typedef struct SceNetAdhocDiscoverParam {
-	u32_le unknown1; // SleepMode? (ie. 0 on on Legend Of The Dragon, 1 on Dissidia 012)
-	char   groupName[ADHOCCTL_GROUPNAME_LEN];
-	u32_le unknown2; // size of something? (ie. 0x3c on Legend Of The Dragon, 0x14 on Dissidia 012) // Note: the param size is 0x14 may be it can contains extra data too?
-	u32_le result; // inited to 0?
-} PACK SceNetAdhocDiscoverParam;
 
 typedef struct ProductStruct { // Similar to SceNetAdhocctlAdhocId ?
 	s32_le unknown; // Unknown, set to 0 // Product Type ?
@@ -78,6 +72,14 @@ enum AdhocSocketRequestType : int
 	PDP_RECV = 6,
 	ADHOC_POLL_SOCKET = 7,
 };
+
+// TODO: maybe move these to sceNetAdhocDiscover?
+typedef struct SceNetAdhocDiscoverParam {
+    u32_le unknown1; // SleepMode? (ie. 0 on on Legend Of The Dragon, 1 on Dissidia 012)
+    char   groupName[ADHOCCTL_GROUPNAME_LEN];
+    u32_le unknown2; // size of something? (ie. 0x3c on Legend Of The Dragon, 0x14 on Dissidia 012) // Note: the param size is 0x14 may be it can contains extra data too?
+    u32_le result; // inited to 0?
+} PACK SceNetAdhocDiscoverParam;
 
 enum AdhocDiscoverStatus : int
 {
@@ -133,15 +135,11 @@ int NetAdhocctl_Create(const char* groupName);
 int NetAdhoc_Term();
 
 // May need to use these from sceNet.cpp
-extern bool netAdhocInited;
-extern bool netAdhocctlInited;
+extern bool netAdhocInited; // TODO: keep here
+extern bool netAdhocctlInited; // TODO: move to sceNetAdhocctl
 extern bool g_adhocServerConnected;
 extern bool netAdhocGameModeEntered;
-extern s32 netAdhocDiscoverStatus;
-
-
-extern u32 matchingThreadHackAddr;
-extern u32_le matchingThreadCode[3];
+extern s32 netAdhocDiscoverStatus; // TODO: maybe move to sceNetAdhocDiscover?
 
 // Exposing those for the matching routines
 // NOTE: use hleCall for sceNet* ones!

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -99,12 +99,16 @@ class PointerWrap;
 
 void Register_sceNetAdhoc();
 void Register_sceNetAdhocDiscover();
+
+// TODO: expose it via "sceNetAdhocctl.h"
 void Register_sceNetAdhocctl();
 
 
 void __NetAdhocInit();
 void __NetAdhocShutdown();
 void __NetAdhocDoState(PointerWrap &p);
+
+// TODO: expose it via "sceNetAdhocctl.h"
 void __UpdateAdhocctlHandlers(u32 flags, u32 error);
 
 bool __NetAdhocConnected();
@@ -134,16 +138,6 @@ extern bool netAdhocctlInited;
 extern bool g_adhocServerConnected;
 extern bool netAdhocGameModeEntered;
 extern s32 netAdhocDiscoverStatus;
-
-extern int netAdhocEnterGameModeTimeout;
-extern int adhocDefaultTimeout; //3000000 usec
-extern int adhocDefaultDelay; //10000
-extern int adhocExtraDelay; //20000
-extern int adhocEventPollDelay; //100000; // Seems to be the same with PSP_ADHOCCTL_RECV_TIMEOUT
-extern int adhocMatchingEventDelay; //30000
-extern int adhocEventDelay; //1000000
-extern std::recursive_mutex adhocEvtMtx;
-extern int IsAdhocctlInCB;
 
 
 extern u32 matchingThreadHackAddr;

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -72,8 +72,6 @@ void RestoreNetAdhocMatchingInited() {
 
 int netAdhocMatchingStarted = 0;
 
-constexpr u32 defaultLastRecvDelta = 10000; //10000 usec worked well for games published by Falcom (ie. Ys vs Sora Kiseki, Vantage Master Portable)
-
 
 void __UpdateMatchingHandler(const MatchingArgs &ArgsPtr) {
 	std::lock_guard<std::recursive_mutex> adhocGuard(adhocEvtMtx);

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -18,6 +18,7 @@
 
 #include "Core/HLE/sceNetAdhocMatching.h"
 #include "Core/HLE/sceNetAdhoc.h"
+#include "Core/HLE/NetAdhocCommon.h"
 
 #include <deque>
 #include <algorithm>
@@ -43,6 +44,8 @@ std::vector<SceUID> matchingThreads;
 std::deque<MatchingArgs> matchingEvents;
 
 bool netAdhocMatchingInited;
+int adhocMatchingEventDelay = 30000; //30000
+
 static bool savedNetAdhocMatchingInited; // the storage to use during the savestating routine in sceNetAdhoc.cpp
 
 void DoNetAdhocMatchingInited(PointerWrap &p) {

--- a/Core/HLE/sceNetAdhocMatching.h
+++ b/Core/HLE/sceNetAdhocMatching.h
@@ -44,3 +44,4 @@ void __NetAdhocMatchingInit();
 void __NetAdhocMatchingShutdown();
 
 extern bool netAdhocMatchingInited;
+extern int adhocMatchingEventDelay; //30000

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -36,6 +36,7 @@
 #include "Core/HLE/sceNetAdhoc.h"
 #include "Core/HLE/proAdhoc.h"
 #include "Core/HLE/sceNetAdhocMatching.h"
+#include "Core/HLE/NetAdhocCommon.h"
 #include "Common/System/Request.h"
 
 #include "Core/Util/AtracTrack.h"

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -47,6 +47,7 @@
 #include "Core/HLE/sceNet.h"
 #include "Core/HLE/sceNetInet.h"
 #include "Core/HLE/sceNetAdhoc.h"
+#include "Core/HLE/NetAdhocCommon.h"
 
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -214,6 +214,7 @@
     <ClInclude Include="..\..\Core\HLE\sceMt19937.h" />
     <ClInclude Include="..\..\Core\HLE\sceNet.h" />
     <ClInclude Include="..\..\Core\HLE\sceNet_lib.h" />
+    <ClInclude Include="..\..\Core\HLE\NetAdhocCommon.h" />
     <ClInclude Include="..\..\Core\HLE\sceNetAdhoc.h" />
     <ClInclude Include="..\..\Core\HLE\sceNetAdhocMatching.h" />
     <ClInclude Include="..\..\Core\HLE\sceNp.h" />
@@ -478,6 +479,7 @@
     <ClCompile Include="..\..\Core\HLE\sceMt19937.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNet.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNet_lib.cpp" />
+    <ClCompile Include="..\..\Core\HLE\NetAdhocCommon.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNetAdhoc.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNetAdhocMatching.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNp.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -126,6 +126,7 @@
     <ClCompile Include="..\..\Core\HLE\sceMt19937.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNet.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNet_lib.cpp" />
+    <ClCompile Include="..\..\Core\HLE\NetAdhocCommon.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNetAdhoc.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNetAdhocMatching.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNp.cpp" />
@@ -538,6 +539,7 @@
     <ClInclude Include="..\..\Core\HLE\sceMt19937.h" />
     <ClInclude Include="..\..\Core\HLE\sceNet.h" />
     <ClInclude Include="..\..\Core\HLE\sceNet_lib.h" />
+    <ClInclude Include="..\..\Core\HLE\NetAdhocCommon.h" />
     <ClInclude Include="..\..\Core\HLE\sceNetAdhoc.h" />
     <ClInclude Include="..\..\Core\HLE\sceNetAdhocMatching.h" />
     <ClInclude Include="..\..\Core\HLE\sceNp.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -708,6 +708,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/HLE/sceNet_lib.cpp \
   $(SRC)/Core/HLE/proAdhoc.cpp \
   $(SRC)/Core/HLE/proAdhocServer.cpp \
+  $(SRC)/Core/HLE/NetAdhocCommon.cpp \
   $(SRC)/Core/HLE/sceNetAdhoc.cpp \
   $(SRC)/Core/HLE/sceNetAdhocMatching.cpp \
   $(SRC)/Core/HLE/sceNetApctl.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -739,6 +739,7 @@ SOURCES_CXX += \
 	       $(COREDIR)/HLE/sceMpeg.cpp \
 	       $(COREDIR)/HLE/sceNet.cpp \
 	       $(COREDIR)/HLE/sceNet_lib.cpp \
+	       $(COREDIR)/HLE/NetAdhocCommon.cpp \
 	       $(COREDIR)/HLE/sceNetAdhoc.cpp \
 	       $(COREDIR)/HLE/sceNetAdhocMatching.cpp \
 	       $(COREDIR)/HLE/sceNetApctl.cpp \


### PR DESCRIPTION
Before January 2025, the files `sceNetAdhoc.h/.cpp` used to store the implementations of the firmware modules `sceNetAdhoc` (PTP/PDP sockets), `sceNetAdhocctl`, `sceNetAdhocMatching` and `sceNetAdhocDiscover` (also some gamemode stuff) and generic adhoc code that is used in many places. I have managed to rip the matching stuff out to a new pair of files (and refactored it later). While attempting to do the same with `sceNetAdhocctl`, I noticed that its functions need some stuff from `sceNetAdhoc`.
Fearing I would introduce some sort of cyclic dependency between `sceNetAdhoc` and `sceNetAdhocctl`, I've decided to move the generic adhoc code into the dedicated `NetAdhocCommon` files first. Really, if the files were called `Adhoc.h/.cpp`, it would have made sense to keep the configs there, but then again, the `sceNetAdhoc` module would have to be moved out...

I haven't decided if there's more to refactor, I want to know your feedback for the current changes (don't merge yet).