### PR TITLE
Rework how sceAudio sample queueing works internally.

### DIFF
--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -42,7 +42,7 @@ void __AudioSetOutputFrequency(int freq);
 void __AudioSetSRCFrequency(int freq);
 
 // May return SCE_ERROR_AUDIO_CHANNEL_BUSY if buffer too large
-u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking);
+u32 __AudioEnqueue(AudioChannel &chan, int chanNum, int leftVol, int rightVol, int samplePtr, bool blocking);
 void __AudioWakeThreads(AudioChannel &chan, int result, int step);
 void __AudioWakeThreads(AudioChannel &chan, int result);
 

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -76,11 +76,8 @@ static u32 sceVaudioChRelease() {
 
 static u32 sceVaudioOutputBlocking(int vol, u32 buffer) {
 	DEBUG_LOG(Log::sceAudio, "sceVaudioOutputBlocking(%i, %08x)", vol, buffer);
-	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = vol;
-	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = vol;
 	// TODO: This may be wrong, not sure if's in a different format?
-	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].sampleAddress = buffer;
-	return __AudioEnqueue(g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO], PSP_AUDIO_CHANNEL_VAUDIO, true);
+	return __AudioEnqueue(g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO], PSP_AUDIO_CHANNEL_VAUDIO, vol, vol, buffer, true);
 }
 
 static u32 sceVaudioSetEffectType(int effectType, int vol) {

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1332,7 +1332,7 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 			ImGui::TableNextColumn();
 			char id[2]{};
 			id[0] = i + 1;
-			ImClickableValue(id, g_audioChans[i].sampleAddress, control, ImCmd::SHOW_IN_MEMORY_VIEWER);
+			ImClickableValue(id, g_audioChans[i].sampleAddressUnused, control, ImCmd::SHOW_IN_MEMORY_VIEWER);
 			ImGui::TableNextColumn();
 			ImGui::Text("%08x", g_audioChans[i].sampleCount);
 			ImGui::TableNextColumn();
@@ -1351,9 +1351,9 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 			}
 			ImGui::TableNextColumn();
 			for (auto t : g_audioChans[i].waitingThreads) {
-				KernelObject *thread = kernelObjects.GetFast<KernelObject>(t.threadID);
+				KernelObject *thread = kernelObjects.GetFast<KernelObject>(t);
 				if (thread) {
-					ImGui::Text("%s: %d", thread->GetName(), t.numSamples);
+					ImGui::Text("%s", thread->GetName());
 				}
 			}
 			ImGui::PopID();


### PR DESCRIPTION
Funny sometimes how when you look at your old code, you realize that there's no possible way the audio queueing can work like that on real hardware.

This reworks audio queueing/dequeing to not use an external queue, but instead just use the queue memory provided by the game directly.  Seems to work just as well and will probably reduce audio latency very slightly, although this can still be improved further.

Needs a bit more testing and work before merge, so marking as draft.