### PR TITLE
Windows: Remove the "inner" window

### DIFF
--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -140,7 +140,7 @@ bool CreateGraphicsBackend(std::string *error_message, GraphicsContext **ctx) {
 		return false;
 	}
 
-	if (graphicsContext->Init(MainWindow::GetHInstance(), MainWindow::GetDisplayHWND(), error_message)) {
+	if (graphicsContext->Init(MainWindow::GetHInstance(), MainWindow::GetHWND(), error_message)) {
 		*ctx = graphicsContext;
 		return true;
 	} else {

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -70,10 +70,8 @@ namespace MainWindow
 	void UpdateCommands();
 	void UpdateSwitchUMD();
 	void SetWindowTitle(const wchar_t *title);
-	void Redraw();
 	HWND GetHWND();
 	HINSTANCE GetHInstance();
-	HWND GetDisplayHWND();
 	void ToggleFullscreen(HWND hWnd, bool goingFullscreen);
 	void Minimize();
 	void SendToggleFullscreen(bool fullscreen);  // To be used off-thread

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -233,7 +233,7 @@ std::string System_GetProperty(SystemProperty prop) {
 	case SYSPROP_CLIPBOARD_TEXT:
 		{
 			std::string retval;
-			if (OpenClipboard(MainWindow::GetDisplayHWND())) {
+			if (OpenClipboard(MainWindow::GetHWND())) {
 				HANDLE handle = GetClipboardData(CF_UNICODETEXT);
 				const wchar_t *wstr = (const wchar_t*)GlobalLock(handle);
 				if (wstr)
@@ -601,7 +601,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 	case SystemRequestType::COPY_TO_CLIPBOARD:
 	{
 		std::wstring data = ConvertUTF8ToWString(param1);
-		W32Util::CopyTextToClipboard(MainWindow::GetDisplayHWND(), data);
+		W32Util::CopyTextToClipboard(MainWindow::GetHWND(), data);
 		return true;
 	}
 	case SystemRequestType::SET_WINDOW_TITLE:


### PR DESCRIPTION
For historical reasons, we've actually displayed inside an inner window completely covering the client area of the main window. This seems to be entirely unnecessary so I'm just getting rid of it and using the main window directly for everything.

Not expecting any noticable change, just a nice cleanup. Well, in dark mode it also completely eliminates the white flash on startup.