### PR TITLE
Add configurable login data for PSN revival

### DIFF
--- a/Common/Net/URL.h
+++ b/Common/Net/URL.h
@@ -106,8 +106,7 @@ protected:
 // Easy to swap out for a UrlEncoder.
 struct MultipartFormDataEncoder : UrlEncoder
 {
-	MultipartFormDataEncoder() : UrlEncoder()
-	{
+	MultipartFormDataEncoder() : UrlEncoder() {
 		data.reserve(8192);
 		int r1 = rand();
 		int r2 = rand();

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -976,6 +976,11 @@ static const ConfigSetting networkSettings[] = {
 	ConfigSetting("AllowSpeedControlWhileConnected", &g_Config.bAllowSpeedControlWhileConnected, false, CfgFlag::PER_GAME),
 	ConfigSetting("DontDownloadInfraJson", &g_Config.bDontDownloadInfraJson, false, CfgFlag::DONT_SAVE),
 
+	// See comment in header
+	ConfigSetting("PSNNPID", &g_Config.sPSNNPID, "", CfgFlag::PER_GAME),
+	ConfigSetting("PSNPassword", &g_Config.sPSNPassword, "", CfgFlag::PER_GAME),
+	ConfigSetting("PSNToken", &g_Config.sPSNToken, "", CfgFlag::PER_GAME),
+
 	ConfigSetting("EnableNetworkChat", &g_Config.bEnableNetworkChat, false, CfgFlag::PER_GAME),
 	ConfigSetting("ChatButtonPosition", &g_Config.iChatButtonPosition, (int)ScreenEdgePosition::BOTTOM_LEFT, CfgFlag::PER_GAME),
 	ConfigSetting("ChatScreenPosition", &g_Config.iChatScreenPosition, (int)ScreenEdgePosition::BOTTOM_LEFT, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -489,6 +489,11 @@ public:
 	bool bAllowSavestateWhileConnected;  // Developer option, ini-only. No normal users need this, it's always wrong to save/load state when online.
 	bool bAllowSpeedControlWhileConnected;  // Useful in some games but not recommended.
 
+	// PSN revival servers (actual code in development by FoxLovesYou from Discord)
+	std::string sPSNNPID;
+	std::string sPSNPassword;
+	std::string sPSNToken;  // This will be set by a login mechanism
+
 	bool bEnableWlan;
 	std::map<std::string, std::string> mHostToAlias;  // Local DNS database stored in ini file
 	bool bEnableUPnP;

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -147,8 +147,9 @@ static int sceNpInit()
 	ERROR_LOG(Log::sceNet, "UNIMPL %s()", __FUNCTION__);
 
 	// We'll sanitize an extra time here, just to be safe from ini modifications.
-	if (g_Config.sInfrastructureUsername == SanitizeString(g_Config.sInfrastructureUsername, StringRestriction::AlphaNumDashUnderscore, 3, 16)) {
-		npOnlineId = g_Config.sInfrastructureUsername;
+	if (g_Config.sPSNNPID == SanitizeString(g_Config.sPSNNPID, StringRestriction::AlphaNumDashUnderscore, 3, 16)) {
+		npOnlineId = g_Config.sPSNNPID;
+		// There is also sPSNToken and sPSNPassword
 	} else {
 		npOnlineId.clear();
 	}

--- a/UI/DeveloperToolsScreen.cpp
+++ b/UI/DeveloperToolsScreen.cpp
@@ -343,8 +343,17 @@ void DeveloperToolsScreen::CreateNetworkTab(UI::LinearLayout *list) {
 	using namespace UI;
 	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
 	auto ms = GetI18NCategory(I18NCat::MAINSETTINGS);
+	auto di = GetI18NCategory(I18NCat::DIALOG);
 	list->Add(new ItemHeader(ms->T("Networking")));
 	list->Add(new CheckBox(&g_Config.bDontDownloadInfraJson, dev->T("Don't download infra-dns.json")));
+
+	// Note: Intensionally didn't use translation here, until we move these to the
+	// regular settings after the code is merged.
+	list->Add(new ItemHeader("PSN replacement"));
+	PopupTextInputChoice *usernameChoice = list->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sPSNNPID, di->T("Username"), "", 64, screenManager()));
+	usernameChoice->SetRestriction(StringRestriction::AlphaNumDashUnderscore, 3);
+	list->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sPSNPassword, di->T("Password"), "", 64, screenManager()));
+	list->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sPSNToken, "Token", "", 64, screenManager()));
 }
 
 void DeveloperToolsScreen::CreateGraphicsTab(UI::LinearLayout *list) {


### PR DESCRIPTION
FoxLovesYou in our Discord is working on sceNp and related to get certain PSN games working.

These parameters are needed for his work, but it's not merged yet so I'm just throwing them in development tools for now.