### PR TITLE
Hook framebuffer readback function in Never7, Ever17, and Remember11

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1307,6 +1307,23 @@ static int Hook_steinsgate_download_frame() {
 	return 0;
 }
 
+static int Hook_infinity_download_frame() {
+	// There are a few games that share this same function.
+	// The hash matches, but due to relocations, the addresses it references differ.
+	// Because of this, the address, even though hardcoded, has to be fetched from the function.
+	u32 magic_value_addr;
+	if (!GetMIPSStaticAddress(magic_value_addr, 0x08, 0x1C)) {
+		return 0;
+	}
+
+	// Not sure why it was done like this, but that's what the actual function does.
+	const u32 fb_address = (Memory::Read_U32(magic_value_addr) & 1) ? 0x04000000 : 0x04088000;
+
+	gpu->PerformReadbackToMemory(fb_address, 0x00088000);
+	NotifyMemInfo(MemBlockFlags::WRITE, fb_address, 0x00088000, "infinity_download_frame");
+	return 0;
+}
+
 static int Hook_katamari_render_check() {
 	const u32 fb_address = Memory::Read_U32(currentMIPS->r[MIPS_REG_A0] + 0x3C);
 	const u32 fbInfoPtr = Memory::Read_U32(currentMIPS->r[MIPS_REG_A0] + 0x40);
@@ -1625,6 +1642,7 @@ static const ReplacementTableEntry entries[] = {
 	{ "persona1_download_frame", &Hook_persona_download_frame, 0, REPFLAG_HOOKENTER, 0 },
 	{ "persona2_download_frame", &Hook_persona_download_frame, 0, REPFLAG_HOOKENTER, 0 },
 	{ "steinsgate_download_frame", &Hook_steinsgate_download_frame, 0, REPFLAG_HOOKENTER, 0 },
+	{ "infinity_download_frame", &Hook_infinity_download_frame, 0, REPFLAG_HOOKENTER, 0 },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -517,6 +517,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xc1d4af42a4c8860f, 964, "persona1_download_frame", },  // Persona 1 (issue #13079)
 	{ 0xde4286b2e7f6d3c1, 304, "persona2_download_frame", },  // Persona 2 (issue #13079)
 	{ 0x478c9c93d02011af, 1068, "steinsgate_download_frame", }, // Steins;Gate (issue #18262)
+	{ 0xb85dbe639f7acf13, 312, "infinity_download_frame", },  // Never7, Ever17, Remember11
 };
 
 namespace MIPSAnalyst {


### PR DESCRIPTION
Fixes scene transitions in the Infinity (N7, E17, R11) visual novel series. Same issue as #13079.