### PR TITLE
If RetroAchievements' "Hardcore mode" is enabled, prevent debugger use

### DIFF
--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -576,6 +576,10 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			ProcessUpdateDialog();
 			updateDialogScheduled_ = false;
 			KillTimer(GetDlgHandle(), wParam);
+
+			if (Achievements::HardcoreModeActive()) {
+				SendMessage(m_hDlg, WM_CLOSE, 0, 0);
+			}
 		}
 		break;
 	}

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -33,7 +33,7 @@
 
 #include "Core/Config.h"
 #include "Core/Screenshot.h"
-
+#include "Core/RetroAchievements.h"
 #include "Windows/GEDebugger/GEDebugger.h"
 #include "Windows/GEDebugger/SimpleGLWindow.h"
 #include "Windows/GEDebugger/CtrlDisplayListView.h"
@@ -949,6 +949,12 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			}
 		} else if (!PSP_IsInited() && primaryBuffer_) {
 			SendMessage(m_hDlg, WM_COMMAND, IDC_GEDBG_RESUME, 0);
+		}
+		if (Achievements::HardcoreModeActive()) {
+			if (g_activeWindow == WINDOW_GEDEBUGGER) {
+				g_activeWindow = WINDOW_OTHER;
+			}
+			SendMessage(m_hDlg, WM_CLOSE, 0, 0);
 		}
 		break;
 

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -974,6 +974,19 @@ namespace MainWindow {
 		}
 	}
 
+	void HideDebugWindows() {
+		if (disasmWindow)
+			disasmWindow->Show(false);
+#if PPSSPP_API(ANY_GL)
+		if (geDebuggerWindow)
+			geDebuggerWindow->Show(false);
+#endif
+		if (memoryWindow)
+			memoryWindow->Show(false);
+		if (vfpudlg)
+			vfpudlg->Show(false);
+	}
+
 	void UpdateMenus(bool isMenuSelect) {
 		if (isMenuSelect) {
 			menuShaderInfoLoaded = false;

--- a/Windows/MainWindowMenu.h
+++ b/Windows/MainWindowMenu.h
@@ -12,4 +12,5 @@ namespace MainWindow {
 	void BrowseAndBoot(RequesterToken token, std::string defaultPath, bool browseDirectory = false);
 	void setTexScalingMultiplier(int level);
 	void SetIngameMenuItemStates(HMENU menu, const GlobalUIState state);
+	void HideDebugWindows();
 }

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -47,14 +47,13 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Net/Resolve.h"
 #include "Common/TimeUtil.h"
-#include "W32Util/DarkMode.h"
-#include "W32Util/ShellUtil.h"
 
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Core/SaveState.h"
 #include "Core/Instance.h"
 #include "Core/HLE/Plugins.h"
+#include "Core/RetroAchievements.h"
 #include "Windows/EmuThread.h"
 #include "Windows/WindowsAudio.h"
 #include "ext/disarm.h"
@@ -79,6 +78,7 @@
 #endif
 #include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/DialogManager.h"
+#include "Windows/W32Util/DarkMode.h"
 #include "Windows/W32Util/ShellUtil.h"
 
 #include "Windows/Debugger/CtrlDisAsmView.h"
@@ -453,8 +453,11 @@ void System_Notify(SystemNotification notification) {
 			g_symbolMap->SortSymbols();  // internal locking is performed here
 		PostMessage(MainWindow::GetHWND(), WM_USER + 1, 0, 0);
 
-		if (disasmWindow)
+		if (Achievements::HardcoreModeActive()) {
+			MainWindow::HideDebugWindows();
+		} else if (disasmWindow) {
 			PostDialogMessage(disasmWindow, WM_DEB_SETDEBUGLPARAM, 0, (LPARAM)Core_IsStepping());
+		}
 		break;
 	}
 
@@ -462,7 +465,7 @@ void System_Notify(SystemNotification notification) {
 	{
 		PostMessage(MainWindow::GetHWND(), MainWindow::WM_USER_UPDATE_UI, 0, 0);
 
-		int peers = GetInstancePeerCount();
+		const int peers = GetInstancePeerCount();
 		if (PPSSPP_ID >= 1 && peers != g_lastNumInstances) {
 			g_lastNumInstances = peers;
 			PostMessage(MainWindow::GetHWND(), MainWindow::WM_USER_WINDOW_TITLE_CHANGED, 0, 0);
@@ -538,7 +541,6 @@ void System_Notify(SystemNotification notification) {
 	case SystemNotification::ROTATE_UPDATED:
 	case SystemNotification::TEST_JAVA_EXCEPTION:
 		break;
-	case SystemNotification::UI_STATE_CHANGED:
 	case SystemNotification::AUDIO_MODE_CHANGED:
 	case SystemNotification::APP_SWITCH_MODE_CHANGED:
 		break;


### PR DESCRIPTION
Fixes an easy way you could access the debugger windows.