### PR TITLE
[CI] Use force when fetching tags from upstream

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
-          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
+          git fetch --deepen=15000 --no-recurse-submodules --tags --force upstream || exit 0
 
       - name: Set up ccache for ${{ matrix.id }}
         uses: actions/cache@v4.2.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
         git remote add upstream https://github.com/hrydgard/ppsspp.git
-        git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
+        git fetch --deepen=15000 --no-recurse-submodules --tags --force upstream || exit 0
 
     - name: Create git-version.cpp for Windows # Not sure why the one at git-version-gen.cmd couldn't get the version properly.
       #if: github.ref_type == 'tag'

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
-          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
+          git fetch --deepen=15000 --no-recurse-submodules --tags --force upstream || exit 0
         
       - name: Setup JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
-          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
+          git fetch --deepen=15000 --no-recurse-submodules --tags --force upstream || exit 0
 
       - name: Set Env Var(s)
         run: |

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # TODO: should try to fetch tags from whereever this repo was forked from before fetching from official repo
           git remote add upstream https://github.com/hrydgard/ppsspp.git # fetching from official repo as a fallback
-          git fetch --deepen=15000 --no-recurse-submodules --tags upstream || exit 0
+          git fetch --deepen=15000 --no-recurse-submodules --tags --force upstream || exit 0
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0


### PR DESCRIPTION
Based on my comment at https://github.com/hrydgard/ppsspp/pull/20630#issuecomment-3076740051

To prevent an issue of rejected tags on tags that were recreated on upstream, we should overrides existing local tags (which might still have the old tag with the same name) during git fetch from upstream.

PS: If i checked the logs at https://github.com/hrydgard/ppsspp/actions/runs/16290383294/job/45998753988
This rejected tag `[rejected]              v1.19.3                -> v1.19.3  (would clobber existing tag) ` seems to also happened when fetching tag from it's own repo 🤔 

May be i should added `--force` too, since the branch might still have a commit linked to the old tag. Oh well, may be on a different PR later if it's causing version issue on workflows that doesn't have the fallback step yet (currently only windows build have the fallback step in build.yml). 