### PR TITLE
Infra DNS resolver code cleanup

### DIFF
--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -21,7 +21,7 @@
 bool LoadRemoteFileList(const Path &url, const std::string &userAgent, bool *cancel, std::vector<File::FileInfo> &files) {
 	_dbg_assert_(url.Type() == PathType::HTTP);
 
-	http::Client http;
+	http::Client http(nullptr);
 	Buffer result;
 	int code = 500;
 	std::vector<std::string> responseHeaders;

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -5,7 +5,6 @@
 #include <cstring>
 #include <iostream>
 
-#include "Core/Config.h"
 #include "Common/System/System.h"
 #include "Common/System/Display.h"
 #include "Common/Log.h"
@@ -171,7 +170,7 @@ VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 #endif
 #endif
 
-	if ((flags_ & VulkanInitFlags::VALIDATE) && g_Config.sCustomDriver.empty()) {
+	if ((flags_ & VulkanInitFlags::VALIDATE) && info.customDriver.empty()) {
 		if (IsInstanceExtensionAvailable(VK_EXT_DEBUG_UTILS_EXTENSION_NAME)) {
 			// Enable the validation layers
 			for (size_t i = 0; i < ARRAY_SIZE(validationLayers); i++) {

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -184,6 +184,7 @@ public:
 		const char *app_name;
 		int app_ver;
 		VulkanInitFlags flags;
+		std::string customDriver;
 	};
 
 	VkResult CreateInstance(const CreateInfo &info);

--- a/Common/GhidraClient.cpp
+++ b/Common/GhidraClient.cpp
@@ -193,7 +193,7 @@ bool GhidraClient::FetchTypes() {
 }
 
 bool GhidraClient::FetchResource(const std::string &path, std::string &outResult) {
-	http::Client http;
+	http::Client http(nullptr);
 	if (!http.Resolve(host_.c_str(), port_)) {
 		pendingResult_.error = "can't resolve host";
 		return false;

--- a/Common/Net/Resolve.cpp
+++ b/Common/Net/Resolve.cpp
@@ -1,5 +1,4 @@
 #include "ppsspp_config.h"
-#include "Common/Net/Resolve.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -13,6 +12,7 @@
 #include "Common/StringUtils.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Net/SocketCompat.h"
+#include "Common/Net/Resolve.h"
 
 #ifndef HTTPS_NOT_AVAILABLE
 #include "ext/naett/naett.h"

--- a/Common/Net/Resolve.cpp
+++ b/Common/Net/Resolve.cpp
@@ -1,5 +1,3 @@
-#include "Core/Config.h"
-#include "Core/HLE/sceNet.h"
 #include "ppsspp_config.h"
 #include "Common/Net/Resolve.h"
 
@@ -502,55 +500,6 @@ bool DirectDNSLookupIPV4(const char *dns_server_ip, const char *domain, uint32_t
 
 	g_directDNSCache[key] = DNSCacheEntry{ *ipv4_addr };
 	return true;
-}
-
-std::string ProcessHostnameWithInfraDNS(const std::string& hostname) {
-	std::string resolvedHostname = hostname;
-	
-	// Resolve any aliases. First check the ini file, then check the hardcoded DNS config.
-	auto aliasIter = g_Config.mHostToAlias.find(hostname);
-	if (aliasIter != g_Config.mHostToAlias.end()) {
-		const std::string& alias = aliasIter->second;
-		INFO_LOG(Log::sceNet, "%s - Resolved alias %s from hostname %s", __FUNCTION__, alias.c_str(), hostname.c_str());
-		resolvedHostname = alias;
-	}
-
-	if (g_Config.bInfrastructureAutoDNS) {
-		// Also look up into the preconfigured fixed DNS JSON.
-		auto fixedDNSIter = GetInfraDNSConfig().fixedDNS.find(resolvedHostname);
-		if (fixedDNSIter != GetInfraDNSConfig().fixedDNS.end()) {
-			const std::string& domainIP = fixedDNSIter->second;
-			INFO_LOG(Log::sceNet, "%s - Resolved IP %s from fixed DNS lookup with '%s'", __FUNCTION__, domainIP.c_str(), resolvedHostname.c_str());
-			resolvedHostname = domainIP;
-		}
-	}
-
-	// Check if hostname is already an IPv4 address, if so we do not need further lookup. This usually happens
-	// after the mHostToAlias or fixedDNSIter lookups, which effectively both are hardcoded DNS.
-	uint32_t resolvedAddr;
-	if (inet_pton(AF_INET, resolvedHostname.c_str(), &resolvedAddr)) {
-		INFO_LOG(Log::sceNet, "Not looking up '%s', already an IP address.", resolvedHostname.c_str());
-		return resolvedHostname;
-	}
-
-	// Now use the configured primary DNS server to do a lookup.
-	// If auto DNS, use the server from that config.
-	std::string dnsServer;
-	if (g_Config.bInfrastructureAutoDNS && !GetInfraDNSConfig().dns.empty()) {
-		dnsServer = GetInfraDNSConfig().dns;
-	} else {
-		dnsServer = g_Config.sInfrastructureDNSServer;
-	}
-
-	if (net::DirectDNSLookupIPV4(dnsServer.c_str(), resolvedHostname.c_str(), &resolvedAddr)) {
-		char temp[32];
-		inet_ntop(AF_INET, &resolvedAddr, temp, sizeof(temp));
-		INFO_LOG(Log::sceNet, "Direct lookup of '%s' from '%s' succeeded: %s", resolvedHostname.c_str(), dnsServer.c_str(), temp);
-		return std::string(temp);
-	}
-
-	WARN_LOG(Log::sceNet, "Direct DNS lookup of '%s' at DNS server '%s' failed. Will try OS DNS...", resolvedHostname.c_str(), dnsServer.c_str());
-	return resolvedHostname;
 }
 
 }  // namespace net

--- a/Common/Net/Resolve.h
+++ b/Common/Net/Resolve.h
@@ -26,6 +26,5 @@ int inet_pton(int af, const char* src, void* dst);
 
 // Does a DNS lookup without involving the OS, so you can hit any DNS server.
 bool DirectDNSLookupIPV4(const char *dnsServer, const char *host, uint32_t *ipv4_addr);
-std::string ProcessHostnameWithInfraDNS(const std::string& hostname);
 
 }  // namespace net

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -7,11 +7,10 @@
 #include "Common/UI/UI.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
+#include "Common/Data/Collections/TinySet.h"
 
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
-
-#include "Core/KeyMap.h"
 
 void Screen::focusChanged(ScreenFocusChange focusChange) {
 	const char *eventName = "";

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -14,8 +14,7 @@
 
 #include "Common/Math/lin/matrix4x4.h"
 
-#include "Common/Input/InputState.h"
-#include "Common/Input/KeyCodes.h"
+// The deps below need to be inverted, or we need to move this file (probably better)
 
 #include "Core/HLE/sceDisplay.h"
 #include "Core/HLE/sceCtrl.h"

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -23,7 +23,7 @@
 #include "Core/FileLoaders/HTTPFileLoader.h"
 
 HTTPFileLoader::HTTPFileLoader(const ::Path &filename)
-	: url_(filename.ToString()), progress_(&cancel_), filename_(filename) {
+	: url_(filename.ToString()), progress_(&cancel_), filename_(filename), client_(nullptr) {  // no custom resolver support
 }
 
 void HTTPFileLoader::Prepare() {

--- a/Core/HLE/sceHttp.h
+++ b/Core/HLE/sceHttp.h
@@ -268,7 +268,7 @@ private:
 	std::string responseContent_;
 
 public:
-	HTTPRequest(int connectionID, int method, const char* url, u64 contentLength);
+	HTTPRequest(int connectionID, int method, const char* url, u64 contentLength, net::ResolveFunc customResolver);
 	~HTTPRequest();
 
 	virtual const char* className() override { return name_HTTPRequest; }

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -464,6 +464,55 @@ bool PollInfraJsonDownload(std::string *jsonOutput) {
 	return true;
 }
 
+std::string ProcessHostnameWithInfraDNS(const std::string &hostname) {
+	std::string resolvedHostname = hostname;
+	
+	// Resolve any aliases. First check the ini file, then check the hardcoded DNS config.
+	auto aliasIter = g_Config.mHostToAlias.find(hostname);
+	if (aliasIter != g_Config.mHostToAlias.end()) {
+		const std::string& alias = aliasIter->second;
+		INFO_LOG(Log::sceNet, "%s - Resolved alias %s from hostname %s", __FUNCTION__, alias.c_str(), hostname.c_str());
+		resolvedHostname = alias;
+	}
+
+	if (g_Config.bInfrastructureAutoDNS) {
+		// Also look up into the preconfigured fixed DNS JSON.
+		auto fixedDNSIter = GetInfraDNSConfig().fixedDNS.find(resolvedHostname);
+		if (fixedDNSIter != GetInfraDNSConfig().fixedDNS.end()) {
+			const std::string& domainIP = fixedDNSIter->second;
+			INFO_LOG(Log::sceNet, "%s - Resolved IP %s from fixed DNS lookup with '%s'", __FUNCTION__, domainIP.c_str(), resolvedHostname.c_str());
+			resolvedHostname = domainIP;
+		}
+	}
+
+	// Check if hostname is already an IPv4 address, if so we do not need further lookup. This usually happens
+	// after the mHostToAlias or fixedDNSIter lookups, which effectively both are hardcoded DNS.
+	uint32_t resolvedAddr;
+	if (inet_pton(AF_INET, resolvedHostname.c_str(), &resolvedAddr)) {
+		INFO_LOG(Log::sceNet, "Not looking up '%s', already an IP address.", resolvedHostname.c_str());
+		return resolvedHostname;
+	}
+
+	// Now use the configured primary DNS server to do a lookup.
+	// If auto DNS, use the server from that config.
+	std::string dnsServer;
+	if (g_Config.bInfrastructureAutoDNS && !GetInfraDNSConfig().dns.empty()) {
+		dnsServer = GetInfraDNSConfig().dns;
+	} else {
+		dnsServer = g_Config.sInfrastructureDNSServer;
+	}
+
+	if (net::DirectDNSLookupIPV4(dnsServer.c_str(), resolvedHostname.c_str(), &resolvedAddr)) {
+		char temp[32];
+		inet_ntop(AF_INET, &resolvedAddr, temp, sizeof(temp));
+		INFO_LOG(Log::sceNet, "Direct lookup of '%s' from '%s' succeeded: %s", resolvedHostname.c_str(), dnsServer.c_str(), temp);
+		return std::string(temp);
+	}
+
+	WARN_LOG(Log::sceNet, "Direct DNS lookup of '%s' at DNS server '%s' failed. Will try OS DNS...", resolvedHostname.c_str(), dnsServer.c_str());
+	return resolvedHostname;
+}
+
 void InitLocalhostIP() {
 	// The entire 127.*.*.* is reserved for loopback.
 	uint32_t localIP = 0x7F000001 + PPSSPP_ID - 1;

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -127,6 +127,7 @@ void StartInfraJsonDownload();
 bool PollInfraJsonDownload(std::string *jsonOutput);
 bool LoadAutoDNS(std::string_view json);
 void DeleteAutoDNSCacheFile();
+std::string ProcessHostnameWithInfraDNS(const std::string &hostname);
 
 // These return false if allowed to be consistent with the similar function for achievements.
 bool NetworkWarnUserIfOnlineAndCantSavestate();

--- a/Core/HLE/sceNetResolver.cpp
+++ b/Core/HLE/sceNetResolver.cpp
@@ -89,7 +89,7 @@ static int NetResolver_StartNtoA(NetResolver *resolver, u32 hostnamePtr, u32 inA
 	std::string hostname = std::string(safe_string(Memory::GetCharPointer(hostnamePtr)));
 	
 	// Process hostname with infra-DNS
-	std::string processedHostname = net::ProcessHostnameWithInfraDNS(hostname);
+	std::string processedHostname = ProcessHostnameWithInfraDNS(hostname);
 
 	// Flag resolver as in-progress - not relevant for sync functions but potentially relevant for async
 	resolver->isRunning = true;

--- a/Core/HLE/sceNp2.cpp
+++ b/Core/HLE/sceNp2.cpp
@@ -22,6 +22,7 @@
 #include "Core/CoreTiming.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
+#include "Core/HLE/sceNet.h"
 #include "Core/HLE/sceNp.h"
 #include "Core/HLE/sceNp2.h"
 
@@ -157,7 +158,7 @@ static int sceNpMatching2ContextStart(int ctxId)
 	// TODO: use sceNpGetUserProfile and check server availability using sceNpService_76867C01
 	//npMatching2Ctx.started = true;
 	Url url("http://static-resource.np.community.playstation.net/np/resource/psp-title/" + std::string(npTitleId.data) + "_00/matching/" + std::string(npTitleId.data) + "_00-matching.xml");
-	http::Client client;
+	http::Client client(&ProcessHostnameWithInfraDNS);
 	bool cancelled = false;
 	net::RequestProgress progress(&cancelled);
 	if (!client.Resolve(url.Host().c_str(), url.Port())) {

--- a/Core/HLE/sceParseUri.cpp
+++ b/Core/HLE/sceParseUri.cpp
@@ -246,7 +246,7 @@ static int sceUriBuild(u32 workAreaAddr, u32 workAreaSizeAddr, int workAreaSize,
 	}
 
 	if (workAreaAddr == 0) {
-		return hleLogDebug(Log::sceNet, -1, "size query, required size: %d", requiredSize);
+		return hleLogDebug(Log::sceNet, 0, "size query, required size: %d", requiredSize);
 	}
 
 	if (requiredSize > workAreaSize) {
@@ -305,7 +305,7 @@ static int sceUriEscape(u32 escapedAddr, u32 escapedLengthAddr, int escapedBuffe
 	}
 
 	if (escapedAddr == 0) {
-		return hleLogError(Log::sceNet, -1, "size query, required size: %d", requiredSize);
+		return hleLogDebug(Log::sceNet, 0, "size query, required size: %d", requiredSize);
 	}
 
 	if (requiredSize > escapedBufferLength) {

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -76,7 +76,7 @@ static ServerStatus RetrieveStatus() {
 // relay that address to a mobile device searching for the server.
 static bool RegisterServer(int port) {
 	bool success = false;
-	http::Client http;
+	http::Client http(nullptr);
 	bool cancelled = false;
 	net::RequestProgress progress(&cancelled);
 	Buffer theVoid = Buffer::Void();

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -72,6 +72,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int w, in
 	info.app_name = "PPSSPP";
 	info.app_ver = gitVer.ToInteger();
 	info.flags = FlagsFromConfig();
+	info.customDriver = g_Config.sCustomDriver;
 	if (VK_SUCCESS != vulkan_->CreateInstance(info)) {
 		*error_message = vulkan_->InitError();
 		delete vulkan_;

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -106,7 +106,7 @@ std::string RemoteSubdir() {
 }
 
 bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort) {
-	http::Client http;
+	http::Client http(nullptr);
 	Buffer result;
 	int code = 500;
 	bool hadTimeouts = false;

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -71,6 +71,7 @@ bool AndroidVulkanContext::InitAPI() {
 	info.app_name = "PPSSPP";
 	info.app_ver = gitVer.ToInteger();
 	info.flags = FlagsFromConfig();
+	info.customDriver = g_Config.sCustomDriver;
 	if (!g_Vulkan->CreateInstanceAndDevice(info)) {
 		delete g_Vulkan;
 		g_Vulkan = nullptr;


### PR DESCRIPTION
Removes the ugly reverse dependency from Common->Core by adding the ability to pass in a custom resolver. This also avoids going through the infra resolver for stuff like the homebrew store, reporting etc.

NOTE: Just as before, this works only on HTTP requests, not HTTPS (since those go through a different mechanism currently, until we start doing TLS ourselves)

See #20670 , where this was introduced.