### PR TITLE
Rework the game info screen implementation

### DIFF
--- a/Common/Common.h
+++ b/Common/Common.h
@@ -38,21 +38,21 @@
 
 #ifndef ENUM_CLASS_BITOPS
 #define ENUM_CLASS_BITOPS(T) \
-	static inline T operator |(const T &lhs, const T &rhs) { \
+	static inline constexpr T operator |(const T &lhs, const T &rhs) { \
 		return T((int)lhs | (int)rhs); \
 	} \
 	static inline T &operator |= (T &lhs, const T &rhs) { \
 		lhs = lhs | rhs; \
 		return lhs; \
 	} \
-	static inline bool operator &(const T &lhs, const T &rhs) { \
+	static inline constexpr bool operator &(const T &lhs, const T &rhs) { \
 		return ((int)lhs & (int)rhs) != 0; \
 	} \
 	static inline T &operator &= (T &lhs, const T &rhs) { \
 		lhs = (T)((int)lhs & (int)rhs); \
 		return lhs; \
 	} \
-	static inline T operator ~(const T &rhs) { \
+	static inline constexpr T operator ~(const T &rhs) { \
 		return (T)(~((int)rhs)); \
 	}
 #endif

--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -399,6 +399,7 @@ std::string_view GameRegionToString(GameRegion region) {
 	case GameRegion::ASIA: return "Asia";
 	case GameRegion::KOREA: return "Korea";
 	case GameRegion::HOMEBREW: return "Homebrew";
+	case GameRegion::OTHER: return "(Unknown)";
 	default: return "Other";
 	}
 }

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -534,3 +534,29 @@ void DetectZipFileContents(struct zip *z, ZipFileInfo *info) {
 		info->contents = ZipFileContents::UNKNOWN;
 	}
 }
+
+const char *IdentifiedFileTypeToString(IdentifiedFileType type) {
+	switch (type) {
+	case IdentifiedFileType::ERROR_IDENTIFYING: return "ERROR_IDENTIFYING";
+	case IdentifiedFileType::PSP_PBP_DIRECTORY: return "PSP_PBP_DIRECTORY";
+	case IdentifiedFileType::PSP_PBP: return "PSP_PBP";
+	case IdentifiedFileType::PSP_ELF: return "PSP_ELF";
+	case IdentifiedFileType::PSP_ISO: return "PSP_ISO";
+	case IdentifiedFileType::PSP_ISO_NP: return "PSP_ISO_NP";
+	case IdentifiedFileType::PSP_DISC_DIRECTORY: return "PSP_DISC_DIRECTORY";
+	case IdentifiedFileType::UNKNOWN_BIN: return "UNKNOWN_BIN";
+	case IdentifiedFileType::UNKNOWN_ELF: return "UNKNOWN_ELF";
+	case IdentifiedFileType::UNKNOWN_ISO: return "UNKNOWN_ISO";
+	case IdentifiedFileType::ARCHIVE_RAR: return "ARCHIVE_RAR";
+	case IdentifiedFileType::ARCHIVE_ZIP: return "ARCHIVE_ZIP";
+	case IdentifiedFileType::ARCHIVE_7Z: return "ARCHIVE_7Z";
+	case IdentifiedFileType::PSP_PS1_PBP: return "PSP_PS1_PBP";
+	case IdentifiedFileType::ISO_MODE2: return "ISO_MODE2";
+	case IdentifiedFileType::NORMAL_DIRECTORY: return "NORMAL_DIRECTORY";
+	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY: return "PSP_SAVEDATA_DIRECTORY";
+	case IdentifiedFileType::PPSSPP_SAVESTATE: return "PPSSPP_SAVESTATE";
+	case IdentifiedFileType::PPSSPP_GE_DUMP: return "PPSSPP_GE_DUMP";
+	case IdentifiedFileType::UNKNOWN: return "UNKNOWN";
+	default: return "INVALID_TYPE";
+	}
+}

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -61,6 +61,8 @@ enum class IdentifiedFileType {
 	UNKNOWN,
 };
 
+const char *IdentifiedFileTypeToString(IdentifiedFileType type);
+
 // NB: It is a REQUIREMENT that implementations of this class are entirely thread safe!
 // TOOD: actually, is it really?
 class FileLoader {

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -39,6 +39,7 @@ namespace Draw {
 // A GameInfo object can also represent a piece of savedata.
 
 enum class GameInfoFlags {
+	EMPTY = 0x00,
 	FILE_TYPE = 0x01,  // Don't need to specify this, always included.
 	PARAM_SFO = 0x02,
 	ICON = 0x04,
@@ -194,7 +195,7 @@ public:
 	// redrawing the UI often. Only set flags to GAMEINFO_WANTBG or WANTSND if you really want them 
 	// because they're big. bgTextures and sound may be discarded over time as well.
 	// NOTE: This never returns null, so you don't need to check for that. Do check Ready() flags though.
-	std::shared_ptr<GameInfo> GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags);
+	std::shared_ptr<GameInfo> GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags, GameInfoFlags *outHasFlags = nullptr);
 	void FlushBGs();  // Gets rid of all BG textures. Also gets rid of bg sounds.
 
 	void CancelAll();

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -324,13 +324,14 @@ void GameScreen::CreateViews() {
 	if (inGame_) {
 		deleteChoice->SetEnabled(false);
 	}
-	if (System_GetPropertyBool(SYSPROP_CAN_CREATE_SHORTCUT)) {
+
+	if ((hasFlags & GameInfoFlags::PARAM_SFO) && System_GetPropertyBool(SYSPROP_CAN_CREATE_SHORTCUT)) {
 		rightColumnItems->Add(new Choice(ga->T("Create Shortcut")))->OnClick.Add([this](UI::EventParams &e) {
 			GameInfoFlags hasFlags;
 			std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GameInfoFlags::PARAM_SFO, &hasFlags);
 			if (hasFlags & GameInfoFlags::PARAM_SFO) {
-				// TODO: Should we block on Ready?
 				System_CreateGameShortcut(gamePath_, info->GetTitle());
+				g_OSD.Show(OSDType::MESSAGE_SUCCESS, GetI18NCategory(I18NCat::DIALOG)->T("Desktop shortcut created"), 2.0f);
 			}
 			return UI::EVENT_DONE;
 		});

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -50,11 +50,16 @@
 #include "UI/MainScreen.h"
 #include "UI/BackgroundAudio.h"
 #include "UI/SavedataScreen.h"
-#include "Core/Reporting.h"
+
+constexpr GameInfoFlags g_desiredFlags = GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::PIC0 | GameInfoFlags::PIC1 | GameInfoFlags::UNCOMPRESSED_SIZE | GameInfoFlags::SIZE;
 
 GameScreen::GameScreen(const Path &gamePath, bool inGame) : UIDialogScreenWithGameBackground(gamePath), inGame_(inGame) {
 	g_BackgroundAudio.SetGame(gamePath);
 	System_PostUIMessage(UIMessage::GAME_SELECTED, gamePath.ToString());
+
+	// Start fetching info, we'll display it as it arrives. We keep the known fetch status in knownFlags_,
+	// and recreate views whenever info->hasFlags != knownFlags_.
+	g_gameInfoCache->GetInfo(NULL, gamePath_, g_desiredFlags, &knownFlags_);
 }
 
 GameScreen::~GameScreen() {
@@ -75,28 +80,39 @@ template <typename I> std::string int2hexstr(I w, size_t hex_len = sizeof(I) << 
 void GameScreen::update() {
 	UIScreen::update();
 
+	GameInfoFlags hasFlags;
+	g_gameInfoCache->GetInfo(NULL, gamePath_, g_desiredFlags, &hasFlags);
+
+	bool recreate = false;
+
+	if (knownFlags_ != hasFlags) {
+		knownFlags_ = hasFlags;
+		recreate = true;
+	}
+
 	// Has the user requested a CRC32?
 	if (CRC32string == "...") {
 		// Wait until the CRC32 is ready.  It might take time on some devices.
-		if (Reporting::HasCRC(gamePath_)) {
-			uint32_t crcvalue = Reporting::RetrieveCRC(gamePath_);
-			CRC32string = int2hexstr(crcvalue);
-			if (tvCRC_) {
-				tvCRC_->SetVisibility(UI::V_VISIBLE);
-				tvCRC_->SetText(CRC32string);
-			}
-			if (tvCRCCopy_) {
-				tvCRCCopy_->SetVisibility(UI::V_VISIBLE);
-			}
-			if (btnCalcCRC_) {
-				btnCalcCRC_->SetVisibility(UI::V_GONE);
-			}
+		const bool hasCRC = Reporting::HasCRC(gamePath_);
+		if (hasCRC != knownHasCRC_) {
+			knownHasCRC_ = hasCRC;
+			recreate = true;
+			RecreateViews();
 		}
+	}
+
+	if (recreate) {
+		RecreateViews();
 	}
 }
 
 void GameScreen::CreateViews() {
-	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::PIC0 | GameInfoFlags::PIC1);
+	GameInfoFlags hasFlags;
+	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, g_desiredFlags, &hasFlags);
+	if (!info) {
+		// Shouldn't happen
+		return;
+	}
 
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 	auto ga = GetI18NCategory(I18NCat::GAME);
@@ -129,52 +145,77 @@ void GameScreen::CreateViews() {
 	}
 
 	leftColumn->Add(new Choice(di->T("Back"), "", false, new AnchorLayoutParams(150, WRAP_CONTENT, 10, NONE, NONE, 10)))->OnClick.Handle(this, &GameScreen::OnSwitchBack);
-	if (info->Ready(GameInfoFlags::PARAM_SFO)) {
-		ViewGroup *badgeHolder = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(10, 10, 110, NONE));
-		LinearLayout *mainGameInfo = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
-		mainGameInfo->SetSpacing(3.0f);
 
-		// Need an explicit size here because homebrew uses screenshots as icons.
-		badgeHolder->Add(new GameIconView(gamePath_, 2.0f, new LinearLayoutParams(144 * 2, 80 * 2, UI::Margins(0))));
-		badgeHolder->Add(mainGameInfo);
+	ViewGroup *badgeHolder = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(10, 10, 110, NONE));
+	LinearLayout *mainGameInfo = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
+	mainGameInfo->SetSpacing(3.0f);
 
-		leftColumn->Add(badgeHolder);
+	// Need an explicit size here because homebrew uses screenshots as icons.
+	badgeHolder->Add(new GameIconView(gamePath_, 2.0f, new LinearLayoutParams(144 * 2, 80 * 2, UI::Margins(0))));
+	badgeHolder->Add(mainGameInfo);
+	leftColumn->Add(badgeHolder);
 
-		LinearLayout *infoLayout = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(10, 200, NONE, NONE));
-		leftColumn->Add(infoLayout);
+	LinearLayout *infoLayout = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(10, 200, NONE, NONE));
+	leftColumn->Add(infoLayout);
 
+	if (hasFlags & GameInfoFlags::PARAM_SFO) {
 		// TODO: Add non-translated title here if available in gameDB.
-		tvTitle_ = mainGameInfo->Add(new TextView(info->GetTitle(), ALIGN_LEFT | FLAG_WRAP_TEXT, false, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvTitle_->SetShadow(true);
-		tvID_ = mainGameInfo->Add(new TextView("", ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvID_->SetShadow(true);
-		tvRegion_ = mainGameInfo->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvRegion_->SetShadow(true);
-		tvGameSize_ = mainGameInfo->Add(new TextView("...", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvGameSize_->SetShadow(true);
+		TextView *tvTitle = mainGameInfo->Add(new TextView(info->GetTitle(), ALIGN_LEFT | FLAG_WRAP_TEXT, false, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+		tvTitle->SetShadow(true);
 
-		// This one doesn't need to be updated.
-		infoLayout->Add(new TextView(gamePath_.ToVisualString(), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetShadow(true);
-		tvSaveDataSize_ = infoLayout->Add(new TextView("...", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvSaveDataSize_->SetShadow(true);
-		tvInstallDataSize_ = infoLayout->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvInstallDataSize_->SetShadow(true);
-		tvInstallDataSize_->SetVisibility(V_GONE);
-		tvPlayTime_ = infoLayout->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvPlayTime_->SetShadow(true);
-		tvPlayTime_->SetVisibility(V_GONE);
+		TextView *tvID = mainGameInfo->Add(new TextView(ReplaceAll(info->id_version, "_", " v"), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+		tvID->SetShadow(true);
+
+		TextView *tvRegion = mainGameInfo->Add(new TextView(ga->T(GameRegionToString(info->region)), ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+		tvRegion->SetShadow(true);
+	}
+
+	if ((hasFlags & GameInfoFlags::UNCOMPRESSED_SIZE) && (hasFlags & GameInfoFlags::SIZE)) {
+		char temp[256];
+		snprintf(temp, sizeof(temp), "%s: %s", ga->T_cstr("Game"), NiceSizeFormat(info->gameSizeOnDisk).c_str());
+		if (info->gameSizeUncompressed != info->gameSizeOnDisk) {
+			size_t len = strlen(temp);
+			snprintf(temp + len, sizeof(temp) - len, " (%s: %s)", ga->T_cstr("Uncompressed"), NiceSizeFormat(info->gameSizeUncompressed).c_str());
+		}
+		TextView *tvGameSize = mainGameInfo->Add(new TextView(temp, ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+		tvGameSize->SetShadow(true);
 		
-		LinearLayout *crcHoriz = infoLayout->Add(new LinearLayout(ORIENT_HORIZONTAL));
+		if (info->saveDataSize > 0) {
+			snprintf(temp, sizeof(temp), "%s: %s", ga->T_cstr("SaveData"), NiceSizeFormat(info->saveDataSize).c_str());
+			TextView *tvSaveDataSize = infoLayout->Add(new TextView(temp, ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+			tvSaveDataSize->SetShadow(true);
+		}
+		if (info->installDataSize > 0) {
+			snprintf(temp, sizeof(temp), "%s: %1.2f %s", ga->T_cstr("InstallData"), (float)(info->installDataSize) / 1024.f / 1024.f, ga->T_cstr("MB"));
+			TextView *tvInstallDataSize = infoLayout->Add(new TextView(temp, ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+			tvInstallDataSize->SetShadow(true);
+		}
+	}
 
-		if (fileTypeSupportCRC) {
+	infoLayout->Add(new TextView(gamePath_.ToVisualString(), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetShadow(true);
+
+	std::string str;
+	if (g_Config.TimeTracker().GetPlayedTimeString(info->id, &str)) {
+		TextView *tvPlayTime = infoLayout->Add(new TextView(str, ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+		tvPlayTime->SetShadow(true);
+		tvPlayTime->SetText(str);
+	}
+
+	LinearLayout *crcHoriz = infoLayout->Add(new LinearLayout(ORIENT_HORIZONTAL));
+
+	if (fileTypeSupportCRC) {
+		if (Reporting::HasCRC(gamePath_)) {
+			auto rp = GetI18NCategory(I18NCat::REPORTING);
+			uint32_t crcVal = Reporting::RetrieveCRC(gamePath_);
+			std::string crc = StringFromFormat("%08X", crcVal);
+
 			// CRC button makes sense.
-			tvCRC_ = crcHoriz->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(0.0, G_VCENTER)));
-			tvCRC_->SetShadow(true);
-			Visibility crcVisibility = Reporting::HasCRC(gamePath_) ? V_VISIBLE : V_GONE;
-			tvCRC_->SetVisibility(crcVisibility);
+			TextView *tvCRC = crcHoriz->Add(new TextView(ReplaceAll(rp->T("FeedbackCRCValue", "Disc CRC: %1"), "%1", crc), ALIGN_LEFT, true, new LinearLayoutParams(0.0, G_VCENTER)));
+			tvCRC->SetShadow(true);
+
 			if (System_GetPropertyBool(SYSPROP_HAS_TEXT_CLIPBOARD)) {
-				tvCRCCopy_ = crcHoriz->Add(new Button(di->T("Copy to clipboard"), new LinearLayoutParams(0.0, G_VCENTER)));
-				tvCRCCopy_->OnClick.Add([this](UI::EventParams &) {
+				Button *tvCRCCopy = crcHoriz->Add(new Button(di->T("Copy to clipboard"), new LinearLayoutParams(0.0, G_VCENTER)));
+				tvCRCCopy->OnClick.Add([this](UI::EventParams &) {
 					u32 crc = Reporting::RetrieveCRC(gamePath_);
 					char buffer[16];
 					snprintf(buffer, sizeof(buffer), "%08X", crc);
@@ -183,37 +224,63 @@ void GameScreen::CreateViews() {
 					g_OSD.Show(OSDType::MESSAGE_SUCCESS, buffer, 1.0f);
 					return UI::EVENT_DONE;
 				});
-				tvCRCCopy_->SetVisibility(crcVisibility);
-				tvCRCCopy_->SetScale(0.82f);
-			} else {
-				tvCRCCopy_ = nullptr;
+			}
+
+			// Let's check the CRC in the game database, looking up the ID and also matching the crc.
+			std::vector<GameDBInfo> dbInfos;
+			if ((hasFlags & GameInfoFlags::PARAM_SFO) && g_gameDB.GetGameInfos(info->id_version, &dbInfos)) {
+				bool found = false;
+				for (auto &dbInfo : dbInfos) {
+					if (dbInfo.crc == crcVal) {
+						found = true;
+					}
+				}
+				if (found) {
+					NoticeView *tvVerified = infoLayout->Add(new NoticeView(NoticeLevel::INFO, ga->T("ISO OK according to the ReDump project"), "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+					tvVerified->SetLevel(NoticeLevel::SUCCESS);
+				}
+			}
+		} else if (!isHomebrew_) {
+			GameDBInfo dbInfo;
+			std::vector<GameDBInfo> dbInfos;
+			if ((hasFlags & GameInfoFlags::PARAM_SFO) && !g_gameDB.GetGameInfos(info->id_version, &dbInfos)) {
+				// tvVerified_->SetText(ga->T("Game ID unknown - not in the ReDump database"));
+				// tvVerified_->SetVisibility(UI::V_VISIBLE);
+				// tvVerified_->SetLevel(NoticeLevel::WARN);
+			} else if ((hasFlags & GameInfoFlags::UNCOMPRESSED_SIZE) && info->gameSizeUncompressed != 0) {  // don't do this check if info still pending
+				bool found = false;
+				for (auto &dbInfo : dbInfos) {
+					// TODO: Doesn't take CSO/CHD into account.
+					if (info->gameSizeUncompressed == dbInfo.size) {
+						found = true;
+					}
+				}
+				if (!found) {
+					// tvVerified_->SetText(ga->T("File size incorrect, bad or modified ISO"));
+					// tvVerified_->SetVisibility(UI::V_VISIBLE);
+					// tvVerified_->SetLevel(NoticeLevel::ERROR);
+					// INFO_LOG(Log::Loader, "File size %d not matching game DB", (int)info->gameSizeUncompressed);
+				}
+
+				NoticeView *tvVerified = infoLayout->Add(new NoticeView(NoticeLevel::INFO, ga->T("Click \"Calculate CRC\" to verify ISO"), "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+				tvVerified->SetVisibility(UI::V_VISIBLE);
+				tvVerified->SetLevel(NoticeLevel::INFO);
 			}
 		}
+	}
 
-		tvVerified_ = infoLayout->Add(new NoticeView(NoticeLevel::INFO, ga->T("Click \"Calculate CRC\" to verify ISO"), "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		tvVerified_->SetVisibility(UI::V_GONE);
-		tvVerified_->SetSquishy(true);
+	NoticeView *tvVerified = infoLayout->Add(new NoticeView(NoticeLevel::INFO, ga->T("Click \"Calculate CRC\" to verify ISO"), "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+	tvVerified->SetVisibility(UI::V_GONE);
+	tvVerified->SetSquishy(true);
 
-		// Show plugin info, if any. Later might add checkboxes.
-		auto plugins = HLEPlugins::FindPlugins(info->id, g_Config.sLanguageIni);
-		if (!plugins.empty()) {
-			auto sy = GetI18NCategory(I18NCat::SYSTEM);
-			infoLayout->Add(new TextView(sy->T("Plugins"), ALIGN_LEFT, true));
-			for (const auto &plugin : plugins) {
-				infoLayout->Add(new TextView(ApplySafeSubstitutions("* %1", plugin.name), ALIGN_LEFT, true));
-			}
+	// Show plugin info, if any. Later might add checkboxes.
+	auto plugins = HLEPlugins::FindPlugins(info->id, g_Config.sLanguageIni);
+	if (!plugins.empty()) {
+		auto sy = GetI18NCategory(I18NCat::SYSTEM);
+		infoLayout->Add(new TextView(sy->T("Plugins"), ALIGN_LEFT, true));
+		for (const auto &plugin : plugins) {
+			infoLayout->Add(new TextView(ApplySafeSubstitutions("* %1", plugin.name), ALIGN_LEFT, true));
 		}
-	} else {
-		tvTitle_ = nullptr;
-		tvID_ = nullptr;
-		tvGameSize_ = nullptr;
-		tvSaveDataSize_ = nullptr;
-		tvInstallDataSize_ = nullptr;
-		tvRegion_ = nullptr;
-		tvPlayTime_ = nullptr;
-		tvCRC_ = nullptr;
-		tvCRCCopy_ = nullptr;
-		tvVerified_ = nullptr;
 	}
 
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
@@ -227,41 +294,41 @@ void GameScreen::CreateViews() {
 		rightColumnItems->Add(new Choice(ga->T("Play")))->OnClick.Handle(this, &GameScreen::OnPlay);
 	}
 
-	btnGameSettings_ = rightColumnItems->Add(new Choice(ga->T("Game Settings")));
-	btnGameSettings_->OnClick.Handle(this, &GameScreen::OnGameSettings);
-	if (inGame_)
-		btnGameSettings_->SetEnabled(false);
+	if (!info->id.empty()) {
+		Choice *btnGameSettings = rightColumnItems->Add(new Choice(ga->T("Game Settings")));
+		btnGameSettings->OnClick.Handle(this, &GameScreen::OnGameSettings);
+		if (inGame_)
+			btnGameSettings->SetEnabled(false);
 
-	btnDeleteGameConfig_ = rightColumnItems->Add(new Choice(ga->T("Delete Game Config")));
-	btnDeleteGameConfig_->OnClick.Handle(this, &GameScreen::OnDeleteConfig);
-	if (inGame_)
-		btnDeleteGameConfig_->SetEnabled(false);
+		if (info->hasConfig) {
+			Choice *btnDeleteGameConfig = rightColumnItems->Add(new Choice(ga->T("Delete Game Config")));
+			btnDeleteGameConfig->OnClick.Handle(this, &GameScreen::OnDeleteConfig);
+			if (inGame_)
+				btnDeleteGameConfig->SetEnabled(false);
+		} else {
+			Choice *btnCreateGameConfig = rightColumnItems->Add(new Choice(ga->T("Create Game Config")));
+			btnCreateGameConfig->OnClick.Handle(this, &GameScreen::OnCreateConfig);
+			if (inGame_)
+				btnCreateGameConfig->SetEnabled(false);
+		}
+	}
 
-	btnCreateGameConfig_ = rightColumnItems->Add(new Choice(ga->T("Create Game Config")));
-	btnCreateGameConfig_->OnClick.Handle(this, &GameScreen::OnCreateConfig);
-	if (inGame_)
-		btnCreateGameConfig_->SetEnabled(false);
-
-	btnGameSettings_->SetVisibility(V_GONE);
-	btnDeleteGameConfig_->SetVisibility(V_GONE);
-	btnCreateGameConfig_->SetVisibility(V_GONE);
-
-	btnDeleteSaveData_ = new Choice(ga->T("Delete Save Data"));
-	rightColumnItems->Add(btnDeleteSaveData_)->OnClick.Handle(this, &GameScreen::OnDeleteSaveData);
-	btnDeleteSaveData_->SetVisibility(V_GONE);
-
-	otherChoices_.clear();
+	if (info->saveDataSize) {
+		Choice *btnDeleteSaveData = new Choice(ga->T("Delete Save Data"));
+		rightColumnItems->Add(btnDeleteSaveData)->OnClick.Handle(this, &GameScreen::OnDeleteSaveData);
+	}
 
 	// Don't want to be able to delete the game while it's running.
-	Choice *deleteChoice = rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Delete Game"))));
+	Choice *deleteChoice = rightColumnItems->Add(new Choice(ga->T("Delete Game")));
 	deleteChoice->OnClick.Handle(this, &GameScreen::OnDeleteGame);
 	if (inGame_) {
 		deleteChoice->SetEnabled(false);
 	}
 	if (System_GetPropertyBool(SYSPROP_CAN_CREATE_SHORTCUT)) {
-		rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Create Shortcut"))))->OnClick.Add([=](UI::EventParams &e) {
-			std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GameInfoFlags::PARAM_SFO);
-			if (info->Ready(GameInfoFlags::PARAM_SFO)) {
+		rightColumnItems->Add(new Choice(ga->T("Create Shortcut")))->OnClick.Add([this](UI::EventParams &e) {
+			GameInfoFlags hasFlags;
+			std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GameInfoFlags::PARAM_SFO, &hasFlags);
+			if (hasFlags & GameInfoFlags::PARAM_SFO) {
 				// TODO: Should we block on Ready?
 				System_CreateGameShortcut(gamePath_, info->GetTitle());
 			}
@@ -271,7 +338,7 @@ void GameScreen::CreateViews() {
 
 	// TODO: This is synchronous, bad!
 	if (g_recentFiles.ContainsFile(gamePath_.ToString())) {
-		Choice *removeButton = rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Remove From Recent"))));
+		Choice *removeButton = rightColumnItems->Add(new Choice(ga->T("Remove From Recent")));
 		removeButton->OnClick.Handle(this, &GameScreen::OnRemoveFromRecent);
 		if (inGame_) {
 			removeButton->SetEnabled(false);
@@ -279,7 +346,7 @@ void GameScreen::CreateViews() {
 	}
 
 	if (System_GetPropertyBool(SYSPROP_CAN_SHOW_FILE)) {
-		rightColumnItems->Add(AddOtherChoice(new Choice(di->T("Show in folder"))))->OnClick.Add([this](UI::EventParams &e) {
+		rightColumnItems->Add(new Choice(di->T("Show in folder")))->OnClick.Add([this](UI::EventParams &e) {
 			System_ShowFileInFolder(gamePath_);
 			return UI::EVENT_DONE;
 		});
@@ -287,27 +354,24 @@ void GameScreen::CreateViews() {
 
 	if (g_Config.bEnableCheats) {
 		auto pa = GetI18NCategory(I18NCat::PAUSE);
-		rightColumnItems->Add(AddOtherChoice(new Choice(pa->T("Cheats"))))->OnClick.Handle(this, &GameScreen::OnCwCheat);
+		rightColumnItems->Add(new Choice(pa->T("Cheats")))->OnClick.Handle(this, &GameScreen::OnCwCheat);
 	}
 
-	btnSetBackground_ = rightColumnItems->Add(new Choice(ga->T("Use UI background")));
-	btnSetBackground_->OnClick.Handle(this, &GameScreen::OnSetBackground);
-	btnSetBackground_->SetVisibility(V_GONE);
+	if (info->pic1.texture) {
+		Choice *btnSetBackground = rightColumnItems->Add(new Choice(ga->T("Use UI background")));
+		btnSetBackground->OnClick.Handle(this, &GameScreen::OnSetBackground);
+		btnSetBackground->SetVisibility(V_GONE);
+	}
 
 	isHomebrew_ = info && info->region == GameRegion::HOMEBREW;
 	if (fileTypeSupportCRC && !isHomebrew_ && !Reporting::HasCRC(gamePath_) ) {
-		btnCalcCRC_ = rightColumnItems->Add(new ChoiceWithValueDisplay(&CRC32string, ga->T("Calculate CRC"), I18NCat::NONE));
-		btnCalcCRC_->OnClick.Handle(this, &GameScreen::OnDoCRC32);
-	} else {
-		btnCalcCRC_ = nullptr;
+		Choice *btnCalcCRC = rightColumnItems->Add(new ChoiceWithValueDisplay(&CRC32string, ga->T("Calculate CRC"), I18NCat::NONE));
+		btnCalcCRC->OnClick.Add([this](UI::EventParams &) {
+			CRC32string = "...";
+			Reporting::QueueCRC(gamePath_);
+			return UI::EVENT_DONE;
+		});
 	}
-}
-
-UI::Choice *GameScreen::AddOtherChoice(UI::Choice *choice) {
-	otherChoices_.push_back(choice);
-	// While loading.
-	choice->SetVisibility(UI::V_GONE);
-	return choice;
 }
 
 UI::EventReturn GameScreen::OnCreateConfig(UI::EventParams &e) {
@@ -336,176 +400,21 @@ UI::EventReturn GameScreen::OnDeleteConfig(UI::EventParams &e) {
 			}
 			g_Config.deleteGameConfig(info->id);
 			info->hasConfig = false;
-			screenManager()->RecreateAllViews();
+			RecreateViews();
 		}
 	}));
 	return UI::EVENT_DONE;
 }
 
 ScreenRenderFlags GameScreen::render(ScreenRenderMode mode) {
-	ScreenRenderFlags flags = UIScreen::render(mode);
-
-	auto ga = GetI18NCategory(I18NCat::GAME);
-
+	// Draw PIC0 as an underlay.
 	UIContext &dc = *screenManager()->getUIContext();
 	Draw::DrawContext *draw = dc.GetDrawContext();
 
-	float maxY = 0;
-	// NOTE: This won't be correct the first frame.
-	auto updateMaxY = [&](UI::View *v) {
-		maxY = std::max(maxY, v->GetBounds().y2());
-	};
+	GameInfoFlags hasFlags;
+	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(draw, gamePath_, GameInfoFlags::PARAM_SFO, &hasFlags);
 
-	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(draw, gamePath_, GameInfoFlags::PIC1 | GameInfoFlags::SIZE | GameInfoFlags::UNCOMPRESSED_SIZE);
-
-	if (tvTitle_) {
-		tvTitle_->SetText(info->GetTitle());
-		updateMaxY(tvTitle_);
-	}
-
-	if (info->Ready(GameInfoFlags::SIZE | GameInfoFlags::UNCOMPRESSED_SIZE)) {
-		char temp[256];
-		if (tvGameSize_) {
-			snprintf(temp, sizeof(temp), "%s: %s", ga->T_cstr("Game"), NiceSizeFormat(info->gameSizeOnDisk).c_str());
-			if (info->gameSizeUncompressed != info->gameSizeOnDisk) {
-				size_t len = strlen(temp);
-				snprintf(temp + len, sizeof(temp) - len, " (%s: %s)", ga->T_cstr("Uncompressed"), NiceSizeFormat(info->gameSizeUncompressed).c_str());
-			}
-			tvGameSize_->SetText(temp);
-			updateMaxY(tvGameSize_);
-		}
-		if (tvSaveDataSize_) {
-			if (info->saveDataSize > 0) {
-				snprintf(temp, sizeof(temp), "%s: %s", ga->T_cstr("SaveData"), NiceSizeFormat(info->saveDataSize).c_str());
-				tvSaveDataSize_->SetText(temp);
-			} else {
-				tvSaveDataSize_->SetVisibility(UI::V_GONE);
-			}
-			updateMaxY(tvSaveDataSize_);
-		}
-		if (info->installDataSize > 0 && tvInstallDataSize_) {
-			snprintf(temp, sizeof(temp), "%s: %1.2f %s", ga->T_cstr("InstallData"), (float) (info->installDataSize) / 1024.f / 1024.f, ga->T_cstr("MB"));
-			tvInstallDataSize_->SetText(temp);
-			tvInstallDataSize_->SetVisibility(UI::V_VISIBLE);
-			updateMaxY(tvInstallDataSize_);
-		}
-	}
-
-	if (tvRegion_) {
-		if (info->region == GameRegion::OTHER) {
-			tvRegion_->SetText(ga->T("Homebrew"));
-		} else {
-			tvRegion_->SetText(ga->T(GameRegionToString(info->region)));
-		}
-		updateMaxY(tvRegion_);
-	}
-
-	if (tvPlayTime_) {
-		std::string str;
-		if (g_Config.TimeTracker().GetPlayedTimeString(info->id, &str)) {
-			tvPlayTime_->SetText(str);
-			tvPlayTime_->SetVisibility(UI::V_VISIBLE);
-		}
-		updateMaxY(tvPlayTime_);
-	}
-
-	if (tvCRC_ && Reporting::HasCRC(gamePath_)) {
-		auto rp = GetI18NCategory(I18NCat::REPORTING);
-		uint32_t crcVal = Reporting::RetrieveCRC(gamePath_);
-		std::string crc = StringFromFormat("%08X", crcVal);
-		tvCRC_->SetText(ReplaceAll(rp->T("FeedbackCRCValue", "Disc CRC: %1"), "%1", crc));
-		tvCRC_->SetVisibility(UI::V_VISIBLE);
-		if (tvCRCCopy_) {
-			tvCRCCopy_->SetVisibility(UI::V_VISIBLE);
-		}
-
-		// Let's check the CRC in the game database, looking up the ID and also matching the crc.
-		std::vector<GameDBInfo> dbInfos;
-		if (tvVerified_ && info->Ready(GameInfoFlags::PARAM_SFO) && g_gameDB.GetGameInfos(info->id_version, &dbInfos)) {
-			bool found = false;
-			for (auto &dbInfo : dbInfos) {
-				if (dbInfo.crc == crcVal) {
-					found = true;
-				}
-			}
-			if (found) {
-				tvVerified_->SetText(ga->T("ISO OK according to the ReDump project"));
-				tvVerified_->SetLevel(NoticeLevel::SUCCESS);
-				tvVerified_->SetVisibility(UI::V_VISIBLE);
-			} else {
-				// Like the other messages below, disabled until we have a database we have confidence in.
-				// tvVerified_->SetText(ga->T("CRC checksum does not match, bad or modified ISO"));
-				// tvVerified_->SetLevel(NoticeLevel::ERROR);
-				tvVerified_->SetVisibility(UI::V_GONE);
-			}
-		} else if (tvVerified_) {
-			// tvVerified_->SetText(ga->T("Game ID unknown - not in the ReDump database"));
-			// tvVerified_->SetVisibility(UI::V_VISIBLE);
-			// tvVerified_->SetLevel(NoticeLevel::WARN);
-			tvVerified_->SetVisibility(UI::V_GONE);
-		}
-
-		updateMaxY(tvCRC_);
-		updateMaxY(tvVerified_);
-	} else if (!isHomebrew_) {
-		GameDBInfo dbInfo;
-		if (tvVerified_) {
-			std::vector<GameDBInfo> dbInfos;
-			if (info->Ready(GameInfoFlags::PARAM_SFO) && !g_gameDB.GetGameInfos(info->id_version, &dbInfos)) {
-				// tvVerified_->SetText(ga->T("Game ID unknown - not in the ReDump database"));
-				// tvVerified_->SetVisibility(UI::V_VISIBLE);
-				// tvVerified_->SetLevel(NoticeLevel::WARN);
-			} else if (info->Ready(GameInfoFlags::UNCOMPRESSED_SIZE) && info->gameSizeUncompressed != 0) {  // don't do this check if info still pending
-				bool found = false;
-				for (auto &dbInfo : dbInfos) {
-					// TODO: Doesn't take CSO/CHD into account.
-					if (info->gameSizeUncompressed == dbInfo.size) {
-						found = true;
-					}
-				}
-				if (!found) {
-					// tvVerified_->SetText(ga->T("File size incorrect, bad or modified ISO"));
-					// tvVerified_->SetVisibility(UI::V_VISIBLE);
-					// tvVerified_->SetLevel(NoticeLevel::ERROR);
-					// INFO_LOG(Log::Loader, "File size %d not matching game DB", (int)info->gameSizeUncompressed);
-				} else {
-					tvVerified_->SetText(ga->T("Click \"Calculate CRC\" to verify ISO"));
-					tvVerified_->SetVisibility(UI::V_VISIBLE);
-					tvVerified_->SetLevel(NoticeLevel::INFO);
-				}
-			}
-			updateMaxY(tvVerified_);
-		}
-	}
-
-	if (tvID_) {
-		tvID_->SetText(ReplaceAll(info->id_version, "_", " v"));
-		updateMaxY(tvID_);
-	}
-
-	if (!info->id.empty()) {
-		btnGameSettings_->SetVisibility(info->hasConfig ? UI::V_VISIBLE : UI::V_GONE);
-		btnDeleteGameConfig_->SetVisibility(info->hasConfig ? UI::V_VISIBLE : UI::V_GONE);
-		btnCreateGameConfig_->SetVisibility(info->hasConfig ? UI::V_GONE : UI::V_VISIBLE);
-
-		if (info->saveDataSize) {
-			btnDeleteSaveData_->SetVisibility(UI::V_VISIBLE);
-		}
-		if (info->pic1.texture) {
-			btnSetBackground_->SetVisibility(UI::V_VISIBLE);
-		}
-	}
-
-	if (info->Ready(GameInfoFlags::PARAM_SFO)) {
-		// At this point, the above buttons won't become visible.  We can show these now.
-		for (UI::Choice *choice : otherChoices_) {
-			choice->SetVisibility(UI::V_VISIBLE);
-		}
-	}
-
-	if (info->Ready(GameInfoFlags::PIC0) && info->pic0.texture) {
-		// Draw PIC0 as an overlay.
-
+	if ((knownFlags_ & GameInfoFlags::PIC0) && info->pic0.texture) {
 		bool draw = true;
 
 		const float w = dc.GetBounds().w - 500;
@@ -514,7 +423,7 @@ ScreenRenderFlags GameScreen::render(ScreenRenderMode mode) {
 		// Bottom align the image.
 		Bounds bounds(180, dc.GetBounds().h - h - 10, w, h);
 
-		maxY += 20;
+		float maxY = bounds.h / 2.0f;
 
 		if (bounds.y < maxY) {
 			// Recalculate.
@@ -537,23 +446,14 @@ ScreenRenderFlags GameScreen::render(ScreenRenderMode mode) {
 			dc.Begin();
 		}
 	}
-	return flags;
+
+	return UIScreen::render(mode);
 }
 
 UI::EventReturn GameScreen::OnCwCheat(UI::EventParams &e) {
 	screenManager()->push(new CwCheatScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
-
-UI::EventReturn GameScreen::OnDoCRC32(UI::EventParams& e) {
-	CRC32string = "...";
-	Reporting::QueueCRC(gamePath_);
-	if (btnCalcCRC_) {
-		btnCalcCRC_->SetEnabled(false);
-	}
-	return UI::EVENT_DONE;
-}
-
 
 UI::EventReturn GameScreen::OnSwitchBack(UI::EventParams &e) {
 	TriggerFinish(DR_OK);

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -23,6 +23,8 @@
 #include "Common/UI/UIScreen.h"
 #include "Common/File/Path.h"
 
+#include "UI/GameInfoCache.h"
+
 class NoticeView;
 
 // Game screen: Allows you to start a game, delete saves, delete the game,
@@ -46,8 +48,6 @@ protected:
 	void CreateViews() override;
 
 private:
-	UI::Choice *AddOtherChoice(UI::Choice *choice);
-
 	// Event handlers
 	UI::EventReturn OnPlay(UI::EventParams &e);
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
@@ -59,31 +59,14 @@ private:
 	UI::EventReturn OnDeleteConfig(UI::EventParams &e);
 	UI::EventReturn OnCwCheat(UI::EventParams &e);
 	UI::EventReturn OnSetBackground(UI::EventParams &e);
-	UI::EventReturn OnDoCRC32(UI::EventParams& e);
 
-	// As we load metadata in the background, we need to be able to update these after the fact.
-	UI::TextView *tvTitle_ = nullptr;
-	UI::TextView *tvGameSize_ = nullptr;
-	UI::TextView *tvSaveDataSize_ = nullptr;
-	UI::TextView *tvInstallDataSize_ = nullptr;
-	UI::TextView *tvRegion_ = nullptr;
-	UI::TextView *tvPlayTime_ = nullptr;
-	UI::TextView *tvCRC_ = nullptr;
-	UI::TextView *tvID_ = nullptr;
-	UI::Button *tvCRCCopy_ = nullptr;
-	NoticeView *tvVerified_ = nullptr;
-
-	UI::Choice *btnGameSettings_ = nullptr;
-	UI::Choice *btnCreateGameConfig_ = nullptr;
-	UI::Choice *btnDeleteGameConfig_ = nullptr;
-	UI::Choice *btnDeleteSaveData_ = nullptr;
-	UI::Choice *btnSetBackground_ = nullptr;
-
-	UI::Choice *btnCalcCRC_ = nullptr;
-
-	std::vector<UI::Choice *> otherChoices_;
 	std::string CRC32string;
 
 	bool isHomebrew_ = false;
 	bool inGame_ = false;
+
+	// Keep track of progressive loading of metadata.
+	GameInfoFlags knownFlags_ = GameInfoFlags::EMPTY;
+
+	bool knownHasCRC_ = false;
 };

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -65,6 +65,7 @@
 #include "UI/ImDebugger/ImDebugger.h"
 #include "UI/ImDebugger/ImGe.h"
 #include "UI/AudioCommon.h"
+#include "UI/GameInfoCache.h"
 
 extern bool g_TakeScreenshot;
 static ImVec4 g_normalTextColor;
@@ -545,6 +546,50 @@ void DrawParamSFO(ImConfig &cfg, ImControl &control) {
 		}
 		if (ImGui::BeginTabItem("Original")) {
 			renderParamSFOTable(g_paramSFORaw);
+			ImGui::EndTabItem();
+		}
+		if (ImGui::BeginTabItem("GameInfo")) {
+			Path path = PSP_CoreParameter().fileToStart;
+			std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, path, GameInfoFlags::PARAM_SFO);
+
+			if (info && ImGui::BeginTable("paramsfo", 2, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH | ImGuiTableFlags_Resizable)) {
+				ImGui::TableSetupColumn("Key", ImGuiTableColumnFlags_WidthFixed, 140.0f);
+				ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed, 270.0f);
+
+				ImGui::TableHeadersRow();
+
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted("Title");
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(info->GetTitle());
+
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted("Path");
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(path.ToVisualString());
+
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted("Detected type");
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(IdentifiedFileTypeToString(info->fileType));
+
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted("Detected region");
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(GameRegionToString(info->region));
+
+				ImGui::TableNextRow();
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted("HasConfig");
+				ImGui::TableNextColumn();
+				ImGui::TextUnformatted(BoolStr(info->hasConfig));
+
+				ImGui::EndTable();
+			}
 			ImGui::EndTabItem();
 		}
 		ImGui::EndTabBar();

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -570,6 +570,7 @@ Create Shortcut = ‎إصنع إختصار
 Delete Game = ‎إمسح اللعبة
 Delete Game Config = ‎مسح إعدادات اللعبة
 Delete Save Data = ‎مسح بيانات الحفظ
+Desktop shortcut created = تم إنشاء اختصار على سطح المكتب
 Europe = ‎أوروبا
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = ‎اللعبة

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -562,6 +562,7 @@ Create Shortcut = Create shortcut
 Delete Game = Delete game
 Delete Game Config = Delete game config
 Delete Save Data = Delete savedata
+Desktop shortcut created = Masa üstü qısa yol yaradıldı
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Game

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -562,6 +562,7 @@ Create Shortcut = Стварыць ярлык
 Delete Game = Выдаліць гульню
 Delete Game Config = Выдаліць канфіг
 Delete Save Data = Выдаліць дадзеныя захаванняў
+Desktop shortcut created = Створаны ярлык на працоўным стале
 Europe = Еўропа
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Гульня

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -562,6 +562,7 @@ Create Shortcut = Създай пряк път
 Delete Game = Изтрий игра
 Delete Game Config = Изтриване на конфигурацията на играта
 Delete Save Data = Изтриване на запаметени данни
+Desktop shortcut created = Създаден е десктопен пряк път
 Europe = Европа
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Игра

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -562,6 +562,7 @@ Create Shortcut = Crear accés directe
 Delete Game = Esborrar joc
 Delete Game Config = Esborrar config. del joc
 Delete Save Data = Esborrar dades guardades
+Desktop shortcut created = Accés directe de secretària creat
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Joc

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -562,6 +562,7 @@ Create Shortcut = Vytvořit zkratku
 Delete Game = Smazat hru
 Delete Game Config = Smazat nastavení hry
 Delete Save Data = Smazat uložená data
+Desktop shortcut created = Zástupce na ploše byl vytvořen
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Hra

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -562,6 +562,7 @@ Create Shortcut = Opret genvej
 Delete Game = Slet spil
 Delete Game Config = Slet data konfiguration
 Delete Save Data = Slet gemt data
+Desktop shortcut created = Genvej på skrivebordet oprettet
 Europe = Europa
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Spil

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -553,6 +553,7 @@ Create Shortcut = Verknüpfung erstellen
 Delete Game = Spiel löschen
 Delete Game Config = Spielkonfig. löschen
 Delete Save Data = Spielstand löschen
+Desktop shortcut created = Desktop-Verknüpfung erstellt
 Europe = Europa
 File size incorrect, bad or modified ISO = Dateigröße falsch, schlechtes oder verändertes ISO
 Game = Spiel

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -562,6 +562,7 @@ Create Shortcut = Garaganni shortcut
 Delete Game = Delete game
 Delete Game Config = Delete game config
 Delete Save Data = Delete savedata
+Desktop shortcut created = Jalan pintas desktop dibuat
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Paningoan

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -586,6 +586,7 @@ Create Shortcut = Create shortcut
 Delete Game = Delete game
 Delete Game Config = Delete game config
 Delete Save Data = Delete savedata
+Desktop shortcut created = Desktop shortcut created
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Game

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -563,6 +563,7 @@ Create Shortcut = Crear acceso directo
 Delete Game = Eliminar juego
 Delete Game Config = Eliminar configuración
 Delete Save Data = Eliminar datos guardados
+Desktop shortcut created = Acceso directo en el escritorio creado
 Europe = Europa
 File size incorrect, bad or modified ISO = Tamaño de archivo incorrecto, ISO incorrecta o modificada
 Game = Juego

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -562,6 +562,7 @@ Create Shortcut = Crear acceso directo
 Delete Game = Borrar juego
 Delete Game Config = Borrar config. del juego
 Delete Save Data = Borrar datos
+Desktop shortcut created = Acceso directo en el escritorio creado
 Europe = Europa
 File size incorrect, bad or modified ISO = Tamaño de archivo incorrecto, ISO incorrecto o modificado
 Game = Juego

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -562,6 +562,7 @@ Create Shortcut = ‎ساخت میانبر
 Delete Game = حذف بازی
 Delete Game Config = حذف تنظیمات بازی؟
 Delete Save Data = حذف دادهٔ بازی؟
+Desktop shortcut created = میانبر دسکتاپ ایجاد شد
 Europe = اروپا
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = ‎بازی

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -562,6 +562,7 @@ Create Shortcut = Luo pikakuvake
 Delete Game = Poista peli
 Delete Game Config = Poista pelin asetus
 Delete Save Data = Poista tallennustiedot
+Desktop shortcut created = Työpöydän pikakuvake luotu
 Europe = Eurooppa
 File size incorrect, bad or modified ISO = Tiedoston koko virheellinen – ISO-tiedosto on viallinen tai muokattu.
 Game = Peli

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -562,6 +562,7 @@ Create Shortcut = Créer un raccourci
 Delete Game = Supprimer jeu
 Delete Game Config = Supprimer config. de jeu
 Delete Save Data = Supprimer sauvegardes
+Desktop shortcut created = Raccourci sur le bureau créé
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Jeu 

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -562,6 +562,7 @@ Create Shortcut = Crear acceso directo
 Delete Game = Borrar xogo
 Delete Game Config = Borrar config. do xogo
 Delete Save Data = Borrar datos
+Desktop shortcut created = Acceso directo de escritorio creado
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Xogo

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -562,6 +562,7 @@ Create Shortcut = Δημιουργία Συντόμευσης
 Delete Game = Διαγραφή Παιχνιδιού
 Delete Game Config = Διαγραφή ρυθμίσεων παιχνιδιού
 Delete Save Data = Διαγραφή savedata
+Desktop shortcut created = Δημιουργήθηκε συντόμευση στην επιφάνεια εργασίας
 Europe = Ευρώπη
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Παιχνίδι

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -562,6 +562,7 @@ Create Shortcut = צור קיצור דרך
 Delete Game = Delete game
 Delete Game Config = Delete game config
 Delete Save Data = Delete savedata
+Desktop shortcut created = קיצור דרך לשולחן העבודה נוצר
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = משחק

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -559,6 +559,7 @@ Create Shortcut = Create shortcut
 Delete Game = Delete game
 Delete Game Config = Delete game config
 Delete Save Data = Delete savedata
+Desktop shortcut created = נוצר קיצור דרך לשולחן העבודה
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Game

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -562,6 +562,7 @@ Create Shortcut = Kreiraj prečac
 Delete Game = Izbriši igru
 Delete Game Config = Izbriši postavke igre
 Delete Save Data = Izbriši savedatu
+Desktop shortcut created = Stvorena prečica na radnoj površini
 Europe = Europa
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Igra

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -562,6 +562,7 @@ Create Shortcut = Parancsikon létrehozása
 Delete Game = Játék törlése
 Delete Game Config = Játékbeállítások törlése
 Delete Save Data = Mentések törlése
+Desktop shortcut created = Asztali parancsik létrehozva
 Europe = Európa
 File size incorrect, bad or modified ISO = Fájlméret helytelen - hibás vagy módosított ISO
 Game = Játék

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -562,6 +562,7 @@ Create Shortcut = Buat jalan pintas
 Delete Game = Hapus permainan
 Delete Game Config = Hapus konfigurasi permainan
 Delete Save Data = Hapus simpanan data
+Desktop shortcut created = Shortcut desktop telah dibuat
 Europe = Eropa
 File size incorrect, bad or modified ISO = Ukuran file salah, ISO rusak atau dimodifikasi
 Game = Permainan

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -562,6 +562,7 @@ Create Shortcut = Crea Scorciatoia
 Delete Game = Elimina Gioco
 Delete Game Config = Elimina Configurazione di Gioco
 Delete Save Data = Elimina Dati Salvataggio
+Desktop shortcut created = Scorciatoia sul desktop creata
 Europe = Europa
 File size incorrect, bad or modified ISO = Dimensione del file non corretta, l'ISO è errata o modificata
 Game = Gioco

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -562,6 +562,7 @@ Create Shortcut = ショートカットを作成する
 Delete Game = ゲームを削除する
 Delete Game Config = ゲームの設定を削除する
 Delete Save Data = セーブデータを削除する
+Desktop shortcut created = デスクトップショートカットが作成されました
 Europe = ヨーロッパ
 File size incorrect, bad or modified ISO = ファイルサイズが正しくありません。不良であるか変更されたISOです
 Game = ゲーム

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -562,6 +562,7 @@ Create Shortcut = Nggawe Trobosan
 Delete Game = Mbusek Dolanan
 Delete Game Config = Mbusek Setelan Dolanan
 Delete Save Data = Mbusek Simpenan
+Desktop shortcut created = Panjangnya desktop wis digawe
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Dolanan

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -562,6 +562,7 @@ Create Shortcut = 단축 키 생성
 Delete Game = 게임 삭제
 Delete Game Config = 게임 구성 삭제
 Delete Save Data = 저장데이터 삭제
+Desktop shortcut created = 바탕 화면 바로가기가 생성되었습니다
 Europe = 유럽
 File size incorrect, bad or modified ISO = 파일 크기가 잘못되었거나 잘못되었거나, 수정된 ISO
 Game = 게임

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -576,6 +576,7 @@ Create Shortcut = Create shortcut
 Delete Game = سڕینەوەی یاریەکە
 Delete Game Config = سڕینەوەی سێتینگی تایبەت بە یاریەکە
 Delete Save Data = سڕینەوەی زانیاری خەزن کراوی یاریەکە
+Desktop shortcut created = Shortcut-yê ser navê amadekirî
 Europe = ئەوروپا
 File size incorrect, bad or modified ISO = بریگەی فایلەکە هەڵەیە، ISO هەڵەیە یان دەستکاری کراوە
 Game = یاری

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -562,6 +562,7 @@ Create Shortcut = ຈາກຫຼ້າສຸດ
 Delete Game = ລຶບເກມ
 Delete Game Config = ລຶບການຕັ້ງຄ່າເກມ
 Delete Save Data = ລຶບຂໍ້ມູນທີ່ບັນທຶກ
+Desktop shortcut created = ສັນຍາລັກສາບ ສໍ່ເດັນສະຖານທີ່ ເປັນ ສໍ່ໃຈ
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = ເກມ

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -562,6 +562,7 @@ Create Shortcut = Kurti nuorodą
 Delete Game = Ištrinti žaidimą
 Delete Game Config = Delete game config
 Delete Save Data = Ištrinti išsaugojimą
+Desktop shortcut created = Darbalaukio nuoroda sukurta
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Žaidimas

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -562,6 +562,7 @@ Create Shortcut = Buat pintasan
 Delete Game = Padam permainan
 Delete Game Config = Delete game config
 Delete Save Data = Padam data disimpan
+Desktop shortcut created = Pintasan desktop dibuat
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Permainan

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -562,6 +562,7 @@ Create Shortcut = Snelkoppeling maken
 Delete Game = Game wissen
 Delete Game Config = Gameopties wissen
 Delete Save Data = Savedata wissen
+Desktop shortcut created = Bureaublad snelkoppeling gemaakt
 Europe = Europa
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Game

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -562,6 +562,7 @@ Create Shortcut = Create shortcut
 Delete Game = Delete game
 Delete Game Config = Delete game config
 Delete Save Data = Delete savedata
+Desktop shortcut created = Skrivebordsgenvei opprettet
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Game

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -564,6 +564,7 @@ Create Shortcut = Utwórz skrót
 Delete Game = Usuń grę
 Delete Game Config = Usuń konfigurację gry
 Delete Save Data = Usuń zapisy gry
+Desktop shortcut created = Utworzono skrót na pulpicie
 Europe = Europa
 File size incorrect, bad or modified ISO = Nieprawidłowy rozmiar pliku, plik ISO jest niepoprawny lub został zmodyfikowany
 Game = Gra

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -585,6 +585,7 @@ Create Shortcut = Criar atalho
 Delete Game = Apagar jogo
 Delete Game Config = Apagar configuração do jogo
 Delete Save Data = Apagar dados do save
+Desktop shortcut created = Atalho de desktop criado
 Europe = Europa
 File size incorrect, bad or modified ISO = Tamanho do arquivo incorreto, ISO ruim ou modificada
 Game = Jogo

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -586,6 +586,7 @@ Create Shortcut = Criar atalho
 Delete Game = Eliminar jogo
 Delete Game Config = Eliminar definições do jogo
 Delete Save Data = Eliminar dados salvos
+Desktop shortcut created = Atalho de área de trabalho criado
 Europe = Europa
 File size incorrect, bad or modified ISO = Tamanho de ficheiro incorreto, esta ISO provavelmente é uma copia de má qualidade ou está modificada
 Game = Jogo

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -563,6 +563,7 @@ Create Shortcut = Creează scurtătură
 Delete Game = Ștergere joc
 Delete Game Config = Ștergere configurare joc
 Delete Save Data = Ștergere salvare
+Desktop shortcut created = Shortcut pe desktop creat
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Joc

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -562,6 +562,7 @@ Create Shortcut = Создать ярлык
 Delete Game = Удалить игру
 Delete Game Config = Удалить конфиг
 Delete Save Data = Удалить сохранения
+Desktop shortcut created = Ярлык на рабочем столе создан
 Europe = Европа
 File size incorrect, bad or modified ISO = Некорректный размер файла, ISO испорчен или изменён
 Game = Игра

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -563,6 +563,7 @@ Create Shortcut = Skapa genväg
 Delete Game = Ta bort spel
 Delete Game Config = Ta bort spelconfig
 Delete Save Data = Ta bort sparad data
+Desktop shortcut created = Skrivbordsgenväg skapad
 Europe = Europa
 File size incorrect, bad or modified ISO = Filstorlek inkorrekt, eller korrupt ISO
 Game = Spel

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -563,6 +563,7 @@ Create Shortcut = Gumawa ng shortcut
 Delete Game = Burahin ang laro
 Delete Game Config = Burahin ang game config
 Delete Save Data = Burahin ang save data
+Desktop shortcut created = Символи десктоп сохта шуд
 Europe = Europa
 File size incorrect, bad or modified ISO = Mali ang laki ng file, maaring binago/dinaya ang ISO
 Game = Laro

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -578,6 +578,7 @@ Create Shortcut = สร้างทางลัด
 Delete Game = ลบเกม
 Delete Game Config = ลบการตั้งค่าเฉพาะเกม
 Delete Save Data = ลบข้อมูลเซฟที่บันทึกไว้
+Desktop shortcut created = สร้างทางลัดบนเดสก์ท็อป
 Europe = EU (โซนยุโรป)
 File size incorrect, bad or modified ISO = ขนาดไฟล์ผิดพลาด ไฟล์เกม ISO นี้ อาจจะไม่ดีหรือถูกดัดแปลงมา
 Game = ขนาดไฟล์เกม

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -564,6 +564,7 @@ Create Shortcut = Kısayol Oluştur
 Delete Game = Oyunu Sil
 Delete Game Config = Oyun Yapılandırmasını Sil
 Delete Save Data = Kayıtlı Veriyi Sil
+Desktop shortcut created = Masaüstü kısayolu oluşturuldu
 Europe = Avrupa
 File size incorrect, bad or modified ISO = Dosya boyutu yanlış, ISO hatalı veya değiştirilmiş olabilir.
 Game = Oyun

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -562,6 +562,7 @@ Create Shortcut = Створити ярлик
 Delete Game = Видалити гру
 Delete Game Config = Видалити конфіг
 Delete Save Data = Видалити збереження
+Desktop shortcut created = Ярлик на робочому столі створено
 Europe = Європа
 File size incorrect, bad or modified ISO = Неправильний розмір файлу, поганий або модифікований ISO
 Game = Гра

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -562,6 +562,7 @@ Create Shortcut = Tạo lối tắt
 Delete Game = Xóa trò chơi
 Delete Game Config = Xóa thiết lập cho game
 Delete Save Data = Xóa dữ liệu save
+Desktop shortcut created = Lối tắt trên desktop đã được tạo
 Europe = Europe
 File size incorrect, bad or modified ISO = File size incorrect, bad or modified ISO
 Game = Trò chơi

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -562,6 +562,7 @@ Create Shortcut = 创建快捷方式
 Delete Game = 删除游戏
 Delete Game Config = 删除游戏配置
 Delete Save Data = 删除存档
+Desktop shortcut created = 桌面快捷方式已创建
 Europe = 欧洲
 File size incorrect, bad or modified ISO = 文件大小与原版不符, 此ISO镜像有修改或损坏
 Game = 游戏

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -562,6 +562,7 @@ Create Shortcut = 建立捷徑
 Delete Game = 刪除遊戲
 Delete Game Config = 刪除遊戲組態
 Delete Save Data = 刪除存檔資料
+Desktop shortcut created = 桌面快速捷徑已創建
 Europe = 歐洲
 File size incorrect, bad or modified ISO = 檔案大小不正確，ISO 檔案錯誤或經過修改
 Game = 遊戲


### PR DESCRIPTION
This doesn't change the look much, but it cleans up the code and fixes race conditions, and also makes it much easier to change.

Somewhat related to #20785 

Also adds a GameInfo tab to the ParamSFO window in ImDebugger, and a notification when you create a desktop icon.