### PR TITLE
VertexDecoder: Improve logging for missing formats. 

### DIFF
--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -312,6 +312,7 @@ Atrac2::Atrac2(u32 contextAddr, int codecType) {
 
 Atrac2::~Atrac2() {
 	DumpBufferToFile();
+	delete[] decodeTemp_;
 	// Nothing else to do here, the context is freed by the HLE.
 }
 

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -256,9 +256,9 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			EndWrite();
 			// Reset the code ptr and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
-			char temp[1024] = {0};
+			char temp[1024]{};
 			dec.ToString(temp, true);
-			INFO_LOG(Log::G3D, "Could not compile vertex decoder: %s", temp);
+			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return 0;
 		}
 	}

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1606,3 +1606,100 @@ void VertexDecoderJitCache::Clear() {
 		ClearCodeSpace(0);
 	}
 }
+
+struct StepFunctionNameEntry {
+	StepFunction func;
+	const char *name;
+};
+
+static const StepFunctionNameEntry stepFunctionNames[] = {
+	{VertexDecoder::Step_WeightsU8, "WeightsU8"},
+	{VertexDecoder::Step_WeightsU16, "WeightsU16"},
+	{VertexDecoder::Step_WeightsU8ToFloat, "WeightsU8ToFloat"},
+	{VertexDecoder::Step_WeightsU16ToFloat, "WeightsU16ToFloat"},
+	{VertexDecoder::Step_WeightsFloat, "WeightsFloat"},
+
+	{VertexDecoder::Step_WeightsU8Skin, "WeightsU8Skin"},
+	{VertexDecoder::Step_WeightsU16Skin, "WeightsU16Skin"},
+	{VertexDecoder::Step_WeightsFloatSkin, "WeightsFloatSkin"},
+
+	{VertexDecoder::Step_TcU8ToFloat, "TcU8ToFloat"},
+	{VertexDecoder::Step_TcU16ToFloat, "TcU16ToFloat"},
+	{VertexDecoder::Step_TcFloat, "TcFloat"},
+
+	{VertexDecoder::Step_TcU8Prescale, "TcU8Prescale"},
+	{VertexDecoder::Step_TcU16Prescale, "TcU16Prescale"},
+	{VertexDecoder::Step_TcU16DoublePrescale, "TcU16DoublePrescale"},
+	{VertexDecoder::Step_TcFloatPrescale, "TcFloatPrescale"},
+
+	{VertexDecoder::Step_TcU16DoubleToFloat, "TcU16DoubleToFloat"},
+	{VertexDecoder::Step_TcU16ThroughToFloat, "TcU16ThroughToFloat"},
+	{VertexDecoder::Step_TcU16ThroughDoubleToFloat, "TcU16ThroughDoubleToFloat"},
+	{VertexDecoder::Step_TcFloatThrough, "TcFloatThrough"},
+
+	{VertexDecoder::Step_TcU8MorphToFloat, "TcU8MorphToFloat"},
+	{VertexDecoder::Step_TcU16MorphToFloat, "TcU16MorphToFloat"},
+	{VertexDecoder::Step_TcU16DoubleMorphToFloat, "TcU16DoubleMorphToFloat"},
+	{VertexDecoder::Step_TcFloatMorph, "TcFloatMorph"},
+	{VertexDecoder::Step_TcU8PrescaleMorph, "TcU8PrescaleMorph"},
+	{VertexDecoder::Step_TcU16PrescaleMorph, "TcU16PrescaleMorph"},
+	{VertexDecoder::Step_TcU16DoublePrescaleMorph, "TcU16DoublePrescaleMorph"},
+	{VertexDecoder::Step_TcFloatPrescaleMorph, "TcFloatPrescaleMorph"},
+
+	{VertexDecoder::Step_ColorInvalid, "ColorInvalid"},
+	{VertexDecoder::Step_Color4444, "Color4444"},
+	{VertexDecoder::Step_Color565, "Color565"},
+	{VertexDecoder::Step_Color5551, "Color5551"},
+	{VertexDecoder::Step_Color8888, "Color8888"},
+
+	{VertexDecoder::Step_Color4444Morph, "Color4444Morph"},
+	{VertexDecoder::Step_Color565Morph, "Color565Morph"},
+	{VertexDecoder::Step_Color5551Morph, "Color5551Morph"},
+	{VertexDecoder::Step_Color8888Morph, "Color8888Morph"},
+
+	{VertexDecoder::Step_NormalS8, "NormalS8"},
+	{VertexDecoder::Step_NormalS8ToFloat, "NormalS8ToFloat"},
+	{VertexDecoder::Step_NormalS16, "NormalS16"},
+	{VertexDecoder::Step_NormalFloat, "NormalFloat"},
+
+	{VertexDecoder::Step_NormalS8Skin, "NormalS8Skin"},
+	{VertexDecoder::Step_NormalS16Skin, "NormalS16Skin"},
+	{VertexDecoder::Step_NormalFloatSkin, "NormalFloatSkin"},
+
+	{VertexDecoder::Step_NormalS8Morph, "NormalS8Morph"},
+	{VertexDecoder::Step_NormalS16Morph, "NormalS16Morph"},
+	{VertexDecoder::Step_NormalFloatMorph, "NormalFloatMorph"},
+
+	{VertexDecoder::Step_NormalS8MorphSkin, "NormalS8MorphSkin"},
+	{VertexDecoder::Step_NormalS16MorphSkin, "NormalS16MorphSkin"},
+	{VertexDecoder::Step_NormalFloatMorphSkin, "NormalFloatMorphSkin"},
+
+	{VertexDecoder::Step_PosS8, "PosS8"},
+	{VertexDecoder::Step_PosS16, "PosS16"},
+	{VertexDecoder::Step_PosFloat, "PosFloat"},
+
+	{VertexDecoder::Step_PosS8Skin, "PosS8Skin"},
+	{VertexDecoder::Step_PosS16Skin, "PosS16Skin"},
+	{VertexDecoder::Step_PosFloatSkin, "PosFloatSkin"},
+
+	{VertexDecoder::Step_PosS8Morph, "PosS8Morph"},
+	{VertexDecoder::Step_PosS16Morph, "PosS16Morph"},
+	{VertexDecoder::Step_PosFloatMorph, "PosFloatMorph"},
+
+	{VertexDecoder::Step_PosS8MorphSkin, "PosS8MorphSkin"},
+	{VertexDecoder::Step_PosS16MorphSkin, "PosS16MorphSkin"},
+	{VertexDecoder::Step_PosFloatMorphSkin, "PosFloatMorphSkin"},
+
+	{VertexDecoder::Step_PosInvalid, "PosInvalid"},
+	{VertexDecoder::Step_PosS8Through, "PosS8Through"},
+	{VertexDecoder::Step_PosS16Through, "PosS16Through"},
+	{VertexDecoder::Step_PosFloatThrough, "PosFloatThrough"},
+};
+
+const char *GetStepFunctionName(StepFunction func) {
+	for (const StepFunctionNameEntry &entry : stepFunctionNames) {
+		if (entry.func == func)
+			return entry.name;
+	}
+	return "(unknown)";
+}

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -513,6 +513,7 @@ private:
 	void CompareToJit(const u8 *startPtr, u8 *decodedptr, int count, const UVScale *uvScaleOffset) const;
 };
 
