### PR TITLE
GEDebugger: fixed Verts tab displaying Invalid

### DIFF
--- a/Windows/GEDebugger/TabVertices.cpp
+++ b/Windows/GEDebugger/TabVertices.cpp
@@ -169,7 +169,7 @@ int CtrlVertexList::GetRowCount() {
 	// TODO: Maybe there are smarter ways?  Also, is this the best place to recalc?
 	auto state = gpuDebug->GetGState();
 
-	int rowCount_ = gpuDebug->GetCurrentPrimCount();
+	rowCount_ = gpuDebug->GetCurrentPrimCount();
 	if (!gpuDebug->GetCurrentDrawAsDebugVertices(rowCount_, vertices, indices)) {
 		rowCount_ = 0;
 	}


### PR DESCRIPTION
Resolves an issue where the Verts tab on the GE Debugger consistently displays "Invalid" for all vertex values. This was due to rowCount_ in TabVertices being left uninitialized.