### PR TITLE
[Libretro] Fix Windows build + D3D11 glitches

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -367,6 +367,7 @@ else ifneq (,$(findstring windows_msvc2019,$(platform)))
 	WindowsSDKSharedIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\shared")
 	WindowsSDKUCRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\ucrt")
 	WindowsSDKUMIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\um")
+	WindowsSDKWinRTIncludeDir := $(shell cygpath -w "$(WindowsSdkDir)\Include\$(WindowsSDKVersion)\winrt")
 	WindowsSDKUCRTLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\ucrt\$(TargetArchMoniker)")
 	WindowsSDKUMLibDir := $(shell cygpath -w "$(WindowsSdkDir)\Lib\$(WindowsSDKVersion)\um\$(TargetArchMoniker)")
 
@@ -388,7 +389,7 @@ else ifneq (,$(findstring windows_msvc2019,$(platform)))
 	PATH := $(shell IFS=$$'\n'; cygpath "$(VCCompilerToolsBinDir)"):$(PATH)
 	PATH := $(PATH):$(shell IFS=$$'\n'; cygpath "$(VsInstallRoot)/Common7/IDE")
 
-	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir)
+	export INCLUDE := $(INCLUDE);$(WindowsSDKSharedIncludeDir);$(WindowsSDKUCRTIncludeDir);$(WindowsSDKUMIncludeDir);$(WindowsSDKWinRTIncludeDir)
 	export LIB := $(LIB);$(WindowsSDKUCRTLibDir);$(WindowsSDKUMLibDir);$(FFMPEGDIR)/Windows/$(TARGET_ARCH)/lib
 	TARGET := $(TARGET_NAME)_libretro.dll
 	PSS_STYLE :=2

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -998,9 +998,6 @@ SOURCES_CXX += \
 SOURCES_CXX += \
 	$(COMMONDIR)/GPU/D3D11/D3D11Loader.cpp \
 	$(COMMONDIR)/GPU/D3D11/thin3d_d3d11.cpp
-
-INCFLAGS += -I$(CORE_DIR)/dx9sdk/Include/DX11
-
 endif
 
 SOURCES_CXX += \


### PR DESCRIPTION
Libretro builds for Windows were failing because of a `#include <wrl/client.h>` in `DrawEngineD3D11.h` and I was about to PR a revert for that change in Libretro Makefile.common: https://github.com/hrydgard/ppsspp/pull/20742/files#diff-a5bf97aabc7c821b1424e62ae1b16408638a3ccce3c10d265e5f5de5c233e92aL1002

Instead I tried a different approach with the Makefile and builds succeed: https://git.libretro.com/bslenul/ppsspp/-/pipelines/6619
But even better, it seems to fix the issues from #20110!