+const char *GetStepFunctionName(StepFunction func);
 
 // A compiled vertex decoder takes the following arguments (C calling convention):
 // u8 *src, u8 *dst, int count

--- a/GPU/Common/VertexDecoderLoongArch64.cpp
+++ b/GPU/Common/VertexDecoderLoongArch64.cpp
@@ -298,7 +298,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
             ResetCodePtr(GetOffset(start));
             char temp[1024]{};
             dec.ToString(temp, true);
-            ERROR_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %d: %s", i, temp);
+            WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
             return nullptr;
         }
     }

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -317,7 +317,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			ResetCodePtr(GetOffset(start));
 			char temp[1024]{};
 			dec.ToString(temp, true);
-			ERROR_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %d: %s", i, temp);
+			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return nullptr;
 		}
 	}

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -280,6 +280,9 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			EndWrite();
 			// Reset the code ptr and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
+			char temp[1024]{};
+			dec.ToString(temp, true);
+			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return 0;
 		}
 	}


### PR DESCRIPTION
Also adds a missing convert function, NormalS8ToFloat, to the ARM64 backend.

The missing function is only used in D3D11, which can be used on Windows for ARM64. It's not necesssary for the other backends, which is why it used to be missing in the ARM64 vertex decoder.

Also fix a minor memory leak in AtracCtx2.