### PR TITLE
[Libretro] Display a warning message if assets are missing

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1247,6 +1247,42 @@ void retro_init(void)
 
    retro_base_dir /= "PPSSPP";
 
+   // Check if '<system_dir>/PPSSPP/compat.ini' exists, if not we can assume
+   // the user is missing the assets entirely, so let's warn them about it.
+   if (!File::Exists(Path(retro_base_dir / "compat.ini")))
+   {
+      const char* str = "Core system files missing, expect bugs.";
+      unsigned msg_interface_version = 0;
+      environ_cb(RETRO_ENVIRONMENT_GET_MESSAGE_INTERFACE_VERSION, &msg_interface_version);
+
+      if (msg_interface_version >= 1)
+      {
+         retro_message_ext msg = {
+            str,
+            3000,
+            3,
+            RETRO_LOG_WARN,
+            RETRO_MESSAGE_TARGET_ALL,
+            RETRO_MESSAGE_TYPE_NOTIFICATION,
+            -1
+         };
+         environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg);
+      }
+      else
+      {
+         retro_message msg = {
+            str,
+            180
+         };
+         environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE, &msg);
+      }
+
+      // OSD messages should be kept pretty short, but
+      // let's give the user a bit more info in logs.
+      WARN_LOG(Log::System, "Please check the docs for more informations on how to install "
+                            "the PPSSPP assets: https://docs.libretro.com/library/ppsspp/");
+   }
+
    g_Config.currentDirectory = retro_base_dir;
    g_Config.defaultCurrentDirectory = retro_base_dir;
    g_Config.memStickDirectory = retro_save_dir;


### PR DESCRIPTION
People keep asking on Reddit, Discord, etc. about missing fonts in some games, usually save menus. So in case the user is missing the PPSSPP assets (by checking is "compat.ini" is present) display a little OSD message about it:

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/a243bb0e-af83-4560-99fe-c84096c92da1" />

With a warning in logs pointing to the Libretro docs webpage.

Ideally the assets would be embedded in the core but I don't know how to do that :p This is still better than nothing, IMO.