### PR TITLE
Windows: More startup performance

### DIFF
--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -970,9 +970,9 @@ namespace MainWindow
 			DestroyWindow(hWnd);
 			break;
 
-		case WM_MENUSELECT:
-			// Called when a menu is opened. Also when an item is selected, but meh.
-			UpdateMenus((HMENU)lParam);
+		case WM_INITMENUPOPUP:
+			// Called when a menu or submenu is about to be opened.
+			UpdateMenus((HMENU)wParam);
 			WindowsRawInput::NotifyMenu();
 			trapMouse = false;
 			break;

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -66,7 +66,7 @@ namespace MainWindow
 	void CreateVFPUWindow();
 	void NotifyDebuggerMapLoaded();
 	void DestroyDebugWindows();
-	void UpdateMenus(bool isMenuSelect = false);
+	void UpdateMenus(HMENU menuSelected);
 	void UpdateCommands();
 	void UpdateSwitchUMD();
 	void SetWindowTitle(const wchar_t *title);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -63,13 +63,11 @@ extern bool g_TakeScreenshot;
 namespace MainWindow {
 	extern HINSTANCE hInst;
 	extern bool noFocusPause;
-	static bool browsePauseAfter;
 
 	static std::unordered_map<int, std::string> initialMenuKeys;
 	static std::vector<std::string> availableShaders;
 	static std::string menuLanguageID = "";
 	static int menuKeymapGeneration = -1;
-	static bool menuShaderInfoLoaded = false;
 	std::vector<ShaderInfo> menuShaderInfo;
 
 	LRESULT CALLBACK AboutDlgProc(HWND, UINT, WPARAM, LPARAM);
@@ -162,30 +160,25 @@ namespace MainWindow {
 		return initialMenuKeys[menuID];
 	}
 
-	// TODO: Why isn't this just defined in the resoucre
-	void CreateHelpMenu(HMENU menu) {
-		auto des = GetI18NCategory(I18NCat::DESKTOPUI);
-
-		const std::wstring visitMainWebsite = ConvertUTF8ToWString(des->T("www.ppsspp.org"));
-		const std::wstring visitForum = ConvertUTF8ToWString(des->T("PPSSPP Forums"));
-		const std::wstring buyGold = ConvertUTF8ToWString(des->T("Buy PPSSPP Gold"));
-		const std::wstring gitHub = ConvertUTF8ToWString(des->T("GitHub"));
-		const std::wstring discord = ConvertUTF8ToWString(des->T("Discord"));
-		const std::wstring aboutPPSSPP = ConvertUTF8ToWString(des->T("About PPSSPP..."));
-
-		HMENU helpMenu = GetSubmenuById(menu, ID_HELP_MENU);
-		EmptySubMenu(helpMenu);
-
-		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_OPENWEBSITE, visitMainWebsite.c_str());
-		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_OPENFORUM, visitForum.c_str());
-		// Repeat the process for other languages, if necessary.
-		if (!System_GetPropertyBool(SYSPROP_APP_GOLD)) {
-			AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_BUYGOLD, buyGold.c_str());
+	void MainMenuInit(HWND hwndMain, HMENU hMenu) {
+		MENUINFO info;
+		ZeroMemory(&info, sizeof(MENUINFO));
+		info.cbSize = sizeof(MENUINFO);
+		info.cyMax = 0;
+		info.dwStyle = MNS_CHECKORBMP;
+		info.fMask = MIM_STYLE;
+		for (int i = 0; i < GetMenuItemCount(hMenu); i++) {
+			SetMenuInfo(GetSubMenu(hMenu, i), &info);
 		}
-		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_GITHUB, gitHub.c_str());
-		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_DISCORD, discord.c_str());
-		AppendMenu(helpMenu, MF_SEPARATOR, 0, 0);
-		AppendMenu(helpMenu, MF_STRING | MF_BYCOMMAND, ID_HELP_ABOUT, aboutPPSSPP.c_str());
+
+		// Always translate first: translating resets the menu.
+		TranslateMenus(hwndMain, hMenu);
+		// Don't need to update here, happens later.
+
+		HMENU helpMenu = GetSubmenuById(hMenu, ID_HELP_MENU);
+		if (System_GetPropertyBool(SYSPROP_APP_GOLD)) {
+			RemoveMenu(helpMenu, ID_HELP_BUYGOLD, MF_BYCOMMAND);
+		}
 	}
 
 	static void TranslateMenuItem(const HMENU hMenu, const int menuID, const std::wstring& accelerator = L"", const char *key = nullptr) {
@@ -321,7 +314,12 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_EMULATION_CHAT, g_Config.bSystemControls ? L"\tCtrl+C" : L"");
 
 		// Help menu: it's translated in CreateHelpMenu.
