### PR TITLE
fix 2 compiler warnings

### DIFF
--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -107,7 +107,7 @@ public:
 
 	void CreateTabs() override;
 	void update() override;
-	void resized() { RecreateViews(); }
+	void resized() override { RecreateViews(); }
 
 protected:
 	UI::EventReturn CopySummaryToClipboard(UI::EventParams &e);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -720,7 +720,7 @@ void GameSettingsScreen::CreateAudioSettings(UI::ViewGroup *audioSettings) {
 		audioDeviceIds.insert(audioDeviceIds.begin(), "");
 
 		PopupMultiChoiceDynamic *audioDevice = audioSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sAudioDevice, a->T("Device"), audioDeviceNames, I18NCat::NONE, screenManager(), &audioDeviceIds));
-		audioDevice->OnChoice.Add([this](UI::EventParams &) {
+		audioDevice->OnChoice.Add([](UI::EventParams &) {
 			bool reverted;
 			if (g_audioBackend->InitOutputDevice(g_Config.sAudioDevice, LatencyMode::Aggressive, &reverted)) {
 				if (reverted) {


### PR DESCRIPTION
Fixes these Clang warnings
```
[953/1016] Building CXX object CMakeFiles/PPSSPPWindows.dir/UI/GameSettingsScreen.cpp.obj
In file included from C:/src/ppsspp/UI/GameSettingsScreen.cpp:49:
C:/src/ppsspp/UI/DevScreens.h:110:7: warning: 'resized' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  110 |         void resized() { RecreateViews(); }
      |              ^
C:/src/ppsspp/Common/UI/Screen.h:80:15: note: overridden virtual function is here
   80 |         virtual void resized() {}
      |                      ^
C:/src/ppsspp/UI/GameSettingsScreen.cpp:723:30: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
  723 |                 audioDevice->OnChoice.Add([this](UI::EventParams &) {
      |                                            ^~~~
2 warnings generated.
```