### PR TITLE
Revert "Github CI: Use pull_request_target instead of pull_request"

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -2,7 +2,7 @@ name: Generate Linux AppImage
 on:
   push:
     branches:
-    - '**'
+    - master
     # For testing.
     #- test_arch
     tags:
@@ -12,7 +12,7 @@ on:
     - 'Tools/**'
     - '.{editorconfig,gitattributes,gitignore}'
     - 'appveyor.yml'
-  pull_request_target:
+  pull_request:
     branches:
     - master
     paths-ignore:
@@ -25,10 +25,6 @@ env:
   SDL_AUDIODRIVER: "dummy" #"disk"
   #SDL_VIDEODRIVER: "dummy"
   #BUILD_CONFIGURATION: Release #RelWithDebInfo
-
-permissions:
-  contents: read
-  pull-requests: read
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-    - '**'
+    - master
     # For testing.
     - actions
     tags:
@@ -13,7 +13,7 @@ on:
     - 'Tools/**'
     - '.{editorconfig,gitattributes,gitignore}'
     - 'appveyor.yml'
-  pull_request_target:
+  pull_request:
     branches:
     - master
     paths-ignore:
@@ -24,10 +24,6 @@ on:
 
 env:
   BUILD_CONFIGURATION: Release
-
-permissions:
-  contents: read
-  pull-requests: read
 
 jobs:
   build-windows:


### PR DESCRIPTION
Reverts hrydgard/ppsspp#20624

It seems to not to be doing what I intended it to do, I misunderstood pull_request_target - now instead of building PRs, CI just builds master it seems like?