### PR TITLE
[CI] Use bash on Fetch step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
 
     - name: Fetch upstream tags # Fallback to fetching tags from upstream
       if: steps.valid-tags.outputs.count == '0'
+      shell: bash
       run: |
         # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
         git remote add upstream https://github.com/hrydgard/ppsspp.git


### PR DESCRIPTION
It seems `exit` is not a valid cmdlet on powershell, so we should use bash.

This should fix the failed step issue on Windows build, but not sure why the fetch is rejecting the v1.19.3 tag and causing this failure 🤔 may be the tag is conflicting with the same tag on master branch, since we're fetching it from all branch i think.
![Screenshot_20250715-181912](https://github.com/user-attachments/assets/50383b32-9416-4985-81f9-3a6c67efed15)
