### PR TITLE
Make the "Enable Achievements" setting per-game

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -358,7 +358,7 @@ static bool DefaultSasThread() {
 
 static const ConfigSetting achievementSettings[] = {
 	// Core settings
-	ConfigSetting("AchievementsEnable", &g_Config.bAchievementsEnable, false, CfgFlag::DEFAULT),
+	ConfigSetting("AchievementsEnable", &g_Config.bAchievementsEnable, false, CfgFlag::PER_GAME),
 	ConfigSetting("AchievementsEnableRAIntegration", &g_Config.bAchievementsEnableRAIntegration, false, CfgFlag::DEFAULT),
 	ConfigSetting("AchievementsChallengeMode", &g_Config.bAchievementsHardcoreMode, true, CfgFlag::PER_GAME | CfgFlag::DEFAULT),
 	ConfigSetting("AchievementsEncoreMode", &g_Config.bAchievementsEncoreMode, false, CfgFlag::PER_GAME | CfgFlag::DEFAULT),


### PR DESCRIPTION
This simply changes the "Enable Achievements" setting to a per-game option, as requested in #20840.

However, I'm not completely sure this is great as it might be a bit confusing if you have existing per-game configs, and this might end up disabling it unexpectedly for those games until you turn it on. On the other hand this is always a problem for per-game configs....