### PR TITLE
Websocket Debugger: fix hanging thread

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -191,9 +191,7 @@ void Core_StateProcessed() {
 void Core_WaitInactive() {
 	while (Core_IsActive() && !GPUStepping::IsStepping()) {
 		std::unique_lock<std::mutex> guard(m_hInactiveMutex);
-		if (coreStatePending) {
-			m_InactiveCond.wait(guard);
-		}
+		m_InactiveCond.wait_for(guard, std::chrono::seconds(1));
 	}
 }
 

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -191,7 +191,9 @@ void Core_StateProcessed() {
 void Core_WaitInactive() {
 	while (Core_IsActive() && !GPUStepping::IsStepping()) {
 		std::unique_lock<std::mutex> guard(m_hInactiveMutex);
-		m_InactiveCond.wait(guard);
+		if (coreStatePending) {
+			m_InactiveCond.wait(guard);
+		}
 	}
 }
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -61,9 +61,13 @@ struct AutoDisabledReplacements {
 // Important: Only use keepReplacements when reading, not writing.
 static AutoDisabledReplacements LockMemoryAndCPU(uint32_t addr, bool keepReplacements) {
 	AutoDisabledReplacements result;
+	CoreState state = coreState;
 	if (Core_IsStepping()) {
 		result.wasStepping = true;
 	} else {
+		while (state != CoreState::CORE_RUNNING_CPU) {
+			state = coreState;
+		}
 		Core_Break(BreakReason::MemoryAccess, addr);
 		Core_WaitInactive();
 	}


### PR DESCRIPTION
Under two specific circumstances, it's possible for the websocket debugger thread to wait forever for a message that will never come:

* If the current core state is not running or stepping (such as newframe), it will attempt to break the CPU, fail, and then wait forever for a break that will never occur. Fixed simply by waiting until we move into the running state before calling `Core_Break`.
* Albeit very unlikely if you aren't bombarding the websocket debugger with messages, it is possible that the websocket debugger will get the mutex, another thread will send the `m_InactiveCond.notify_all()`, and then the debugger will begin its wait, now stuck waiting for a message that was already sent. The fix is simply to time out the `m_InactiveCond.wait` after a short period of time (I've chosen 1 second, but this could probably be made less without issue).