### PR TITLE
Small remote debugger cleanup

### DIFF
--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -181,7 +181,7 @@ void HandleDebuggerRequest(const http::ServerRequest &request) {
 		}
 	});
 	ws->SetBinaryHandler([&](const std::vector<uint8_t> &d) {
-		ws->Send(DebuggerErrorEvent("Bad message", LogLevel::LERROR));
+		ws->Send(DebuggerErrorEvent("Bad message: binary WebSocket frames are not supported", LogLevel::LERROR));
 	});
 
 	while (ws->Process(highActivity ? 1.0f / 1000.0f : 1.0f / 60.0f)) {

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
@@ -192,7 +192,7 @@ void WebSocketCPUBreakpointRemove(DebuggerRequest &req) {
 //  - breakpoints: array of objects, each with properties:
 //     - address: unsigned integer address of instruction to break at.
 //     - enabled: boolean, whether to actually enter stepping when this breakpoint trips.
-//     - log: optional boolean, whether to log when this breakpoint trips.
+//     - log: boolean, whether to log when this breakpoint trips.
 //     - condition: null, or string expression to evaluate - breakpoint does not trip if false.
 //     - logFormat: null, or string to log when breakpoint trips, may include {expression} parts.
 //     - symbol: null, or string label or symbol at breakpoint address.

--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -387,7 +387,7 @@ void WebSocketCPUSetReg(DebuggerRequest &req) {
 //  - expression: string containing labels, operators, regs, etc.
 //
 // Response (same event name):
-//  - uintValue: value in register.
+//  - uintValue: the computed value.
 //  - floatValue: string showing float representation.  May be "nan", "inf", or "-inf".
 void WebSocketCPUEvaluate(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive()) {

--- a/Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
@@ -262,12 +262,14 @@ static void GenericStreamBuffer(DebuggerRequest &req, std::function<bool(const G
 // Retrieve a screenshot (gpu.buffer.screenshot)
 //
 // Parameters:
-//  - type: either 'uri' or 'base64'.
+//  - type: either 'uri' or 'base64' (optional, defaults to 'uri').
 //  - alpha: boolean to include the alpha channel for 'uri' type (not normally useful for screenshots.)
+//  - stackWidth: optional, forced width for 'uri' type (increases height.)
 //
 // Response (same event name) for 'uri' type:
 //  - width: numeric width of screenshot.
 //  - height: numeric height of screenshot.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - uri: data: URI of PNG image for display.
 //
 // Response (same event name) for 'base64' type:
@@ -275,6 +277,7 @@ static void GenericStreamBuffer(DebuggerRequest &req, std::function<bool(const G
 //  - height: numeric height of screenshot.
 //  - flipped: boolean to indicate whether buffer is vertically flipped.
 //  - format: string indicating format, such as 'R8G8B8A8_UNORM' or 'B8G8R8A8_UNORM'.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - base64: base64 encode of binary data.
 void WebSocketGPUBufferScreenshot(DebuggerRequest &req) {
 	GenericStreamBuffer(req, [](const GPUDebugBuffer *&buf, bool *isFramebuffer) {
@@ -286,12 +289,14 @@ void WebSocketGPUBufferScreenshot(DebuggerRequest &req) {
 // Retrieve current color render buffer (gpu.buffer.renderColor)
 //
 // Parameters:
-//  - type: either 'uri' or 'base64'.
+//  - type: either 'uri' or 'base64' (optional, defaults to 'uri').
 //  - alpha: boolean to include the alpha channel for 'uri' type.
+//  - stackWidth: optional, forced width for 'uri' type (increases height.)
 //
 // Response (same event name) for 'uri' type:
 //  - width: numeric width of render buffer (may include stride.)
 //  - height: numeric height of render buffer.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - uri: data: URI of PNG image for display.
 //
 // Response (same event name) for 'base64' type:
@@ -299,6 +304,7 @@ void WebSocketGPUBufferScreenshot(DebuggerRequest &req) {
 //  - height: numeric height of render buffer.
 //  - flipped: boolean to indicate whether buffer is vertically flipped.
 //  - format: string indicating format, such as 'R8G8B8A8_UNORM' or 'B8G8R8A8_UNORM'.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - base64: base64 encode of binary data.
 void WebSocketGPUBufferRenderColor(DebuggerRequest &req) {
 	GenericStreamBuffer(req, [](const GPUDebugBuffer *&buf, bool *isFramebuffer) {
@@ -310,12 +316,14 @@ void WebSocketGPUBufferRenderColor(DebuggerRequest &req) {
 // Retrieve current depth render buffer (gpu.buffer.renderDepth)
 //
 // Parameters:
-//  - type: either 'uri' or 'base64'.
+//  - type: either 'uri' or 'base64' (optional, defaults to 'uri').
 //  - alpha: true to use alpha to encode depth, otherwise red for 'uri' type.
+//  - stackWidth: optional, forced width for 'uri' type (increases height.)
 //
 // Response (same event name) for 'uri' type:
 //  - width: numeric width of render buffer (may include stride.)
 //  - height: numeric height of render buffer.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - uri: data: URI of PNG image for display.
 //
 // Response (same event name) for 'base64' type:
@@ -323,6 +331,7 @@ void WebSocketGPUBufferRenderColor(DebuggerRequest &req) {
 //  - height: numeric height of render buffer.
 //  - flipped: boolean to indicate whether buffer is vertically flipped.
 //  - format: string indicating format, such as 'D16', 'D24_X8' or 'D32F'.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - base64: base64 encode of binary data.
 void WebSocketGPUBufferRenderDepth(DebuggerRequest &req) {
 	GenericStreamBuffer(req, [](const GPUDebugBuffer *&buf, bool *isFramebuffer) {
@@ -334,12 +343,14 @@ void WebSocketGPUBufferRenderDepth(DebuggerRequest &req) {
 // Retrieve current stencil render buffer (gpu.buffer.renderStencil)
 //
 // Parameters:
-//  - type: either 'uri' or 'base64'.
+//  - type: either 'uri' or 'base64' (optional, defaults to 'uri').
 //  - alpha: true to use alpha to encode stencil, otherwise red for 'uri' type.
+//  - stackWidth: optional, forced width for 'uri' type (increases height.)
 //
 // Response (same event name) for 'uri' type:
 //  - width: numeric width of render buffer (may include stride.)
 //  - height: numeric height of render buffer.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - uri: data: URI of PNG image for display.
 //
 // Response (same event name) for 'base64' type:
@@ -347,6 +358,7 @@ void WebSocketGPUBufferRenderDepth(DebuggerRequest &req) {
 //  - height: numeric height of render buffer.
 //  - flipped: boolean to indicate whether buffer is vertically flipped.
 //  - format: string indicating format, such as 'X24_S8' or 'S8'.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - base64: base64 encode of binary data.
 void WebSocketGPUBufferRenderStencil(DebuggerRequest &req) {
 	GenericStreamBuffer(req, [](const GPUDebugBuffer *&buf, bool *isFramebuffer) {
@@ -358,9 +370,10 @@ void WebSocketGPUBufferRenderStencil(DebuggerRequest &req) {
 // Retrieve current texture (gpu.buffer.texture)
 //
 // Parameters:
-//  - type: either 'uri' or 'base64'.
+//  - type: either 'uri' or 'base64' (optional, defaults to 'uri').
 //  - alpha: boolean to include the alpha channel for 'uri' type.
-//  - level: texture mip level, default 0.
+//  - level: optional texture mip level, default 0.
+//  - stackWidth: optional, forced width for 'uri' type (increases height.)
 //
 // Response (same event name) for 'uri' type:
 //  - width: numeric width of the texture (often wider than visual.)
@@ -388,13 +401,14 @@ void WebSocketGPUBufferTexture(DebuggerRequest &req) {
 // Retrieve current CLUT (gpu.buffer.clut)
 //
 // Parameters:
-//  - type: either 'uri' or 'base64'.
+//  - type: either 'uri' or 'base64' (optional, defaults to 'uri').
 //  - alpha: boolean to include the alpha channel for 'uri' type.
-//  - stackWidth: forced width for 'uri' type (increases height.)
+//  - stackWidth: optional, forced width for 'uri' type (increases height.)
 //
 // Response (same event name) for 'uri' type:
 //  - width: numeric width of CLUT.
 //  - height: numeric height of CLUT.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - uri: data: URI of PNG image for display.
 //
 // Response (same event name) for 'base64' type:
@@ -402,6 +416,7 @@ void WebSocketGPUBufferTexture(DebuggerRequest &req) {
 //  - height: always 1.
 //  - flipped: boolean to indicate whether buffer is vertically flipped.
 //  - format: string indicating format, such as 'R8G8B8A8_UNORM' or 'B8G8R8A8_UNORM'.
+//  - isFramebuffer: optional, present and true if this came from a hardware framebuffer.
 //  - base64: base64 encode of binary data.
 void WebSocketGPUBufferClut(DebuggerRequest &req) {
 	GenericStreamBuffer(req, [](const GPUDebugBuffer *&buf, bool *isFramebuffer) {

--- a/Core/Debugger/WebSocket/GPUStatsSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GPUStatsSubscriber.cpp
@@ -126,6 +126,7 @@ void WebSocketGPUStatsState::FlipListener() {
 	float *sleepHistory;
 	float *history = __DisplayGetFrameTimes(&valid, &stats.frameTimePos, &sleepHistory);
 
+	// TODO: 'valid' could be 0 => frameTimes[0] and sleepTimes[0] could lead to a crash
 	stats.frameTimes.resize(valid);
 	stats.sleepTimes.resize(valid);
 	memcpy(&stats.frameTimes[0], history, sizeof(double) * valid);
@@ -149,6 +150,7 @@ void WebSocketGPUStatsState::FlipListener() {
 //
 // Note: stats are returned after the next flip completes (paused if CPU or GPU in break.)
 // Note: info and timing may not be accurate if certain settings are disabled.
+// Note: sending this event with no ticket will not trigger a response! (TODO: maybe fix this?)
 void WebSocketGPUStatsState::Get(DebuggerRequest &req) {
 	if (PSP_GetBootState() != BootState::Complete)
 		return req.Fail("CPU not started");

--- a/Core/Debugger/WebSocket/HLESubscriber.cpp
+++ b/Core/Debugger/WebSocket/HLESubscriber.cpp
@@ -180,7 +180,7 @@ void WebSocketHLEThreadStop(DebuggerRequest &req) {
 		break;
 
 	default:
-		return req.Fail("Cannot force run thread based on current status");
+		return req.Fail("Cannot force stop thread based on current status");
 	}
 
 	// Get it again to verify.

--- a/Core/Debugger/WebSocket/MemoryInfoSubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemoryInfoSubscriber.cpp
@@ -73,8 +73,6 @@ void WebSocketMemoryInfoState::UpdateOverride(bool flag) {
 //     - name: string, friendly name.
 //     - address: number, start address of range.
 //     - size: number, in bytes.
-//
-// Note: Even if you set false, may stay enabled if set by user or another debug session.
 void WebSocketMemoryInfoState::Mapping(DebuggerRequest &req) {
 	struct MemRange {
 		const char *type;

--- a/Core/Debugger/WebSocket/SteppingBroadcaster.cpp
+++ b/Core/Debugger/WebSocket/SteppingBroadcaster.cpp
@@ -50,8 +50,8 @@ private:
 // Sent unexpectedly with these properties:
 //  - pc: number value of PC register (inaccurate unless stepping.)
 //  - ticks: number of CPU cycles into emulation.
-//  - reason: a value submitted to Core_EnableStepping ("jit.branchdebug", "savestate.load", "ui.lost_focus", etc.)
-//  - relatedAddress: an address (often zero, but it can be a value of PC saved at some point, a related memory address, etc.)
+//  - reason: an optional property, if present, it's equal to the value submitted to Core_EnableStepping ("jit.branchdebug", "savestate.load", "ui.lost_focus", etc.)
+//  - relatedAddress: an optional address (often zero, but it can be a value of PC saved at some point, a related memory address, etc.), always present if 'reason' is present
 
 // CPU has resumed from stepping (cpu.resume)
 //


### PR DESCRIPTION
This addresses a few issues I've found in our codebase while working on the Python client for this websocket debugger.
1) The error message for the binary frames was too uninformative (at least to my taste).
2) Some event-related comments had been copy-pasted from another events and not all details had been changed accordingly, now they are fixed.
3) I've added more info about the fields of the `gpu.buffer.<...>` events.
4) Added a note about the _current_ `gpu.stats.get` behavior. I don't know whether it needs to be changed, by the way. What needs to be changed, however, is the implementation of the `WebSocketGPUStatsState::FlipListener` function (it's crashing the emulator right now). But it's not gonna be in this PR...
5) Lastly, the huge refactor of PPSSPP's internal state management has forced hrydgard to change the behavior of the stepping broadcaster: now it only adds the `reason` and `relatedAddress` fields to the `cpu.stepping` event if the break reason is not `BreakReason::None` => I've adjusted the comment there.