### PR TITLE
SDL: Fix bug where the mouse got stuck in relative mode when mapping mouse inputs

### DIFF
--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -33,6 +33,8 @@ const char *GetDeviceName(int deviceId) {
 	}
 }
 
+bool g_IsMappingMouseInput;
+
 std::vector<InputMapping> dpadKeys;
 std::vector<InputMapping> confirmKeys;
 std::vector<InputMapping> cancelKeys;

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -211,3 +211,6 @@ void SetInfoKeys(const std::vector<InputMapping> &info);
 // 0 means unknown (attempt autodetect), -1 means flip, 1 means original direction.
 void SetAnalogFlipY(const std::unordered_map<InputDeviceID, int> &flipYByDeviceId);
 int GetAnalogYDirection(InputDeviceID deviceId);
+
+// Gross hack unfortunately.
+extern bool g_IsMappingMouseInput;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -936,7 +936,6 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("HideStickBackground", &g_Config.bHideStickBackground, false, CfgFlag::PER_GAME),
 
 	ConfigSetting("UseMouse", &g_Config.bMouseControl, false, CfgFlag::PER_GAME),
-	ConfigSetting("MapMouse", &g_Config.bMapMouse, false, CfgFlag::PER_GAME),
 	ConfigSetting("ConfineMap", &g_Config.bMouseConfine, false, CfgFlag::PER_GAME),
 	ConfigSetting("MouseSensitivity", &g_Config.fMouseSensitivity, 0.1f, CfgFlag::PER_GAME),
 	ConfigSetting("MouseSmoothing", &g_Config.fMouseSmoothing, 0.9f, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -450,7 +450,6 @@ public:
 	bool bStrictComboOrder;
 
 	bool bMouseControl;
-	bool bMapMouse; // Workaround for mapping screen:|
 	bool bMouseConfine; // Trap inside the window.
 	float fMouseSensitivity;
 	float fMouseSmoothing;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -887,7 +887,7 @@ static void EmuThreadJoin() {
 
 struct InputStateTracker {
 	void MouseCaptureControl() {
-		bool captureMouseCondition = g_Config.bMouseControl && ((GetUIState() == UISTATE_INGAME && g_Config.bMouseConfine) || g_Config.bMapMouse);
+		bool captureMouseCondition = g_Config.bMouseControl && ((GetUIState() == UISTATE_INGAME && g_Config.bMouseConfine) || g_IsMappingMouseInput);
 		if (mouseCaptured != captureMouseCondition) {
 			mouseCaptured = captureMouseCondition;
 			if (captureMouseCondition)

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -57,7 +57,9 @@ using KeyMap::MultiInputMapping;
 class SingleControlMapper : public UI::LinearLayout {
 public:
 	SingleControlMapper(int pspKey, std::string keyName, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams = nullptr);
-
+	~SingleControlMapper() {
+		g_IsMappingMouseInput = false;
+	}
 	int GetPspKey() const { return pspKey_; }
 
 private:
@@ -196,7 +198,7 @@ void SingleControlMapper::MappedCallback(const MultiInputMapping &kdf) {
 		break;
 	}
 	KeyMap::UpdateNativeMenuKeys();
-	g_Config.bMapMouse = false;
+	g_IsMappingMouseInput = false;
 }
 
 UI::EventReturn SingleControlMapper::OnReplace(UI::EventParams &params) {
@@ -219,7 +221,7 @@ UI::EventReturn SingleControlMapper::OnAdd(UI::EventParams &params) {
 }
 UI::EventReturn SingleControlMapper::OnAddMouse(UI::EventParams &params) {
 	action_ = ADD;
-	g_Config.bMapMouse = true;
+	g_IsMappingMouseInput = true;
 	scrm_->push(new KeyMappingNewMouseKeyDialog(pspKey_, true, std::bind(&SingleControlMapper::MappedCallback, this, std::placeholders::_1), I18NCat::KEYMAPPING));
 	return UI::EVENT_DONE;
 }
@@ -430,14 +432,14 @@ bool KeyMappingNewMouseKeyDialog::key(const KeyInput &key) {
 	if (key.flags & KEY_DOWN) {
 		if (key.keyCode == NKCODE_ESCAPE) {
 			TriggerFinish(DR_OK);
-			g_Config.bMapMouse = false;
+			g_IsMappingMouseInput = false;
 			return false;
 		}
 
 		mapped_ = true;
 
 		TriggerFinish(DR_YES);
-		g_Config.bMapMouse = false;
+		g_IsMappingMouseInput = false;
 		if (callback_) {
 			MultiInputMapping kdf(InputMapping(key.deviceId, key.keyCode));
 			callback_(kdf);

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -97,6 +97,9 @@ class KeyMappingNewMouseKeyDialog : public PopupScreen {
 public:
 	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyMap::MultiInputMapping)> callback, I18NCat i18n)
 		: PopupScreen(T(i18n, "Map Mouse"), "", ""), callback_(callback) {}
+	~KeyMappingNewMouseKeyDialog() {
+		g_IsMappingMouseInput = false;
+	}
 
 	const char *tag() const override { return "KeyMappingNewMouseKey"; }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1448,7 +1448,7 @@ static void SendMouseDeltaAxis() {
 	//NOTICE_LOG(Log::System, "delta: %0.2f %0.2f    mx/my: %0.2f %0.2f   dpi: %f  sens: %f ",
 	//	g_mouseDeltaX, g_mouseDeltaY, mx, my, g_display.dpi_scale_x, g_Config.fMouseSensitivity);
 
-	if (GetUIState() == UISTATE_INGAME || g_Config.bMapMouse) {
+	if (GetUIState() == UISTATE_INGAME || g_IsMappingMouseInput) {
 		NativeAxis(axis, 2);
 	}
 }

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -340,7 +340,7 @@ namespace WindowsRawInput {
 		};
 
 		for (int i = 0; i < 5; i++) {
-			if (i > 0 || (g_Config.bMouseControl && (GetUIState() == UISTATE_INGAME || g_Config.bMapMouse))) {
+			if (i > 0 || (g_Config.bMouseControl && (GetUIState() == UISTATE_INGAME || g_IsMappingMouseInput))) {
 				if (raw->data.mouse.usButtonFlags & rawInputDownID[i]) {
 					key.flags = KEY_DOWN;
 					key.keyCode = windowsTransTable[vkInputID[i]];


### PR DESCRIPTION
Unlike Windows, with SDL we need to switch the mouse into relative mode to get relative input, which hides the cursor. We do this in-game if mouse control is enabled, and during control mapping.

However in the latter case, we failed to disable it properly when exiting mapping. And also we accidentally saved the state across sessions.

Both problems fixed. Thanks to Aetheros on Discord for detailed reporting.