### PR TITLE
Resolve #20746 by checking addresses harshly in MIPSAnalyst

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -145,7 +145,7 @@ void VulkanPushPool::NextBlock(VkDeviceSize allocationSize) {
 	}
 
 	double start = time_now_d();
-	VkDeviceSize newBlockSize = std::max(originalBlockSize_ * 2, (VkDeviceSize)RoundUpToPowerOf2((uint32_t)allocationSize));
+	VkDeviceSize newBlockSize = std::max(originalBlockSize_ * 2, (VkDeviceSize)RoundToNextPowerOf2((uint32_t)allocationSize));
 
 	// We're still here and ran off the end of blocks. Create a new one.
 	blocks_.push_back(CreateBlock(newBlockSize));

--- a/Common/Math/math_util.h
+++ b/Common/Math/math_util.h
@@ -7,12 +7,12 @@
 #include <cstring>
 #include <cstdint>
 
-inline bool isPowerOf2(int n) {
+inline constexpr bool isPowerOf2(int n) {
 	return n == 1 || (n & (n - 1)) == 0;
 }
 
-// Next power of 2.
-inline uint32_t RoundUpToPowerOf2(uint32_t v) {
+// Next power of 2 (NOTE: Not next multiple of a power of two, like the below function!)
+inline constexpr uint32_t RoundToNextPowerOf2(uint32_t v) {
 	v--;
 	v |= v >> 1;
 	v |= v >> 2;
@@ -23,8 +23,13 @@ inline uint32_t RoundUpToPowerOf2(uint32_t v) {
 	return v;
 }
 
-inline uint32_t RoundUpToPowerOf2(uint32_t v, uint32_t power) {
-	return (v + power - 1) & ~(power - 1);
+// NOTE: multiple must be a power of two!
+inline constexpr uint32_t RoundUpToMultipleOf(uint32_t v, uint32_t multiple) {
+	return (v + multiple - 1) & ~(multiple - 1);
+}
+
+inline constexpr uint32_t RoundDownToMultipleOf(uint32_t v, uint32_t multiple) {
+	return v & ~(multiple - 1);
 }
 
 // TODO: this should just use a bitscan.

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -27,6 +27,7 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
+#include "Common/Math/math_util.h"
 #include "Core/MemMap.h"
 #include "Core/System.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
@@ -191,7 +192,7 @@ void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 {
 	u32 end = address+size;
 
-	address &= ~3;
+	address = RoundDownToMultipleOf(address, 4);
 	u32 start = address;
 
 	while (address < end && start <= address)

--- a/Core/Debugger/WebSocket/HLESubscriber.cpp
+++ b/Core/Debugger/WebSocket/HLESubscriber.cpp
@@ -247,11 +247,15 @@ void WebSocketHLEFuncAdd(DebuggerRequest &req) {
 	u32 addr;
 	if (!req.ParamU32("address", &addr))
 		return;
+
 	u32 size = -1;
 	if (!req.ParamU32("size", &size, false, DebuggerParamType::OPTIONAL))
 		return;
 	if (size == 0)
 		size = -1;
+
+	addr &= ~0x3; // Align.
+	size = (size + 3) & ~0x3; // Align.
 
 	std::string name;
 	if (!req.ParamString("name", &name, DebuggerParamType::OPTIONAL))
@@ -260,7 +264,7 @@ void WebSocketHLEFuncAdd(DebuggerRequest &req) {
 		name = StringFromFormat("z_un_%08x", addr);
 
 	u32 prevBegin = g_symbolMap->GetFunctionStart(addr);
-	u32 endBegin = size == -1 ? prevBegin : g_symbolMap->GetFunctionStart(addr + size - 1);
+	u32 endBegin = size == -1 ? prevBegin : g_symbolMap->GetFunctionStart(addr + size - 4);
 	if (prevBegin == addr) {
 		return req.Fail("Function already exists at 'address'");
 	} else if (endBegin != prevBegin) {
@@ -275,7 +279,7 @@ void WebSocketHLEFuncAdd(DebuggerRequest &req) {
 			size = prevSize - newPrevSize;
 
 		// Make sure we register the new length for replacements too.
-		MIPSAnalyst::ForgetFunctions(prevBegin, prevBegin + newPrevSize - 1);
+		MIPSAnalyst::ForgetFunctions(prevBegin, prevBegin + newPrevSize);
 		g_symbolMap->SetFunctionSize(prevBegin, newPrevSize);
 		MIPSAnalyst::RegisterFunction(prevBegin, newPrevSize, prevName.c_str());
 	} else {
@@ -285,7 +289,7 @@ void WebSocketHLEFuncAdd(DebuggerRequest &req) {
 	}
 
 	// To ensure we restore replacements.
-	MIPSAnalyst::ForgetFunctions(addr, addr + size - 1);
+	MIPSAnalyst::ForgetFunctions(addr, addr + size);
 	g_symbolMap->AddFunction(name.c_str(), addr, size);
 	g_symbolMap->SortSymbols();
 	MIPSAnalyst::RegisterFunction(addr, size, name.c_str());
@@ -326,6 +330,8 @@ void WebSocketHLEFuncRemove(DebuggerRequest &req) {
 	if (!req.ParamU32("address", &addr))
 		return;
 
+	addr &= ~0x3; // Align.
+
 	u32 funcBegin = g_symbolMap->GetFunctionStart(addr);
 	if (funcBegin == -1)
 		return req.Fail("No function found at 'address'");
@@ -337,10 +343,10 @@ void WebSocketHLEFuncRemove(DebuggerRequest &req) {
 		std::string prevName = g_symbolMap->GetLabelString(prevBegin);
 		u32 expandedSize = g_symbolMap->GetFunctionSize(prevBegin) + funcSize;
 		g_symbolMap->SetFunctionSize(prevBegin, expandedSize);
-		MIPSAnalyst::ForgetFunctions(prevBegin, prevBegin + expandedSize - 1);
+		MIPSAnalyst::ForgetFunctions(prevBegin, prevBegin + expandedSize);
 		MIPSAnalyst::RegisterFunction(prevBegin, expandedSize, prevName.c_str());
 	} else {
-		MIPSAnalyst::ForgetFunctions(funcBegin, funcBegin + funcSize - 1);
+		MIPSAnalyst::ForgetFunctions(funcBegin, funcBegin + funcSize);
 	}
 
 	g_symbolMap->RemoveFunction(funcBegin, true);
@@ -378,7 +384,7 @@ static u32 RemoveFuncSymbolsInRange(u32 addr, u32 size) {
 	}
 
 	if (counter) {
-		MIPSAnalyst::ForgetFunctions(addr, addr + size - 1);
+		MIPSAnalyst::ForgetFunctions(addr, addr + size);
 
 		// The following was copied from hle.func.remove:
 		g_symbolMap->SortSymbols();
@@ -413,9 +419,13 @@ void WebSocketHLEFuncRemoveRange(DebuggerRequest &req) {
 	u32 addr;
 	if (!req.ParamU32("address", &addr))
 		return;
+
 	u32 size;
 	if (!req.ParamU32("size", &size))
 		return;
+
+	addr &= ~0x3; // Align.
+	size = (size + 3) & ~0x3; // Align.
 
 	if (!Memory::IsValidRange(addr, size))
 		return req.Fail("Address or size outside valid memory");
@@ -449,6 +459,8 @@ void WebSocketHLEFuncRename(DebuggerRequest &req) {
 	if (!req.ParamString("name", &name))
 		return;
 
+	addr &= ~0x3; // Align.
+
 	u32 funcBegin = g_symbolMap->GetFunctionStart(addr);
 	if (funcBegin == -1)
 		return req.Fail("No function found at 'address'");
@@ -456,7 +468,7 @@ void WebSocketHLEFuncRename(DebuggerRequest &req) {
 
 	g_symbolMap->SetLabelName(name.c_str(), funcBegin);
 	// To ensure we reapply replacements (in case we check name there.)
-	MIPSAnalyst::ForgetFunctions(funcBegin, funcBegin + funcSize - 1);
+	MIPSAnalyst::ForgetFunctions(funcBegin, funcBegin + funcSize);
 	MIPSAnalyst::RegisterFunction(funcBegin, funcSize, name.c_str());
 	MIPSAnalyst::UpdateHashMap();
 	MIPSAnalyst::ApplyHashMap();
@@ -487,9 +499,14 @@ void WebSocketHLEFuncScan(DebuggerRequest &req) {
 	u32 addr;
 	if (!req.ParamU32("address", &addr))
 		return;
+
+
 	u32 size;
 	if (!req.ParamU32("size", &size))
 		return;
+
+	addr &= ~0x3; // Align.
+	size = (size + 3) & ~0x3; // Align.
 
 	bool remove = false;
 	if (!req.ParamBool("remove", &remove, DebuggerParamType::OPTIONAL))
@@ -502,7 +519,7 @@ void WebSocketHLEFuncScan(DebuggerRequest &req) {
 		RemoveFuncSymbolsInRange(addr, size);
 	}
 
-	bool insertSymbols = MIPSAnalyst::ScanForFunctions(addr, addr + size - 1, true);
+	bool insertSymbols = MIPSAnalyst::ScanForFunctions(addr, addr + size, true);
 	MIPSAnalyst::FinalizeScan(insertSymbols);
 
 	req.Respond();

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1352,11 +1352,11 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 			if (Memory::IsValid4AlignedRange(scanStart, scanEnd - scanStart)) {
 				// Skip the exports and imports sections, they're not code.
 				if (scanEnd >= std::min(modinfo->libent, modinfo->libstub)) {
-					insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
+					insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, std::min(modinfo->libent, modinfo->libstub), insertSymbols);
 					scanStart = std::min(modinfo->libentend, modinfo->libstubend);
 				}
 				if (scanEnd >= std::max(modinfo->libent, modinfo->libstub)) {
-					insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub) - 4, insertSymbols);
+					insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, std::max(modinfo->libent, modinfo->libstub), insertSymbols);
 					scanStart = std::max(modinfo->libentend, modinfo->libstubend);
 				}
 				insertSymbols = MIPSAnalyst::ScanForFunctions(scanStart, scanEnd, insertSymbols);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1172,7 +1172,7 @@ void TextureCacheCommon::SetTextureFramebuffer(const AttachCandidate &candidate)
 		}
 
 		if (needsDepthXSwizzle) {
-			texWidth = RoundUpToPowerOf2(texWidth);
+			texWidth = RoundToNextPowerOf2(texWidth);
 		}
 
 		gstate_c.curTextureWidth = texWidth;
@@ -2359,7 +2359,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		int depalWidth = framebuffer->renderWidth;
 		int texWidth = framebuffer->bufferWidth;
 		if (needsDepthXSwizzle) {
-			texWidth = RoundUpToPowerOf2(framebuffer->bufferWidth);
+			texWidth = RoundToNextPowerOf2(framebuffer->bufferWidth);
 			depalWidth = texWidth * framebuffer->renderScaleFactor;
 			gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
 		}

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -582,8 +582,9 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		plan.GetMipSize(i, &mipWidth, &mipHeight);
 
 		int bpp = VkFormatBytesPerPixel(actualFmt);
-		int optimalStrideAlignment = std::max(4, (int)vulkan->GetPhysicalDeviceProperties().properties.limits.optimalBufferCopyRowPitchAlignment);
-		int byteStride = RoundUpToPowerOf2(mipWidth * bpp, optimalStrideAlignment);  // output stride
+		// RoundToNextPowerOf2 is probably not necessary as the optimal alignment is gonna be a power of 2.
+		int optimalStrideAlignment = RoundToNextPowerOf2(std::max(4, (int)vulkan->GetPhysicalDeviceProperties().properties.limits.optimalBufferCopyRowPitchAlignment));
+		int byteStride = RoundUpToMultipleOf(mipWidth * bpp, optimalStrideAlignment);  // output stride
 		int pixelStride = byteStride / bpp;
 		int uploadSize = byteStride * mipHeight;
 

--- a/Windows/Debugger/EditSymbolsWindow.cpp
+++ b/Windows/Debugger/EditSymbolsWindow.cpp
@@ -165,7 +165,7 @@ void EditSymbolsWindow::Remove() {
 	}
 
 	if (counter) {
-		MIPSAnalyst::ForgetFunctions(address_, address_ + size_ - 1);
+		MIPSAnalyst::ForgetFunctions(address_, address_ + size_);
 
 		// The following was copied from hle.func.remove:
 		g_symbolMap->SortSymbols();


### PR DESCRIPTION
.. but also fixing up badly aligned addresses in HLESubscriber.cpp.

This should help eliminate any bad usage within PPSSPP itself, while also keeping existing websocket code working.

Additionally, this makes some end addresses exclusive instead of inclusive, which simplifies address math.

@Nemoumbra 

Fixes #20746 