### PR TITLE
An attempted to fix strange version issue on Windows artifact

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           echo "Building..."
           uname -m
-          echo "tag=$(git describe --always --tags)" >> $GITHUB_OUTPUT
+          echo "tag=$(git describe --always)" >> $GITHUB_OUTPUT
 
           # Export ccache env var(s)
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Create git-version.cpp for Windows # Not sure why the one at git-version-gen.cmd couldn't get the version properly.
       #if: github.ref_type == 'tag'
       run: |
-        $GIT_VERSION=git describe --always --tags
+        $GIT_VERSION=git describe --always
         echo "Num of Valid Tags = ${{ steps.valid-tags.outputs.count }}"
         echo "Test GitVer = ${{ github.ref_name }} / $GIT_VERSION / ${GITHUB_REF_NAME}"
         echo "const char *PPSSPP_GIT_VERSION = `"$GIT_VERSION`";" > git-version.cpp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,16 +60,19 @@ jobs:
       #if: github.ref_type == 'tag'
       run: |
         $GIT_VERSION=git describe --always --tags
+        echo "Num of Valid Tags = ${{ steps.valid-tags.outputs.count }}"
         echo "Test GitVer = ${{ github.ref_name }} / $GIT_VERSION / ${GITHUB_REF_NAME}"
         echo "const char *PPSSPP_GIT_VERSION = `"$GIT_VERSION`";" > git-version.cpp
         echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
         
         # Generate Windows/win-version.h too.
-        $WIN_VERSION_COMMA=$GIT_VERSION -replace '^v', '' -replace '-g[0-9a-f]+$', '' -replace '[-\.]', ','
-        echo "Test WinVer = $WIN_VERSION_COMMA"
-        echo "#define PPSSPP_WIN_VERSION_STRING `"$GIT_VERSION`"" > Windows/win-version.h
-        echo "#define PPSSPP_WIN_VERSION_COMMA $WIN_VERSION_COMMA" >> Windows/win-version.h
-        echo "#define PPSSPP_WIN_VERSION_NO_UPDATE 1" >> Windows/win-version.h
+        if ($GIT_VERSION.StartsWith("v")) {
+          $WIN_VERSION_COMMA=$GIT_VERSION -replace '^v', '' -replace '-g[0-9a-f]+$', '' -replace '[-\.]', ','
+          echo "Test WinVer = $WIN_VERSION_COMMA"
+          echo "#define PPSSPP_WIN_VERSION_STRING `"$GIT_VERSION`"" > Windows/win-version.h
+          echo "#define PPSSPP_WIN_VERSION_COMMA $WIN_VERSION_COMMA" >> Windows/win-version.h
+          echo "#define PPSSPP_WIN_VERSION_NO_UPDATE 1" >> Windows/win-version.h
+        }
         
     - name: Build Windows
       working-directory: ${{ env.GITHUB_WORKSPACE }}

--- a/b-ios.sh
+++ b/b-ios.sh
@@ -9,7 +9,7 @@ mkdir -p build-ios
 cd build-ios
 rm -rf PPSSPP.app # There seems to be an existing symlink, may be from ccache? We don't want to include old stuff that might be removed to be included in the final IPA file.
 # It seems xcodebuild is looking for "git-version.cpp" file inside "build-ios" directory instead of at repo's root dir.
-echo "const char *PPSSPP_GIT_VERSION = \"$(git describe --always --tags)\";" > git-version.cpp
+echo "const char *PPSSPP_GIT_VERSION = \"$(git describe --always)\";" > git-version.cpp
 echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
 # Generate exportOptions.plist for xcodebuild
 echo '<?xml version="1.0" encoding="UTF-8"?>
@@ -98,7 +98,7 @@ if [ -e PPSSPP.app/PPSSPP ]; then
 	echo "Signing PPSSPP.app/PPSSPP ..."
 	ldid -Sent.xml PPSSPP.app/PPSSPP
 fi
-version_number=`echo "$(git describe --tags --match="v*" | sed -e 's@-\([^-]*\)-\([^-]*\)$@-\1-\2@;s@^v@@;s@%@~@g')"`
+version_number=`echo "$(git describe --always --match="v*" | sed -e 's@-\([^-]*\)-\([^-]*\)$@-\1-\2@;s@^v@@;s@%@~@g')"`
 echo ${version_number} > PPSSPP.app/Version.txt
 sudo -S chown -R 1004:3 Payload
 


### PR DESCRIPTION
This will at least let the build process successful, even when GIT_VERSION only contains the hash.

PS: i didn't have this version issue on my fork even without these changes.

Edit: looks like it was related to lightweight/unannoted tags.