### PR TITLE
Off by one error from 2013

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -905,7 +905,7 @@ const HLEFunction *GetSyscallFuncPointer(MIPSOpcode op) {
 	int funcnum = callno & 0xFFF;
 	int modulenum = (callno & 0xFF000) >> 12;
 	if (funcnum == 0xfff) {
-		std::string_view modName = modulenum > (int)moduleDB.size() ? "(unknown)" : moduleDB[modulenum].name;
+		std::string_view modName = modulenum >= (int)moduleDB.size() ? "(unknown)" : moduleDB[modulenum].name;
 		ERROR_LOG(Log::HLE, "Unknown syscall: Module: '%.*s' (module: %d func: %d)", (int)modName.size(), modName.data(), modulenum, funcnum);
 		return NULL;
 	}


### PR DESCRIPTION
The commit https://github.com/hrydgard/ppsspp/commit/ce2ccd85b237add0883274925ad66f810204a392 was supposed to add a guard against the case when the module id from the syscall opcode is bigger than the size of the vector of registered HLE modules. This leaves out the case when the id is equal to the vector's size...

Found by CppCheck, reproduced by me. You can take any syscall instruction and overwrite it with `0x01BBFFCC` (`CC FF BB 01` in our memory view), which gives `0x6E` for `modulenum` and `0xFFF` for the `funcnum`. `0x6E` is our current HLE module count.

<img width="1328" height="286" alt="image" src="https://github.com/user-attachments/assets/b18eb323-c564-4823-a559-d875659cc69d" />
