### PR TITLE
Allow Atrac files to be accepted with less data

### DIFF
--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -173,8 +173,8 @@ static int ComputeAtracStateAndInitSecondBuffer(SceAtracIdInfo *info, u32 readSi
 	int loopEnd;
 
 	if (bufferSize < (u32)info->fileDataEnd) {
-		if (info->streamDataByte < (s32)info->sampleSize * 3) {
-			return 0x80630011;
+		if (info->streamDataByte < (s32)info->sampleSize * 2) {
+			return SCE_ERROR_ATRAC_SIZE_TOO_SMALL;
 		}
 		loopEnd = info->loopEnd;
 		state = ATRAC_STATUS_STREAMED_WITHOUT_LOOP;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -887,6 +887,7 @@ NPJH50471 = true
 ULJM06033 = true
 NPJH50559 = true
 NPEH00030 = true
+ULKS46191 = true
 
 [GoWFramerateHack60]
 # Replaces ForceMax60FPS for GOW games, should provide smoother experience
@@ -1118,6 +1119,7 @@ NPJH50471 = true
 ULJM06033 = true
 NPJH50559 = true
 NPEH00030 = true
+ULKS46191 = true
 
 [MoreAccurateVMMUL]
 # Fixes leg shaking in Tekken 6. The potential for slowdown in other games is large enough

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:8.12.0'
     }
 }
 


### PR DESCRIPTION
Fixes #20692 , and seems pretty safe.

Also add another game ID for DJ Max, and bump the Android Studio gradle plugin versions again, sigh.