-		CreateHelpMenu(menu);
+		TranslateMenuItem(menu, ID_HELP_OPENWEBSITE);
+		TranslateMenuItem(menu, ID_HELP_OPENFORUM);
+		TranslateMenuItem(menu, ID_HELP_BUYGOLD);
+		TranslateMenuItem(menu, ID_HELP_GITHUB);
+		TranslateMenuItem(menu, ID_HELP_DISCORD);
+		TranslateMenuItem(menu, ID_HELP_ABOUT);
 	}
 
 	void TranslateMenus(HWND hWnd, HMENU menu) {
@@ -342,7 +340,7 @@ namespace MainWindow {
 	void BrowseAndBootDone(std::string filename);
 
 	void BrowseAndBoot(RequesterToken token, std::string defaultPath, bool browseDirectory) {
-		browsePauseAfter = false;
+		bool browsePauseAfter = false;
 		if (GetUIState() == UISTATE_INGAME) {
 			browsePauseAfter = Core_IsStepping();
 			if (!browsePauseAfter)
@@ -990,11 +988,7 @@ namespace MainWindow {
 			vfpudlg->Show(false);
 	}
 
-	void UpdateMenus(bool isMenuSelect) {
-		if (isMenuSelect) {
-			menuShaderInfoLoaded = false;
-		}
-
+	void UpdateMenus(HMENU menuSelected) {
 		HMENU menu = GetMenu(GetHWND());
 #define CHECKITEM(item,value) 	CheckMenuItem(menu,item,MF_BYCOMMAND | ((value) ? MF_CHECKED : MF_UNCHECKED));
 		CHECKITEM(ID_DEBUG_IGNOREILLEGALREADS, g_Config.bIgnoreBadMemAccess);

--- a/Windows/MainWindowMenu.h
+++ b/Windows/MainWindowMenu.h
@@ -7,6 +7,7 @@
 #include "Core/System.h"
 
 namespace MainWindow {
+	void MainMenuInit(HWND hWndMain, HMENU hMenu);
 	void MainWindowMenu_Process(HWND hWnd, WPARAM wParam);
 	void TranslateMenus(HWND hWnd, HMENU menu);
 	void BrowseAndBoot(RequesterToken token, std::string defaultPath, bool browseDirectory = false);

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -688,7 +688,14 @@ BEGIN
 
     POPUP "Help",                                       ID_HELP_MENU
     BEGIN
+        MENUITEM "www.ppsspp.org",                      ID_HELP_OPENWEBSITE
+        MENUITEM "PPSSPP Forums",                       ID_HELP_OPENFORUM
+        MENUITEM "Buy PPSSPP Gold",                     ID_HELP_BUYGOLD
         MENUITEM "", 0, MFT_SEPARATOR
+        MENUITEM "GitHub",                              ID_HELP_GITHUB
+        MENUITEM "Discord",                             ID_HELP_DISCORD
+        MENUITEM "", 0, MFT_SEPARATOR
+        MENUITEM "About PPSSPP...",                     ID_HELP_ABOUT
     END
 END
 


### PR DESCRIPTION
Code cleanup in Windows menu management.

Avoid expensive backend checks until the Backends menu is opened.

(The app is getting criticized by Google Play Console for bad startup performance, so I'm looking at it in general and found this. While irrelevant for Android it's nice to speed up startup on Windows too).