### PR TITLE
Add Colored Floating Symbols background animation, move static vars into classes

### DIFF
--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -168,6 +168,7 @@ enum class BackgroundAnimation {
 	WAVE = 3,
 	MOVING_BACKGROUND = 4,
 	BOUNCING_ICON = 5,
+	FLOATING_SYMBOLS_COLORED = 6,
 };
 
 // iOS only

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1179,7 +1179,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iNotificationPos, sy->T("Notification screen position"), positions, -1, ARRAY_SIZE(positions), I18NCat::DIALOG, screenManager()));
 
-	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves", "Moving background", "Bouncing icon" };
+	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves", "Moving background", "Bouncing icon", "Colored floating symbols" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iBackgroundAnimation, sy->T("UI background animation"), backgroundAnimations, 0, ARRAY_SIZE(backgroundAnimations), I18NCat::SYSTEM, screenManager()));
 
 	PopupMultiChoiceDynamic *theme = systemSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sThemeName, sy->T("Theme"), GetThemeInfoNames(), I18NCat::THEMES, screenManager()));


### PR DESCRIPTION
Improves #20211.

While working on the Bouncing Icon bg anim, I had noticed that Floating Symbols had (practically) unused code for this. I've added a bool member to control whether symbols should be colored, so the same class could be recycled.

I've chosen the alpha value so that it's also acceptable for most of the custom themes. A higher value means better visibility on custom themes but also more distraction from the foreground.

Also moved some global static vars for Floating Symbols and Moving Background inside their respective classes. (I hope this is fine in the same commit.)

![image](https://github.com/user-attachments/assets/b2b1a7d4-2783-4281-9e96-800695da2719)
