### PR TITLE
Android: Update to NDK 28

### DIFF
--- a/Common/LoongArch64Emitter.h
+++ b/Common/LoongArch64Emitter.h
@@ -113,8 +113,8 @@ static inline bool IsGPR(LoongArch64Reg reg) { return (reg & ~0x1F) == 0; }
 static inline bool IsFPR(LoongArch64Reg reg) { return (reg & ~0x1F) == 0x20; }
 static inline bool IsVPR(LoongArch64Reg reg) { return (reg & ~0x1F) == 0x40; }
 static inline bool IsXPR(LoongArch64Reg reg) { return (reg & ~0x1F) == 0x60; }
-static inline bool IsCFR(LoongArch64CFR cfr) { return (cfr < 8); }
-static inline bool IsFCSR(LoongArch64FCSR fcsr) { return (fcsr < 4); }
+static inline bool IsCFR(LoongArch64CFR cfr) { return ((int)cfr < 8); }
+static inline bool IsFCSR(LoongArch64FCSR fcsr) { return ((int)fcsr < 4); }
 inline LoongArch64Reg EncodeRegToV(LoongArch64Reg reg) { return (LoongArch64Reg)(DecodeReg(reg) + V0); }
 
 struct FixupBranch {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -4281,7 +4281,7 @@ int FlushPtpSocket(int socketId) {
 
 	// Send Empty Data just to trigger Nagle on/off effect to flush the send buffer, Do we need to trigger this at all or is it automatically flushed?
 	//changeBlockingMode(socket->id, nonblock);
-	int ret = send(socketId, nullptr, 0, MSG_NOSIGNAL);
+	int ret = send(socketId, "", 0, MSG_NOSIGNAL);
 	if (ret == SOCKET_ERROR) ret = socket_errno;
 	//changeBlockingMode(socket->id, 1);
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'com.gladed.androidgitversion' version '0.4.14'
 }
+
 apply plugin: 'com.android.application'
 
 androidGitVersion {
@@ -54,16 +55,6 @@ android {
 	}
 
 	defaultConfig {
-		/*
-		configurations.all {
-			resolutionStrategy {
-				// Newer versions are not compatible with our minsdk. Should find a way to exclude it entirely
-				// since we have no use for this transitive dependency.
-				force 'androidx.emoji2:emoji2-views-helper:1.0.0'
-			}
-		}
-		*/
-
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown") {
 			println "Overriding Android Version Name, Code: " + androidGitVersion.name() + " " + androidGitVersion.code()
@@ -213,10 +204,15 @@ android {
 			}
 		}
 	}
-	// TODO: This is deprecated and needs a replacement. See https://stackoverflow.com/questions/67330818/android-gradle-plugin7-0-0-alpha15-removed-variantfilter-property-how-to-rest
-	// Though, not really that important.
-	variantFilter { variant ->
-		def needed = variant.name in [
+	buildFeatures {
+		aidl = true
+		buildConfig = true
+	}
+}
+
+androidComponents {
+	beforeVariants(selector().all()) { variantBuilder ->
+		def needed = variantBuilder.name in [
 			'normalDebug',      // for debugging
 			'normalOptimized',  // for testing/user build
 			'normalRelease',    // for Google Play releases
@@ -229,13 +225,10 @@ android {
 			'legacyOptimized',  // for legacy testing/user build
 			'legacyRelease',    // for buildbot releases
 		]
-		variant.setIgnore(!needed)
-	}
-	buildFeatures {
-		aidl = true
-		buildConfig = true
+		variantBuilder.enable = needed
 	}
 }
+
 afterEvaluate {
 	android.sourceSets.main.assets.getSrcDirs().each { println it }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 android {
-	flavorDimensions += "variant"
+	flavorDimensions "variant"
 	namespace = 'org.ppsspp.ppsspp'
 	signingConfigs {
 		debug {
@@ -38,9 +38,6 @@ android {
 				storePassword RELEASE_STORE_PASSWORD
 				keyAlias RELEASE_KEY_ALIAS
 				keyPassword RELEASE_KEY_PASSWORD
-			}
-		} else {
-			release {
 			}
 		}
 	}
@@ -107,7 +104,7 @@ android {
 			aidl.srcDirs = ['src']
 			resources.srcDirs = ['src']
 			assets.srcDirs = [
-					'../assets',
+				'../assets',
 			]
 		}
 		normal {
@@ -132,10 +129,10 @@ android {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-							'-DANDROID_PLATFORM=android-21',
-							'-DANDROID_TOOLCHAIN=clang',
-							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_STL=c++_static'
+						'-DANDROID_PLATFORM=android-21',
+						'-DANDROID_TOOLCHAIN=clang',
+						'-DANDROID_CPP_FEATURES=',
+						'-DANDROID_STL=c++_static'
 				}
 			}
 			ndk {
@@ -149,12 +146,12 @@ android {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-							'-DANDROID_PLATFORM=android-21',
-							'-DANDROID_TOOLCHAIN=clang',
-							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_STL=c++_static',
-							'-DANDROID_ARM_NEON=TRUE',
-							'-DGOLD=TRUE'
+						'-DANDROID_PLATFORM=android-21',
+						'-DANDROID_TOOLCHAIN=clang',
+						'-DANDROID_CPP_FEATURES=',
+						'-DANDROID_STL=c++_static',
+						'-DANDROID_ARM_NEON=TRUE',
+						'-DGOLD=TRUE'
 				}
 			}
 			ndk {
@@ -164,7 +161,7 @@ android {
 		legacy {
 			applicationId 'org.ppsspp.ppsspplegacy'
 			dimension "variant"
-			targetSdkVersion 29  // This is the point of legacy.
+			// targetSdk is overridden in androidComponents below.
 			externalNativeBuild {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
@@ -184,18 +181,18 @@ android {
 		vr {
 			applicationId 'org.ppsspp.ppssppvr'
 			dimension "variant"
-			targetSdkVersion 29  // Do not upgrade this, we depend on not requiring scoped storage on Oculus.
+			// targetSdk is overridden in androidComponents below.
 			externalNativeBuild {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-							'-DANDROID_PLATFORM=android-21',
-							'-DANDROID_TOOLCHAIN=clang',
-							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_STL=c++_static',
-							'-DANDROID_ARM_NEON=TRUE',
-							'-DOPENXR=TRUE',
-							'-DANDROID_LEGACY=TRUE'
+						'-DANDROID_PLATFORM=android-21',
+						'-DANDROID_TOOLCHAIN=clang',
+						'-DANDROID_CPP_FEATURES=',
+						'-DANDROID_STL=c++_static',
+						'-DANDROID_ARM_NEON=TRUE',
+						'-DOPENXR=TRUE',
+						'-DANDROID_LEGACY=TRUE'
 				}
 			}
 			ndk {
@@ -226,6 +223,13 @@ androidComponents {
 			'legacyRelease',    // for buildbot releases
 		]
 		variantBuilder.enable = needed
+
+		// Override targetSdk for legacy and VR variants
+		if (variantBuilder.flavorName.contains("legacy")) {
+			variantBuilder.targetSdk = 29
+		} else if (variantBuilder.flavorName.contains("vr")) {
+			variantBuilder.targetSdk = 29
+		}
 	}
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
 
 	compileSdk = 36
 
-	ndkVersion = "27.2.12479018"
+	ndkVersion = "28.2.13676358"
 
 	compileOptions {
 		sourceCompatibility JavaVersion.VERSION_11
@@ -144,7 +144,6 @@ android {
 							'-DANDROID_PLATFORM=android-21',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 							'-DANDROID_STL=c++_static'
 				}
 			}
@@ -164,7 +163,6 @@ android {
 							'-DANDROID_CPP_FEATURES=',
 							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE',
-							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 							'-DGOLD=TRUE'
 				}
 			}
@@ -184,7 +182,6 @@ android {
 						'-DANDROID_TOOLCHAIN=clang',
 						'-DANDROID_CPP_FEATURES=',
 						'-DANDROID_STL=c++_static',
-						'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 						'-DANDROID_LEGACY=TRUE'
 				}
 			}
@@ -207,8 +204,7 @@ android {
 							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE',
 							'-DOPENXR=TRUE',
-							'-DANDROID_LEGACY=TRUE',
-							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
+							'-DANDROID_LEGACY=TRUE'
 				}
 			}
 			ndk {


### PR DESCRIPTION
We have increased the minimum requirement, so we can now do this. Gets us a newer compiler.

Also updates gradle.properties to avoid some deprecated constructs.