### PR TITLE
Football Manager Handheld series: Fix blackscreen by forcing the software renderer

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1114,6 +1114,17 @@ ULES00016 = true
 ULUS10005 = true
 ULJM05005 = true
 
+# Football Manager Handheld series (#5934)
+ULES00248 = true  # ??
+ULES00549 = true  # 2007
+ULES00934 = true  # 2008
+ULES01152 = true  # 2009
+NPUH10036 = true  # 2010
+ULES01338 = true  # 2010
+ULES01455 = true  # 2011
+ULES01555 = true  # 2012
+ULES01582 = true  # 2013
+
 [DarkStalkersPresentHack]
 # Darkstalkers
 ULES00016 = true


### PR DESCRIPTION
Fixes the blackscreen problem from issue #5934, see explanation there.

Not sure if the game has other issues too.