### PR TITLE
Fix a load slowdown, possible fix for voices in 7th Dragon II

### DIFF
--- a/Common/Render/AtlasGen.cpp
+++ b/Common/Render/AtlasGen.cpp
@@ -254,7 +254,7 @@ void AddDropShadow(Image &img, int shadowSize, float intensity) {
 		for (int x = 0; x < newW; x++) {
 			float a = blurred[y * newW + x];
 			if (a > 0.001f) {
-				newData[y * newW + x] = ((u32)(a * 255 * intensity) << 24); // semi-transparent black;
+				newData[y * newW + x] = ((u32)(a * 255 * intensity) << 24);
 			}
 		}
 	}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2327,10 +2327,10 @@ void __KernelReturnFromModuleFunc() {
 					}
 				}
 				if (plugin_waiting_module->startingPlugins.empty()) {
-					INFO_LOG(Log::sceModule, "Resuming LoadExec thread 0x%x", module->pluginWaitingThread);
+					INFO_LOG(Log::sceModule, "Resuming LoadExec thread %d", module->pluginWaitingThread);
 					__KernelResumeThreadFromWait(module->pluginWaitingThread, 0);
 				} else {
-					INFO_LOG(Log::sceModule, "LoadExec thread 0x%x still waiting for %lld plugin(s)", module->pluginWaitingThread, plugin_waiting_module->startingPlugins.size());
+					INFO_LOG(Log::sceModule, "LoadExec thread %d still waiting for %d plugin(s)", module->pluginWaitingThread, (int)plugin_waiting_module->startingPlugins.size());
 				}
 			}
 		}

--- a/Core/Util/AtracTrack.cpp
+++ b/Core/Util/AtracTrack.cpp
@@ -31,6 +31,8 @@ static u32 Read32(const u8 *buffer, int offset) {
 
 // Old WAVE parser.
 int AnalyzeAtracTrack(const u8 *buffer, u32 size, Track *track, std::string *error) {
+	_assert_(buffer != nullptr);
+
 	// 72 is about the size of the minimum required data to even be valid.
 	if (size < 72) {
 		return SCE_ERROR_ATRAC_SIZE_TOO_SMALL;
@@ -39,7 +41,6 @@ int AnalyzeAtracTrack(const u8 *buffer, u32 size, Track *track, std::string *err
 	// If the pointer is bad, let's try to survive, although I'm pretty sure that on a real PSP,
 	// we crash here.
 	if (!buffer) {
-		_dbg_assert_(false);
 		return SCE_KERNEL_ERROR_INVALID_POINTER;
 	}
 
@@ -351,6 +352,7 @@ static inline int RoundUpToEven(int size) {
 }
 
 int ParseWaveAT3(const u8 *data, int dataLength, TrackInfo *track) {
+	_assert_(data != nullptr);
 	track->loopStart = 0xFFFFFFFF;
 	track->loopEnd = 0xFFFFFFFF;
 	track->firstSampleOffset = 0;


### PR DESCRIPTION
I found a crash report that pointed to a real problem. See #20834 

Also improves the logging of UI atlas generation (less spammy, more accurate timing numbers), and stops accidentally saving out the generated atlas as a png.