### PR TITLE
Android shortcuts: Fix so that setting icons work even if PPSSPP isn't running

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -27,40 +27,46 @@ static jmethodID isExternalStoragePreservedLegacy;
 static jmethodID computeRecursiveDirectorySize;
 
 static jobject g_nativeActivity;
+static jclass g_classActivity;
 
 void Android_StorageSetNativeActivity(jobject nativeActivity) {
 	g_nativeActivity = nativeActivity;
 }
 
 void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
-	openContentUri = env->GetMethodID(env->GetObjectClass(obj), "openContentUri", "(Ljava/lang/String;Ljava/lang/String;)I");
+	jclass localClass = env->GetObjectClass(obj);
+
+	openContentUri = env->GetStaticMethodID(localClass, "openContentUri", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(openContentUri);
-	listContentUriDir = env->GetMethodID(env->GetObjectClass(obj), "listContentUriDir", "(Ljava/lang/String;)[Ljava/lang/String;");
+	listContentUriDir = env->GetMethodID(localClass, "listContentUriDir", "(Ljava/lang/String;)[Ljava/lang/String;");
 	_dbg_assert_(listContentUriDir);
-	contentUriCreateDirectory = env->GetMethodID(env->GetObjectClass(obj), "contentUriCreateDirectory", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriCreateDirectory = env->GetMethodID(localClass, "contentUriCreateDirectory", "(Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriCreateDirectory);
-	contentUriCreateFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriCreateFile", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriCreateFile = env->GetMethodID(localClass, "contentUriCreateFile", "(Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriCreateFile);
-	contentUriCopyFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriCopyFile", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriCopyFile = env->GetMethodID(localClass, "contentUriCopyFile", "(Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriCopyFile);
-	contentUriRemoveFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriRemoveFile", "(Ljava/lang/String;)I");
+	contentUriRemoveFile = env->GetMethodID(localClass, "contentUriRemoveFile", "(Ljava/lang/String;)I");
 	_dbg_assert_(contentUriRemoveFile);
-	contentUriMoveFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriMoveFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriMoveFile = env->GetMethodID(localClass, "contentUriMoveFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriMoveFile);
-	contentUriRenameFileTo = env->GetMethodID(env->GetObjectClass(obj), "contentUriRenameFileTo", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriRenameFileTo = env->GetMethodID(localClass, "contentUriRenameFileTo", "(Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriRenameFileTo);
-	contentUriGetFileInfo = env->GetMethodID(env->GetObjectClass(obj), "contentUriGetFileInfo", "(Ljava/lang/String;)Ljava/lang/String;");
+	contentUriGetFileInfo = env->GetMethodID(localClass, "contentUriGetFileInfo", "(Ljava/lang/String;)Ljava/lang/String;");
 	_dbg_assert_(contentUriGetFileInfo);
-	contentUriFileExists = env->GetMethodID(env->GetObjectClass(obj), "contentUriFileExists", "(Ljava/lang/String;)Z");
+	contentUriFileExists = env->GetMethodID(localClass, "contentUriFileExists", "(Ljava/lang/String;)Z");
 	_dbg_assert_(contentUriFileExists);
-	contentUriGetFreeStorageSpace = env->GetMethodID(env->GetObjectClass(obj), "contentUriGetFreeStorageSpace", "(Ljava/lang/String;)J");
+	contentUriGetFreeStorageSpace = env->GetMethodID(localClass, "contentUriGetFreeStorageSpace", "(Ljava/lang/String;)J");
 	_dbg_assert_(contentUriGetFreeStorageSpace);
-	filePathGetFreeStorageSpace = env->GetMethodID(env->GetObjectClass(obj), "filePathGetFreeStorageSpace", "(Ljava/lang/String;)J");
+	filePathGetFreeStorageSpace = env->GetMethodID(localClass, "filePathGetFreeStorageSpace", "(Ljava/lang/String;)J");
 	_dbg_assert_(filePathGetFreeStorageSpace);
-	isExternalStoragePreservedLegacy = env->GetMethodID(env->GetObjectClass(obj), "isExternalStoragePreservedLegacy", "()Z");
+	isExternalStoragePreservedLegacy = env->GetMethodID(localClass, "isExternalStoragePreservedLegacy", "()Z");
 	_dbg_assert_(isExternalStoragePreservedLegacy);
-	computeRecursiveDirectorySize = env->GetMethodID(env->GetObjectClass(obj), "computeRecursiveDirectorySize", "(Ljava/lang/String;)J");
+	computeRecursiveDirectorySize = env->GetMethodID(localClass, "computeRecursiveDirectorySize", "(Ljava/lang/String;)J");
 	_dbg_assert_(computeRecursiveDirectorySize);
+
+	g_classActivity = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
+	env->DeleteLocalRef(localClass); // cleanup local ref
 }
 
 bool Android_IsContentUri(std::string_view filename) {
@@ -96,7 +102,7 @@ int Android_OpenContentUriFd(std::string_view filename, Android_OpenContentUriMo
 	}
 	jstring j_filename = env->NewStringUTF(fname.c_str());
 	jstring j_mode = env->NewStringUTF(modeStr);
-	int fd = env->CallIntMethod(g_nativeActivity, openContentUri, j_filename, j_mode);
+	int fd = env->CallStaticIntMethod(g_classActivity, openContentUri, g_nativeActivity, j_filename, j_mode);
 	return fd;
 }
 

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -69,6 +69,8 @@ bool Android_IsContentUri(std::string_view filename) {
 
 int Android_OpenContentUriFd(std::string_view filename, Android_OpenContentUriMode mode) {
 	if (!g_nativeActivity) {
+		// Hit this in shortcut creation.
+		ERROR_LOG(Log::IO, "Android_OpenContentUriFd: No native activity");
 		return -1;
 	}
 

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -38,31 +38,31 @@ void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
 
 	openContentUri = env->GetStaticMethodID(localClass, "openContentUri", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(openContentUri);
-	listContentUriDir = env->GetMethodID(localClass, "listContentUriDir", "(Ljava/lang/String;)[Ljava/lang/String;");
+	listContentUriDir = env->GetStaticMethodID(localClass, "listContentUriDir", "(Landroid/app/Activity;Ljava/lang/String;)[Ljava/lang/String;");
 	_dbg_assert_(listContentUriDir);
-	contentUriCreateDirectory = env->GetMethodID(localClass, "contentUriCreateDirectory", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriCreateDirectory = env->GetStaticMethodID(localClass, "contentUriCreateDirectory", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriCreateDirectory);
-	contentUriCreateFile = env->GetMethodID(localClass, "contentUriCreateFile", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriCreateFile = env->GetStaticMethodID(localClass, "contentUriCreateFile", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriCreateFile);
-	contentUriCopyFile = env->GetMethodID(localClass, "contentUriCopyFile", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriCopyFile = env->GetStaticMethodID(localClass, "contentUriCopyFile", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriCopyFile);
-	contentUriRemoveFile = env->GetMethodID(localClass, "contentUriRemoveFile", "(Ljava/lang/String;)I");
+	contentUriRemoveFile = env->GetStaticMethodID(localClass, "contentUriRemoveFile", "(Landroid/app/Activity;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriRemoveFile);
-	contentUriMoveFile = env->GetMethodID(localClass, "contentUriMoveFile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriMoveFile = env->GetStaticMethodID(localClass, "contentUriMoveFile", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriMoveFile);
-	contentUriRenameFileTo = env->GetMethodID(localClass, "contentUriRenameFileTo", "(Ljava/lang/String;Ljava/lang/String;)I");
+	contentUriRenameFileTo = env->GetStaticMethodID(localClass, "contentUriRenameFileTo", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(contentUriRenameFileTo);
-	contentUriGetFileInfo = env->GetMethodID(localClass, "contentUriGetFileInfo", "(Ljava/lang/String;)Ljava/lang/String;");
+	contentUriGetFileInfo = env->GetStaticMethodID(localClass, "contentUriGetFileInfo", "(Landroid/app/Activity;Ljava/lang/String;)Ljava/lang/String;");
 	_dbg_assert_(contentUriGetFileInfo);
-	contentUriFileExists = env->GetMethodID(localClass, "contentUriFileExists", "(Ljava/lang/String;)Z");
+	contentUriFileExists = env->GetStaticMethodID(localClass, "contentUriFileExists", "(Landroid/app/Activity;Ljava/lang/String;)Z");
 	_dbg_assert_(contentUriFileExists);
-	contentUriGetFreeStorageSpace = env->GetMethodID(localClass, "contentUriGetFreeStorageSpace", "(Ljava/lang/String;)J");
+	contentUriGetFreeStorageSpace = env->GetStaticMethodID(localClass, "contentUriGetFreeStorageSpace", "(Landroid/app/Activity;Ljava/lang/String;)J");
 	_dbg_assert_(contentUriGetFreeStorageSpace);
-	filePathGetFreeStorageSpace = env->GetMethodID(localClass, "filePathGetFreeStorageSpace", "(Ljava/lang/String;)J");
+	filePathGetFreeStorageSpace = env->GetStaticMethodID(localClass, "filePathGetFreeStorageSpace", "(Landroid/app/Activity;Ljava/lang/String;)J");
 	_dbg_assert_(filePathGetFreeStorageSpace);
-	isExternalStoragePreservedLegacy = env->GetMethodID(localClass, "isExternalStoragePreservedLegacy", "()Z");
+	isExternalStoragePreservedLegacy = env->GetStaticMethodID(localClass, "isExternalStoragePreservedLegacy", "()Z");  // doesn't need an activity
 	_dbg_assert_(isExternalStoragePreservedLegacy);
-	computeRecursiveDirectorySize = env->GetMethodID(localClass, "computeRecursiveDirectorySize", "(Ljava/lang/String;)J");
+	computeRecursiveDirectorySize = env->GetStaticMethodID(localClass, "computeRecursiveDirectorySize", "(Landroid/app/Activity;Ljava/lang/String;)J");
 	_dbg_assert_(computeRecursiveDirectorySize);
 
 	g_classActivity = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
@@ -113,7 +113,7 @@ StorageError Android_CreateDirectory(const std::string &rootTreeUri, const std::
 	auto env = getEnv();
 	jstring paramRoot = env->NewStringUTF(rootTreeUri.c_str());
 	jstring paramDirName = env->NewStringUTF(dirName.c_str());
-	return StorageErrorFromInt(env->CallIntMethod(g_nativeActivity, contentUriCreateDirectory, paramRoot, paramDirName));
+	return StorageErrorFromInt(env->CallStaticIntMethod(g_classActivity, contentUriCreateDirectory, g_nativeActivity, paramRoot, paramDirName));
 }
 
 StorageError Android_CreateFile(const std::string &parentTreeUri, const std::string &fileName) {
@@ -123,7 +123,7 @@ StorageError Android_CreateFile(const std::string &parentTreeUri, const std::str
 	auto env = getEnv();
 	jstring paramRoot = env->NewStringUTF(parentTreeUri.c_str());
 	jstring paramFileName = env->NewStringUTF(fileName.c_str());
-	return StorageErrorFromInt(env->CallIntMethod(g_nativeActivity, contentUriCreateFile, paramRoot, paramFileName));
+	return StorageErrorFromInt(env->CallStaticIntMethod(g_classActivity, contentUriCreateFile, g_nativeActivity, paramRoot, paramFileName));
 }
 
 StorageError Android_CopyFile(const std::string &fileUri, const std::string &destParentUri) {
@@ -133,7 +133,7 @@ StorageError Android_CopyFile(const std::string &fileUri, const std::string &des
 	auto env = getEnv();
 	jstring paramFileName = env->NewStringUTF(fileUri.c_str());
 	jstring paramDestParentUri = env->NewStringUTF(destParentUri.c_str());
-	return StorageErrorFromInt(env->CallIntMethod(g_nativeActivity, contentUriCopyFile, paramFileName, paramDestParentUri));
+	return StorageErrorFromInt(env->CallStaticIntMethod(g_classActivity, contentUriCopyFile, g_nativeActivity, paramFileName, paramDestParentUri));
 }
 
 StorageError Android_MoveFile(const std::string &fileUri, const std::string &srcParentUri, const std::string &destParentUri) {
@@ -144,7 +144,7 @@ StorageError Android_MoveFile(const std::string &fileUri, const std::string &src
 	jstring paramFileName = env->NewStringUTF(fileUri.c_str());
 	jstring paramSrcParentUri = env->NewStringUTF(srcParentUri.c_str());
 	jstring paramDestParentUri = env->NewStringUTF(destParentUri.c_str());
-	return StorageErrorFromInt(env->CallIntMethod(g_nativeActivity, contentUriMoveFile, paramFileName, paramSrcParentUri, paramDestParentUri));
+	return StorageErrorFromInt(env->CallStaticIntMethod(g_classActivity, contentUriMoveFile, g_nativeActivity, paramFileName, paramSrcParentUri, paramDestParentUri));
 }
 
 StorageError Android_RemoveFile(const std::string &fileUri) {
@@ -153,7 +153,7 @@ StorageError Android_RemoveFile(const std::string &fileUri) {
 	}
 	auto env = getEnv();
 	jstring paramFileName = env->NewStringUTF(fileUri.c_str());
-	return StorageErrorFromInt(env->CallIntMethod(g_nativeActivity, contentUriRemoveFile, paramFileName));
+	return StorageErrorFromInt(env->CallStaticIntMethod(g_classActivity, contentUriRemoveFile, g_nativeActivity, paramFileName));
 }
 
 StorageError Android_RenameFileTo(const std::string &fileUri, const std::string &newName) {
@@ -163,7 +163,7 @@ StorageError Android_RenameFileTo(const std::string &fileUri, const std::string 
 	auto env = getEnv();
 	jstring paramFileUri = env->NewStringUTF(fileUri.c_str());
 	jstring paramNewName = env->NewStringUTF(newName.c_str());
-	return StorageErrorFromInt(env->CallIntMethod(g_nativeActivity, contentUriRenameFileTo, paramFileUri, paramNewName));
+	return StorageErrorFromInt(env->CallStaticIntMethod(g_classActivity, contentUriRenameFileTo, g_nativeActivity, paramFileUri, paramNewName));
 }
 
 // NOTE: Does not set fullName - you're supposed to already know it.
@@ -209,7 +209,7 @@ bool Android_GetFileInfo(const std::string &fileUri, File::FileInfo *fileInfo) {
 	auto env = getEnv();
 	jstring paramFileUri = env->NewStringUTF(fileUri.c_str());
 
-	jstring str = (jstring)env->CallObjectMethod(g_nativeActivity, contentUriGetFileInfo, paramFileUri);
+	jstring str = (jstring)env->CallStaticObjectMethod(g_classActivity, contentUriGetFileInfo, g_nativeActivity, paramFileUri);
 	if (!str) {
 		return false;
 	}
@@ -227,7 +227,7 @@ bool Android_FileExists(const std::string &fileUri) {
 	}
 	auto env = getEnv();
 	jstring paramFileUri = env->NewStringUTF(fileUri.c_str());
-	bool exists = env->CallBooleanMethod(g_nativeActivity, contentUriFileExists, paramFileUri);
+	bool exists = env->CallStaticBooleanMethod(g_classActivity, contentUriFileExists, g_nativeActivity, paramFileUri);
 	return exists;
 }
 
@@ -242,7 +242,7 @@ std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri, const
 	double start = time_now_d();
 
 	jstring param = env->NewStringUTF(uri.c_str());
-	jobject retval = env->CallObjectMethod(g_nativeActivity, listContentUriDir, param);
+	jobject retval = env->CallStaticObjectMethod(g_classActivity, listContentUriDir, g_nativeActivity, param);
 
 	jobjectArray fileList = (jobjectArray)retval;
 	std::vector<File::FileInfo> items;
@@ -283,7 +283,7 @@ int64_t Android_GetFreeSpaceByContentUri(const std::string &uri) {
 	auto env = getEnv();
 
 	jstring param = env->NewStringUTF(uri.c_str());
-	return env->CallLongMethod(g_nativeActivity, contentUriGetFreeStorageSpace, param);
+	return env->CallStaticLongMethod(g_classActivity, contentUriGetFreeStorageSpace, g_nativeActivity, param);
 }
 
 // Hm, this is never used? We use statvfs instead.
@@ -299,7 +299,7 @@ int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath) {
 	}
 
 	jstring param = env->NewStringUTF(filePath.c_str());
-	return env->CallLongMethod(g_nativeActivity, filePathGetFreeStorageSpace, param);
+	return env->CallStaticLongMethod(g_classActivity, filePathGetFreeStorageSpace, g_nativeActivity, param);
 }
 
 int64_t Android_ComputeRecursiveDirectorySize(const std::string &uri) {
@@ -311,7 +311,7 @@ int64_t Android_ComputeRecursiveDirectorySize(const std::string &uri) {
 	jstring param = env->NewStringUTF(uri.c_str());
 
 	double start = time_now_d();
-	int64_t size = env->CallLongMethod(g_nativeActivity, computeRecursiveDirectorySize, param);
+	int64_t size = env->CallStaticLongMethod(g_classActivity, computeRecursiveDirectorySize, g_nativeActivity, param);
 	double elapsed = time_now_d() - start;
 
 	INFO_LOG(Log::IO, "ComputeRecursiveDirectorySize(%s) in %0.3f s", uri.c_str(), elapsed);
@@ -323,7 +323,8 @@ bool Android_IsExternalStoragePreservedLegacy() {
 		return false;
 	}
 	auto env = getEnv();
-	return env->CallBooleanMethod(g_nativeActivity, isExternalStoragePreservedLegacy);
+	// Note: No activity param
+	return env->CallStaticBooleanMethod(g_classActivity, isExternalStoragePreservedLegacy);
 }
 
 const char *Android_ErrorToString(StorageError error) {

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -29,12 +29,13 @@ static jmethodID computeRecursiveDirectorySize;
 static jobject g_nativeActivity;
 static jclass g_classActivity;
 
-void Android_StorageSetNativeActivity(jobject nativeActivity) {
+void Android_StorageSetActivity(jobject nativeActivity) {
 	g_nativeActivity = nativeActivity;
 }
 
 void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
-	jclass localClass = env->GetObjectClass(obj);
+	jclass localClass = env->FindClass("org/ppsspp/ppsspp/PpssppActivity");
+	_dbg_assert_(localClass);
 
 	openContentUri = env->GetStaticMethodID(localClass, "openContentUri", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)I");
 	_dbg_assert_(openContentUri);
@@ -67,6 +68,28 @@ void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
 
 	g_classActivity = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
 	env->DeleteLocalRef(localClass); // cleanup local ref
+}
+
+void Android_UnregisterStorageCallbacks(JNIEnv * env) {
+	if (g_classActivity) {
+		env->DeleteGlobalRef(g_classActivity);
+		g_classActivity = nullptr;
+	}
+	g_nativeActivity = nullptr;
+	openContentUri = nullptr;
+	listContentUriDir = nullptr;
+	contentUriCreateFile = nullptr;
+	contentUriCreateDirectory = nullptr;
+	contentUriCopyFile = nullptr;
+	contentUriMoveFile = nullptr;
+	contentUriRemoveFile = nullptr;
+	contentUriRenameFileTo = nullptr;
+	contentUriGetFileInfo = nullptr;
+	contentUriFileExists = nullptr;
+	contentUriGetFreeStorageSpace = nullptr;
+	filePathGetFreeStorageSpace = nullptr;
+	isExternalStoragePreservedLegacy = nullptr;
+	computeRecursiveDirectorySize = nullptr;
 }
 
 bool Android_IsContentUri(std::string_view filename) {

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -41,7 +41,7 @@ extern std::string g_nativeLibDir;
 
 #include <jni.h>
 
-void Android_StorageSetNativeActivity(jobject nativeActivity);
+void Android_StorageSetActivity(jobject nativeActivity);
 
 bool Android_IsContentUri(std::string_view uri);
 int Android_OpenContentUriFd(std::string_view uri, const Android_OpenContentUriMode mode);
@@ -65,7 +65,9 @@ const char *Android_ErrorToString(StorageError error);
 // TODO: prefix doesn't do anything yet.
 std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri, const std::string &prefix, bool *exists);
 
+// Don't need to add these below, they're only used from app-android.cpp.
 void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj);
+void Android_UnregisterStorageCallbacks(JNIEnv * env);
 
 #else
 

--- a/Common/Log/LogManager.h
+++ b/Common/Log/LogManager.h
@@ -43,7 +43,7 @@ struct LogMessage {
 };
 
 enum class LogOutput {
-	Stdio = (1 << 0),
+	Stdio = (1 << 0),  // Also android log.
 	DebugString = (1 << 1),
 	RingBuffer = (1 << 2),
 	File = (1 << 3),

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -895,15 +895,12 @@ private:
 };
 
 GameInfoCache::GameInfoCache() {
-	Init();
 }
 
 GameInfoCache::~GameInfoCache() {
 	Clear();
 	Shutdown();
 }
-
-void GameInfoCache::Init() {}
 
 void GameInfoCache::Shutdown() {
 	CancelAll();

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -201,7 +201,6 @@ public:
 	void CancelAll();
 
 private:
-	void Init();
 	void Shutdown();
 
 	// Maps ISO path to info. Need to use shared_ptr as we can return these pointers - 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1700,11 +1700,7 @@ static void VulkanEmuThread(ANativeWindow *wnd) {
 	WARN_LOG(Log::G3D, "Render loop function exited.");
 }
 
-// NOTE: This is defunct and not working, due to how the Android storage functions currently require
-// a PpssppActivity specifically and we don't have one here.
-// We need to make openContentUri and friends into static functions that take a jobject activity, and here
-// we need to feed the ShortcutActivity to them.
-extern "C" jstring Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameName(JNIEnv * env, jclass, jstring jpath) {
+extern "C" jstring Java_org_ppsspp_ppsspp_ShortcutActivity_queryGame(JNIEnv * env, jclass, jobject activity, jstring jpath) {
 	bool teardownThreadManager = false;
 	if (!g_threadManager.IsInitialized()) {
 		// Need a thread manager.
@@ -1712,6 +1708,8 @@ extern "C" jstring Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameName(JNIEnv 
 		g_threadManager.Init(1, 1);
 		g_logManager.SetOutputsEnabled(LogOutput::Stdio);
 		g_logManager.SetAllLogLevels(LogLevel::LDEBUG);
+		Android_StorageSetNativeActivity(activity);
+		Android_RegisterStorageCallbacks(env, activity);
 		INFO_LOG(Log::System, "No thread manager - initializing one");
 	}
 
@@ -1759,7 +1757,7 @@ extern "C" jstring Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameName(JNIEnv 
 
 extern "C"
 JNIEXPORT jbyteArray JNICALL
-Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameIcon(JNIEnv * env, jclass clazz, jstring jpath) {
+Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameIcon(JNIEnv * env, jclass, jobject activity, jstring jpath) {
 	bool teardownThreadManager = false;
 	if (!g_threadManager.IsInitialized()) {
 		// Need a thread manager.
@@ -1767,6 +1765,9 @@ Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameIcon(JNIEnv * env, jclass clazz
 		g_threadManager.Init(1, 1);
 		g_logManager.SetOutputsEnabled(LogOutput::Stdio);
 		g_logManager.SetAllLogLevels(LogLevel::LDEBUG);
+
+		Android_StorageSetNativeActivity(activity);
+		Android_RegisterStorageCallbacks(env, activity);
 		INFO_LOG(Log::System, "No thread manager - initializing one");
 	}
 	// TODO: implement requestIcon()

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -267,7 +267,6 @@ public abstract class NativeActivity extends AppCompatActivity implements Sensor
 		if (list == null) {
 			Log.i(TAG, "getSdCardPaths: Attempting fallback");
 			// Try another method.
-			String removableStoragePath;
 			list = new ArrayList<>();
 			File[] fileList = new File("/storage/").listFiles();
 			if (fileList != null) {

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -1,6 +1,8 @@
 package org.ppsspp.ppsspp;
 
 import androidx.annotation.Keep;
+
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
@@ -157,10 +159,10 @@ public class PpssppActivity extends NativeActivity {
 
 	@Keep
 	@SuppressWarnings("unused")
-	public int openContentUri(String uriString, String mode) {
+	public static int openContentUri(Activity activity, String uriString, String mode) {
 		try {
 			Uri uri = Uri.parse(uriString);
-			try (ParcelFileDescriptor filePfd = getContentResolver().openFileDescriptor(uri, mode)) {
+			try (ParcelFileDescriptor filePfd = activity.getContentResolver().openFileDescriptor(uri, mode)) {
 				if (filePfd == null) {
 					// I'd expect an exception to happen before we get here, so this is probably
 					// never reached.

--- a/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
+++ b/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
@@ -12,6 +12,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import java.io.File;
 
 /**
@@ -71,11 +74,11 @@ public class ShortcutActivity extends Activity {
 		finish();
 	}
 
-	public static native String queryGameName(String path);
-	public static native byte[] queryGameIcon(String path);
+	public static native String queryGameName(Activity activity, String path);
+	public static native byte[] queryGameIcon(Activity activity, String path);
 
 	// Create shortcut as response for ACTION_CREATE_SHORTCUT intent.
-	private void respondToShortcutRequest(Uri uri) {
+	private void respondToShortcutRequest(@NonNull Uri uri) {
 		// This is Intent that will be sent when user execute our shortcut on
 		// homescreen. Set our app as target Context. Set Main activity as
 		// target class. Add any parameter as data.
@@ -113,7 +116,7 @@ public class ShortcutActivity extends Activity {
 		String name = pathSegments[pathSegments.length - 1];
 
 		PpssppActivity.CheckABIAndLoadLibrary();
-		String gameName = queryGameName(path);
+		String gameName = queryGameName(this, path);
 		byte [] iconData = null;
 		if (gameName.isEmpty()) {
 			Log.i(TAG, "Failed to retrieve game name - ignoring.");
@@ -122,7 +125,7 @@ public class ShortcutActivity extends Activity {
 			// return;
 		} else {
 			name = gameName;
-			iconData = queryGameIcon(path);
+			iconData = queryGameIcon(this, path);
 		}
 
 		Log.i(TAG, "Game name: " + name + " : Creating shortcut to " + uri);


### PR DESCRIPTION
- Fixes #10885.

This required making all the storage methods static, and passing in an activity as a parameter, so we can also use the ShortcutActivity as the content resolver / application context.

There's a potential race condition if PPSSPP starts while in the process of creating the icon, but seems pretty unlikely... I'll see if I can fix that later though.