### PR TITLE
On the pause screen, if no other banner is visible, move the save buttons down a bit.

### DIFF
--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -122,6 +122,7 @@ PermissionStatus System_GetPermissionStatus(SystemPermission permission);
 void System_AskForPermission(SystemPermission permission);
 
 // This will get muddy with multi-screen support :/ But this will always be the type of the main device.
+// These are the return values from System_GetPropertyInt(SYSPROP_DEVICE_TYPE).
 enum SystemDeviceType {
 	DEVICE_TYPE_MOBILE = 0,  // phones and pads
 	DEVICE_TYPE_TV = 1,  // Android TV and similar

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -419,8 +419,12 @@ void GamePauseScreen::CreateViews() {
 	LinearLayout *leftColumnItems = new LinearLayoutList(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
 	leftColumn->Add(leftColumnItems);
 
+	// If no other banner added, we want to add a spacer to move the Save/Load state buttons down a bit.
+	bool bannerAdded = false;
+
 	leftColumnItems->SetSpacing(5.0f);
 	if (Achievements::IsActive()) {
+		bannerAdded = true;
 		leftColumnItems->Add(new GameAchievementSummaryView());
 
 		char buf[512];
@@ -431,6 +435,7 @@ void GamePauseScreen::CreateViews() {
 	}
 
 	if (IsNetworkConnected()) {
+		bannerAdded = true;
 		leftColumnItems->Add(new NoticeView(NoticeLevel::INFO, nw->T("Network connected"), ""));
 
 		const InfraDNSConfig &dnsConfig = GetInfraDNSConfig();
@@ -478,6 +483,7 @@ void GamePauseScreen::CreateViews() {
 
 	if (showSavestateControls) {
 		if (PSP_CoreParameter().compat.flags().SaveStatesNotRecommended) {
+			bannerAdded = true;
 			LinearLayout *horiz = new LinearLayout(UI::ORIENT_HORIZONTAL);
 			leftColumnItems->Add(horiz);
 			horiz->Add(new NoticeView(NoticeLevel::WARN, pa->T("Using save states is not recommended in this game"), "", new LinearLayoutParams(1.0f)));
@@ -486,6 +492,13 @@ void GamePauseScreen::CreateViews() {
 				return UI::EVENT_DONE;
 			});
 		}
+
+		if (!bannerAdded && System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
+			// Enough so that it's possible to click the save/load buttons of Save 1 without activating
+			// a pulldown on Android for example.
+			leftColumnItems->Add(new Spacer(30.0f));
+		}
+
 		CreateSavestateControls(leftColumnItems, vertical);
 	} else {
 		// Let's show the active challenges.


### PR DESCRIPTION
Was reminded of this problem by Hen_MB on Discord.

This makes them easier to hit when there's a pulldown or something in the way, which there often is on Android.