### PR TITLE
CI : remove refernces to dx9sdk

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -32,8 +32,6 @@ jobs:
         find $PKGNAME/ext -name '*.dylib' -delete || true
         find $PKGNAME/ext -name '*.lib' -delete || true
         find $PKGNAME/ext -name '*.so.*' -delete || true
-        find $PKGNAME/dx9sdk -name '*.lib' -delete || true
-        find $PKGNAME/dx9sdk -name '*.dll' -delete || true
         rm -rf $PKGNAME/ext/rapidjson/thirdparty/gtest || true
         sed -i "s;unknown;${VERSION};" $PKGNAME/git-version.cmake || true
         TARBALL=$PKGNAME.tar.xz


### PR DESCRIPTION
dx9sdk was removed in  https://github.com/hrydgard/ppsspp/commit/f8c654366477c75ca864cc705f0de88e27c97193 this pr just removes refences to dx9sdk in the tarball  GitHub action 

hopefully i havent broken anything 