### PR TITLE
Detect and enable LSX/LASX on LoongArch based on compiler predefined macros.

### DIFF
--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -81,9 +81,15 @@
     //https://github.com/gcc-mirror/gcc/blob/master/gcc/config/loongarch/loongarch-c.cc
     #define PPSSPP_ARCH_LOONGARCH64 1
     #define PPSSPP_ARCH_64BIT 1
-    #define PPSSPP_ARCH_LOONGARCH64_LSX 1
-#endif
 
+    #if defined(__loongarch_asx)
+        #define PPSSPP_ARCH_LOONGARCH64_LASX 1
+    #endif
+
+    #if defined(__loongarch_asx) || defined(__loongarch_sx)
+        #define PPSSPP_ARCH_LOONGARCH64_LSX  1
+    #endif
+#endif
 // PLATFORM defines
 #if defined(_WIN32)
     // Covers both 32 and 64bit Windows


### PR DESCRIPTION
When attempting to compile for a LoongArch64 CPU without 128-bit vector instructions (LSX), I found that simply removing `add_compile_options(-mlsx)` in `CMakeLists.txt` was insufficient, as `PPSSPP_ARCH_LOONGARCH64_LSX` was still being defined by default. 
This change now properly detects and enables LSX/LASX support on LoongArch64 based on compiler predefined macros.