### PR TITLE
Implement iOS bluetooth keyboard mappings for Ctrl/Shift/Alt/Meta

### DIFF
--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -238,6 +238,8 @@ static const KeyMap_IntStrPair key_names[] = {
 	{NKCODE_CTRL_RIGHT, "RCtrl"},
 	{NKCODE_ALT_LEFT, "LAlt"},
 	{NKCODE_ALT_RIGHT, "RAlt"},
+	{NKCODE_META_LEFT, "LMeta"},
+	{NKCODE_META_RIGHT, "RMeta"},
 	{NKCODE_SPACE, "Space"},
 	{NKCODE_WINDOW, "Windows"},
 	{NKCODE_DEL, "Backspace"},

--- a/ios/Controls.mm
+++ b/ios/Controls.mm
@@ -542,6 +542,14 @@ InputKeyCode HIDUsageToInputKeyCode(UIKeyboardHIDUsage usage) {
 	case UIKeyboardHIDUsageKeyboardMute: return NKCODE_MUTE;
 	case UIKeyboardHIDUsageKeyboardVolumeUp: return NKCODE_VOLUME_UP;
 	case UIKeyboardHIDUsageKeypadComma: return NKCODE_NUMPAD_COMMA;
+	case UIKeyboardHIDUsageKeyboardLeftShift: return NKCODE_SHIFT_LEFT;
+	case UIKeyboardHIDUsageKeyboardRightShift: return NKCODE_SHIFT_RIGHT;
+	case UIKeyboardHIDUsageKeyboardLeftControl: return NKCODE_CTRL_LEFT;
+	case UIKeyboardHIDUsageKeyboardRightControl: return NKCODE_CTRL_RIGHT;
+	case UIKeyboardHIDUsageKeyboardLeftAlt: return NKCODE_ALT_LEFT;
+	case UIKeyboardHIDUsageKeyboardRightAlt: return NKCODE_ALT_RIGHT;
+	case UIKeyboardHIDUsageKeyboardLeftGUI: return NKCODE_META_LEFT;
+	case UIKeyboardHIDUsageKeyboardRightGUI: return NKCODE_META_RIGHT;
 	default: return NKCODE_UNKNOWN;
 	}
 }


### PR DESCRIPTION
Missed these when setting up the mapping function.