### PR TITLE
Disable the memcpy slicing thing (for HLE memcpys) in Syphon Filter games

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1934,9 +1934,24 @@ ULJM06009 = true
 UCKS45164 = true
 
 [DisableMemcpySlicing]
+# Resistance (#18821)
 UCES01184 = true
 UCUS98668 = true
 UCJP00174 = true
+
+# Syphon Filter, see issue #20625
+
+# Logan's Shadow
+UCUS98606 = true
+UCES00710 = true
+NPUG80173 = true
+NPUA80013 = true  # Demo
+UCUS98704 = true  # Demo
+NPEG90002 = true  # Demo
+SYPH04036 = true  # Prototype?
+# Combat Ops
+NPUG80114 = true
+NPEG00004 = true
 
 [ForceHLEPsmf]
 # See issue #20467


### PR DESCRIPTION
Fixes #20625

However, it's not clear why. As discussed in #20625, might just try to get rid of many of these replacement functions. The problem with the copy ones is that often we want to take action *after* the copy (for GPU copy detection purposes) and without replacing the whole function that's a bit hard (but doable).