### PR TITLE
Github CI: Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -2,7 +2,7 @@ name: Generate Linux AppImage
 on:
   push:
     branches:
-    - master
+    - '**'
     # For testing.
     #- test_arch
     tags:
@@ -12,7 +12,7 @@ on:
     - 'Tools/**'
     - '.{editorconfig,gitattributes,gitignore}'
     - 'appveyor.yml'
-  pull_request:
+  pull_request_target:
     branches:
     - master
     paths-ignore:
@@ -25,6 +25,10 @@ env:
   SDL_AUDIODRIVER: "dummy" #"disk"
   #SDL_VIDEODRIVER: "dummy"
   #BUILD_CONFIGURATION: Release #RelWithDebInfo
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-    - master
+    - '**'
     # For testing.
     - actions
     tags:
@@ -13,7 +13,7 @@ on:
     - 'Tools/**'
     - '.{editorconfig,gitattributes,gitignore}'
     - 'appveyor.yml'
-  pull_request:
+  pull_request_target:
     branches:
     - master
     paths-ignore:
@@ -24,6 +24,10 @@ on:
 
 env:
   BUILD_CONFIGURATION: Release
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   build-windows:


### PR DESCRIPTION
The idea is that PRs should build on CI even if there are conflicts with master.

This is useful for hotfix branches like v1.19.3-commits, where I cherry-pick PRs from master to produce a new release without including any risky recent changes.

I'm testing it in that branch right now and it seems to work. I'm making this a separate PR before including in the main branch, so you guys can warn me in case this is a mistake somehow :)

I showed my changes to ChatGPT and it suggested the push change and adding the permissions clause, not exactly sure why it's more needed now.

Discussion here: https://github.com/orgs/community/discussions/26304