### PR TITLE
UI image atlas: More cleanup

### DIFF
--- a/Common/Data/Format/PNGLoad.h
+++ b/Common/Data/Format/PNGLoad.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "Common/BitSet.h"
+#include "Common/File/Path.h"
 
 // *image_data_ptr should be deleted with free()
 // return value of 1 == success.
@@ -31,3 +32,5 @@ struct PNGHeaderPeek {
 	int Width() const { return swap32(be_width); }
 	int Height() const { return swap32(be_height); }
 };
+
+bool pngSave(const Path &filename, const void *buffer, int w, int h, int bytesPerPixel);

--- a/Common/Render/AtlasGen.cpp
+++ b/Common/Render/AtlasGen.cpp
@@ -65,14 +65,6 @@ void Image::copyfrom(const Image &img, int ox, int oy, Effect effect) {
 	}
 }
 
-void Image::set(int sx, int sy, int ex, int ey, u32 fil) {
-	for (int y = sy; y < ey; y++) {
-		for (int x = sx; x < ex; x++) {
-			dat[y * w + x] = fil;
-		}
-	}
-}
-
 bool Image::LoadPNG(const char *png_name) {
 	unsigned char *img_data;
 	int w, h;
@@ -89,23 +81,7 @@ bool Image::LoadPNG(const char *png_name) {
 }
 
 void Image::SavePNG(const char *png_name) {
-	// Save PNG
-	FILE *fil = fopen(png_name, "wb");
-	png_structp  png_ptr;
-	png_infop  info_ptr;
-	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
-	assert(png_ptr);
-	info_ptr = png_create_info_struct(png_ptr);
-	assert(info_ptr);
-	png_init_io(png_ptr, fil);
-	//png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);
-	png_set_IHDR(png_ptr, info_ptr, w, h, 8, PNG_COLOR_TYPE_RGBA, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-	png_write_info(png_ptr, info_ptr);
-	for (int y = 0; y < height(); y++) {
-		png_write_row(png_ptr, (png_byte*)(dat.data() + y * w));
-	}
-	png_write_end(png_ptr, NULL);
-	png_destroy_write_struct(&png_ptr, &info_ptr);
+	pngSave(Path(png_name), dat.data(), w, h, 4);
 }
 
 void Image::SaveZIM(const char *zim_name, int zim_format) {

--- a/Common/Render/AtlasGen.h
+++ b/Common/Render/AtlasGen.h
@@ -68,7 +68,6 @@ struct Image {
 	}
 	u32 get1(int x, int y) const { return dat[y * w + x]; }
 	void copyfrom(const Image &img, int ox, int oy, Effect effect);
-	void set(int sx, int sy, int ex, int ey, u32 fil);
 	bool LoadPNG(const char *png_name);
 	void SavePNG(const char *png_name);
 	void SaveZIM(const char *zim_name, int zim_format);

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -42,22 +42,17 @@ void UIContext::Init(Draw::DrawContext *thin3d, Draw::Pipeline *uipipe, Draw::Pi
 void UIContext::BeginFrame() {
 	frameStartTime_ = time_now_d();
 	if (!uitexture_) {
-		uitexture_ = CreateTextureFromFile(draw_, "ui_atlas.zim", ImageFileType::ZIM, false);
-		if (!fontTexture_) {
-#if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-			// Don't bother with loading font_atlas.zim
-#else
-			fontTexture_ = CreateTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
-#endif
-			if (!fontTexture_) {
-				// Load the smaller ascii font only, like on Android. For debug ui etc.
-				fontTexture_ = CreateTextureFromFile(draw_, "asciifont_atlas.zim", ImageFileType::ZIM, false);
-				if (!fontTexture_) {
-					WARN_LOG(Log::System, "Failed to load font_atlas.zim or asciifont_atlas.zim");
-				}
-			}
-		}
+		AtlasData data = atlasProvider_(draw_, AtlasChoice::General);
+		uitexture_ = data.texture;
+		ui_draw2d.SetAtlas(data.atlas);
 	}
+
+	if (!fontTexture_) {
+		AtlasData data = atlasProvider_(draw_, AtlasChoice::Font);
+		fontTexture_ = data.texture;
+		ui_draw2d.SetFontAtlas(data.atlas);
+	}
+
 	uidrawbuffer_->SetCurZ(0.0f);
 	ActivateTopScissor();
 }

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <cstdint>
 #include <string>
+#include <functional>
 
 #include "Common/Math/geom2d.h"
 #include "Common/Math/lin/vec3.h"
@@ -42,6 +43,18 @@ struct UITransform {
 	Lin::Vec3 scale;
 	float alpha;
 };
+
+enum class AtlasChoice : int {
+	General,
+	Font,
+};
+
+struct AtlasData {
+	Atlas *atlas;
+	Draw::Texture *texture;
+};
+
+typedef std::function<AtlasData(Draw::DrawContext *, AtlasChoice)> UIAtlasProviderFunc;
 
 class UIContext {
 public:
@@ -112,6 +125,7 @@ public:
 	Bounds TransformBounds(const Bounds &bounds);
 
 	void SetTheme(const UI::Theme *theme) { this->theme = theme; }
+	void SetAtlasProvider(UIAtlasProviderFunc func) { atlasProvider_ = func; }
 
 private:
 	Draw::DrawContext *draw_ = nullptr;
@@ -136,4 +150,6 @@ private:
 
 	std::vector<Bounds> scissorStack_;
 	std::vector<UITransform> transformStack_;
+
+	UIAtlasProviderFunc atlasProvider_{};
 };

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1833,8 +1833,10 @@ void DrawIconShine(UIContext &dc, const Bounds &bounds, float shine, bool animat
 		dc.Begin();
 	}
 	const AtlasImage *img = dc.Draw()->GetAtlas()->getImage(ImageID("I_DROP_SHADOW"));
-	float scale = bounds.w / img->w;
-	dc.Draw()->DrawImage(ImageID("I_DROP_SHADOW"), bounds.centerX(), bounds.centerY(), scale * 1.7f, colorAlpha(0xFF3EC5FF, 0.75f * shine), ALIGN_CENTER);
+	if (img) {
+		float scale = bounds.w / img->w;
+		dc.Draw()->DrawImage(ImageID("I_DROP_SHADOW"), bounds.centerX(), bounds.centerY(), scale * 1.7f, colorAlpha(0xFF3EC5FF, 0.75f * shine), ALIGN_CENTER);
+	}
 	dc.Flush();
 }
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -25,6 +25,7 @@
 #include "ext/xxhash.h"
 
 #include "Common/Data/Format/IniFile.h"
+#include "Common/Data/Format/PNGLoad.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/File/VFS/DirectoryReader.h"
@@ -679,25 +680,6 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 	return texture;
 }
 
-static bool WriteTextureToPNG(png_imagep image, const Path &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {
-	FILE *fp = File::OpenCFile(filename, "wb");
-	if (!fp) {
-		ERROR_LOG(Log::TexReplacement, "Save texture: Unable to open texture file '%s' for writing.", filename.c_str());
-		return false;
-	}
-
-	if (png_image_write_to_stdio(image, fp, convert_to_8bit, buffer, row_stride, colormap)) {
-		fclose(fp);
-		return true;
-	} else {
-		// This shouldn't really happen.
-		ERROR_LOG(Log::TexReplacement, "Texture PNG encode failed.");
-		fclose(fp);
-		remove(filename.c_str());
-		return false;
-	}
-}
-
 // We save textures on threadpool tasks since it's a fire-and-forget task, and both I/O and png compression
 // can be pretty slow.
 class SaveTextureTask : public Task {
@@ -747,19 +729,11 @@ public:
 		// going to write to to .png.
 		saveFilename = saveFilename.WithReplacedExtension(".png");
 
-		png_image png{};
-		png.version = PNG_IMAGE_VERSION;
-		png.format = PNG_FORMAT_RGBA;
-		png.width = w;
-		png.height = h;
-		bool success = WriteTextureToPNG(&png, saveFilename, 0, rgbaData, w * 4, nullptr);
-		png_image_free(&png);
-		if (png.warning_or_error >= 2) {
+		bool success = pngSave(saveFilename, rgbaData, w, h, 4);
+		if (!success) {
 			ERROR_LOG(Log::TexReplacement, "Saving texture to PNG produced errors.");
-		} else if (success) {
-			NOTICE_LOG(Log::TexReplacement, "Saving texture for replacement: %08x / %dx%d in '%s'", replacedInfoHash, w, h, saveFilename.ToVisualString().c_str());
 		} else {
-			ERROR_LOG(Log::TexReplacement, "Failed to write '%s'", saveFilename.c_str());
+			NOTICE_LOG(Log::TexReplacement, "Saving texture for replacement: %08x / %dx%d in '%s'", replacedInfoHash, w, h, saveFilename.ToVisualString().c_str());
 		}
 	}
 };

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -87,6 +87,7 @@
 #include "Common/VR/PPSSPPVR.h"
 #include "Common/Thread/ThreadManager.h"
 #include "Common/Audio/AudioBackend.h"
+#include "Common/Render/ManagedTexture.h"
 
 #include "Core/ControlMapper.h"
 #include "Core/Config.h"
@@ -820,6 +821,40 @@ static void NativeMixWrapper(float *dest, int framesToWrite, int sampleRateHz, v
 	}
 }
 
+static AtlasData AtlasProvider(Draw::DrawContext *draw, AtlasChoice atlas) {
+	switch (atlas) {
+	case AtlasChoice::General:
+		return {
+			GetUIAtlas(),
+			CreateTextureFromFile(draw, "ui_atlas.zim", ImageFileType::ZIM, false)
+		};
+	case AtlasChoice::Font:
+	{
+		Draw::Texture *fontTexture = nullptr;
+		// NOTE: This ugly check must be the same as the one in UpdateTheme. This will be fixed.
+#if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
+		// Don't bother with loading font_atlas.zim
+#else
+		fontTexture = CreateTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
+#endif
+		if (!fontTexture) {
+			// Load the smaller ascii font only, like on Android. For debug ui etc.
+			// NOTE: We better be sure here that the correct metadata is loaded..
+			fontTexture = CreateTextureFromFile(draw, "asciifont_atlas.zim", ImageFileType::ZIM, false);
+			if (!fontTexture) {
+				WARN_LOG(Log::System, "Failed to load font_atlas.zim or asciifont_atlas.zim");
+			}
+		}
+		return {
+			GetFontAtlas(),
+			fontTexture,
+		};
+	}
+	default:
+		return {};
+	};
+}
+
 bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	INFO_LOG(Log::System, "NativeInitGraphics");
 
@@ -843,6 +878,7 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 
 	uiContext = new UIContext();
 	uiContext->SetTheme(GetTheme());
+	uiContext->SetAtlasProvider(&AtlasProvider);
 	UpdateTheme();
 
 	ui_draw2d.Init(g_draw, texColorPipeline);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -87,8 +87,6 @@
 #include "Common/VR/PPSSPPVR.h"
 #include "Common/Thread/ThreadManager.h"
 #include "Common/Audio/AudioBackend.h"
-#include "Common/Render/ManagedTexture.h"
-
 #include "Core/ControlMapper.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -819,40 +817,6 @@ static void NativeMixWrapper(float *dest, int framesToWrite, int sampleRateHz, v
 	for (int i = 0; i < framesToWrite * 2; i++) {
 		dest[i] = (float)buffer[i] * (float)(1.0f / 32767.0f);
 	}
-}
-
-static AtlasData AtlasProvider(Draw::DrawContext *draw, AtlasChoice atlas) {
-	switch (atlas) {
-	case AtlasChoice::General:
-		return {
-			GetUIAtlas(),
-			CreateTextureFromFile(draw, "ui_atlas.zim", ImageFileType::ZIM, false)
-		};
-	case AtlasChoice::Font:
-	{
-		Draw::Texture *fontTexture = nullptr;
-		// NOTE: This ugly check must be the same as the one in UpdateTheme. This will be fixed.
-#if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-		// Don't bother with loading font_atlas.zim
-#else
-		fontTexture = CreateTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
-#endif
-		if (!fontTexture) {
-			// Load the smaller ascii font only, like on Android. For debug ui etc.
-			// NOTE: We better be sure here that the correct metadata is loaded..
-			fontTexture = CreateTextureFromFile(draw, "asciifont_atlas.zim", ImageFileType::ZIM, false);
-			if (!fontTexture) {
-				WARN_LOG(Log::System, "Failed to load font_atlas.zim or asciifont_atlas.zim");
-			}
-		}
-		return {
-			GetFontAtlas(),
-			fontTexture,
-		};
-	}
-	default:
-		return {};
-	};
 }
 
 bool NativeInitGraphics(GraphicsContext *graphicsContext) {

--- a/UI/Theme.cpp
+++ b/UI/Theme.cpp
@@ -26,6 +26,7 @@
 #include "Common/Data/Format/IniFile.h"
 #include "Common/File/DirListing.h"
 #include "Common/Log/LogManager.h"
+#include "Common/Render/ManagedTexture.h"
 
 #include "Core/Config.h"
 
@@ -171,15 +172,12 @@ static UI::Style MakeStyle(uint32_t fg, uint32_t bg) {
 	return s;
 }
 
-static void LoadAtlasMetadata(Atlas &metadata, const char *filename, bool required) {
+static void LoadAtlasMetadata(Atlas &metadata, const char *filename) {
 	size_t atlas_data_size = 0;
 	const uint8_t *atlas_data = g_VFS.ReadFile(filename, &atlas_data_size);
 	bool load_success = atlas_data != nullptr && metadata.Load(atlas_data, atlas_data_size);
 	if (!load_success) {
-		if (required)
-			ERROR_LOG(Log::G3D, "Failed to load %s - graphics will be broken", filename);
-		else
-			WARN_LOG(Log::G3D, "Failed to load %s", filename);
+		ERROR_LOG(Log::G3D, "Failed to load %s - graphics may be broken", filename);
 		// Stumble along with broken visuals instead of dying...
 	}
 	delete[] atlas_data;
@@ -251,14 +249,6 @@ void UpdateTheme() {
 
 	ui_theme.popupSliderColor = themeInfo.uPopupSliderColor;
 	ui_theme.popupSliderFocusedColor = themeInfo.uPopupSliderFocusedColor;
-
-	// Load any missing atlas metadata (the images are loaded from UIContext).
-	LoadAtlasMetadata(ui_atlas, "ui_atlas.meta", true);
-#if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-	LoadAtlasMetadata(font_atlas, "asciifont_atlas.meta", ui_atlas.num_fonts == 0);
-#else
-	LoadAtlasMetadata(font_atlas, "font_atlas.meta", ui_atlas.num_fonts == 0);
-#endif
 }
 
 UI::Theme *GetTheme() {
@@ -286,4 +276,41 @@ std::vector<std::string> GetThemeInfoNames() {
 		names.push_back(i.name);
 
 	return names;
+}
+
+AtlasData AtlasProvider(Draw::DrawContext *draw, AtlasChoice atlas) {
+	switch (atlas) {
+	case AtlasChoice::General:
+	{
+		// Load any missing atlas metadata (the images are loaded from UIContext).
+		LoadAtlasMetadata(ui_atlas, "ui_atlas.meta");
+		return {
+			&ui_atlas,
+			CreateTextureFromFile(draw, "ui_atlas.zim", ImageFileType::ZIM, false)
+		};
+	}
+	case AtlasChoice::Font:
+	{
+		Draw::Texture *fontTexture = nullptr;
+#if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
+		// Load the smaller ascii font only, like on Android. For debug ui etc.
+		// NOTE: We better be sure here that the correct metadata is loaded..
+		LoadAtlasMetadata(font_atlas, "asciifont_atlas.meta");
+		fontTexture = CreateTextureFromFile(draw, "asciifont_atlas.zim", ImageFileType::ZIM, false);
+		if (!fontTexture) {
+			WARN_LOG(Log::System, "Failed to load font_atlas.zim or asciifont_atlas.zim");
+		}
+#else
+		// Load the full font texture.
+		LoadAtlasMetadata(font_atlas, "font_atlas.meta");
+		fontTexture = CreateTextureFromFile(draw, "font_atlas.zim", ImageFileType::ZIM, false);
+#endif
+		return {
+			&font_atlas,
+			fontTexture,
+		};
+	}
+	default:
+		return {};
+	};
 }

--- a/UI/Theme.cpp
+++ b/UI/Theme.cpp
@@ -254,10 +254,10 @@ void UpdateTheme() {
 
 	// Load any missing atlas metadata (the images are loaded from UIContext).
 	LoadAtlasMetadata(ui_atlas, "ui_atlas.meta", true);
-#if !(PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID))
-	LoadAtlasMetadata(font_atlas, "font_atlas.meta", ui_atlas.num_fonts == 0);
-#else
+#if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
 	LoadAtlasMetadata(font_atlas, "asciifont_atlas.meta", ui_atlas.num_fonts == 0);
+#else
+	LoadAtlasMetadata(font_atlas, "font_atlas.meta", ui_atlas.num_fonts == 0);
 #endif
 }
 

--- a/UI/Theme.h
+++ b/UI/Theme.h
@@ -30,3 +30,5 @@ void UpdateTheme();
 Atlas *GetFontAtlas();
 Atlas *GetUIAtlas();
 UI::Theme *GetTheme();
+
+AtlasData AtlasProvider(Draw::DrawContext *draw, AtlasChoice atlas);


### PR DESCRIPTION
This binds together the loading of metadata and atlas textures, it was previously done in two separate locations. Also inverts the relationship, so now UIContext doesn't know how atlases are loaded. This opens up for clean runtime UI atlas generation, coming in the next PR.

Also collapses some identical code into a pngSave function.