### PR TITLE
Add FIFA07 entry to infra-dns.json

### DIFF
--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -9,6 +9,32 @@
 	},
 	"games": [
 		{
+			"name": "FIFA 07",
+			"comment": {
+				"en_US": "Works"
+			},
+			"revival_credits": {
+				"group": "PSP Online",
+				"url": "https://discord.gg/wxeGVkM"
+			},
+			"dns": "ablondel.ddns.net",
+			"dyn_dns": "ablondel.ddns.net",
+			"domains": {
+				"pspnhl07.ea.com": "ablondel.ddns.net"
+			},
+			"score": 5,
+			"known_working_ids": [
+				"ULES00440",
+				"ULES00441",
+				"ULES00442",
+				"ULES00443",
+				"ULES00444",
+				"ULES00459",
+				"ULJM05191",
+				"ULUS10112"
+			]
+		},
+		{
 			"name": "Medal of Honor: Heroes",
 			"comment": {
 				"en_US": "Works"


### PR DESCRIPTION
## FIFA07 infrastructure support

Not all features are supported yet, but at least the game is playable 🎮 
Additional features are being added gradually.

Revival group set to PSP Online as I don't know yet if there is any dedicated community on FIFA 07.
<img width="400" height="144" alt="image" src="https://github.com/user-attachments/assets/d3fb5bdf-c5be-4b83-96b7-7e5b942fa291" />
