### PR TITLE
fix compiler warnings

### DIFF
--- a/Common/Net/URL.h
+++ b/Common/Net/URL.h
@@ -120,6 +120,8 @@ struct MultipartFormDataEncoder : UrlEncoder
 		Add(key, value, "", "");
 	}
 
+	using UrlEncoder::Add;
+
 	void Add(const std::string &key, const std::string &value, const std::string &filename, const std::string &mimeType)
 	{
 		data += "--" + boundary + "\r\n";

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1899,7 +1899,7 @@ void ImWatchWindow::Draw(ImConfig &cfg, ImControl &control, MIPSDebugInterface *
 				}
 				bool confirmed = ImGui::InputText("##edit", editBuffer_, ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll);
 				// Filter for only enter presses
-				confirmed = confirmed && ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter);
+				confirmed = confirmed && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter));
 				if (confirmed || ImGui::IsItemDeactivated()) {
 					watch.SetExpression(editBuffer_, mipsDebug);
 					editingWatchIndex_ = -1;
@@ -1935,7 +1935,7 @@ void ImWatchWindow::Draw(ImConfig &cfg, ImControl &control, MIPSDebugInterface *
 					break;
 				case WatchFormat::FLOAT:
 					memcpy(&valuef, &value, sizeof(valuef));
-					ImGui::Text("%f", value);
+					ImGui::Text("%f", static_cast<float>(value));
 					break;
 				case WatchFormat::STR:
 					if (Memory::IsValidAddress(value)) {


### PR DESCRIPTION
```
[27/35] Building CXX object CMakeFiles/PPSSPPWindows.dir/UI/ImDebugger/ImDebugger.cpp.obj
C:/src/ppsspp/UI/ImDebugger/ImDebugger.cpp:1902:27: warning: '&&' within '||' [-Wlogical-op-parentheses]
 1902 |                                 confirmed = confirmed && ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter);
      |                                             ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
C:/src/ppsspp/UI/ImDebugger/ImDebugger.cpp:1902:27: note: place parentheses around the '&&' expression to silence this warning
 1902 |                                 confirmed = confirmed && ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter);
      |                                                       ^
      |                                             (                                               )
C:/src/ppsspp/UI/ImDebugger/ImDebugger.cpp:1938:24: warning: format specifies type 'double' but the argument has type 'uint32_t' (aka 'unsigned int') [-Wformat]
 1938 |                                         ImGui::Text("%f", value);
      |                                                      ~~   ^~~~~
      |                                                      %u
2 warnings generated.
```
```
[958/1020] Building CXX object CMakeFiles/PPSSPPWindows.dir/UI/GameSettingsScreen.cpp.obj
In file included from C:/src/ppsspp/UI/GameSettingsScreen.cpp:65:
In file included from C:/src/ppsspp/Common/File/AndroidContentURI.h:6:
C:/src/ppsspp/Common/Net/URL.h:123:7: warning: 'MultipartFormDataEncoder::Add' hides overloaded virtual function [-Woverloaded-virtual]
  123 |         void Add(const std::string &key, const std::string &value, const std::string &filename, const std::string &mimeType)
      |              ^
C:/src/ppsspp/Common/Net/URL.h:35:15: note: hidden overloaded virtual function 'UrlEncoder::Add' declared here: different number of parameters (2 vs 4)
   35 |         virtual void Add(const std::string &key, const std::vector<std::string> &value)
      |                      ^
C:/src/ppsspp/Common/Net/URL.h:142:7: warning: 'MultipartFormDataEncoder::Add' hides overloaded virtual function [-Woverloaded-virtual]
  142 |         void Add(const std::string &key, const std::vector<uint8_t> &value, const std::string &filename, const std::string &mimeType)
      |              ^
C:/src/ppsspp/Common/Net/URL.h:35:15: note: hidden overloaded virtual function 'UrlEncoder::Add' declared here: different number of parameters (2 vs 4)
   35 |         virtual void Add(const std::string &key, const std::vector<std::string> &value)
      |                      ^
2 warnings generated.
```