### PR TITLE
CwCheat code cleanup

### DIFF
--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include <iostream>
 #include <sstream>
@@ -39,7 +40,7 @@ struct CheatOperation;
 
 class CWCheatEngine {
 public:
-	CWCheatEngine(const std::string &gameID);
+	CWCheatEngine(std::string_view gameID);
 	std::vector<CheatFileInfo> FileInfo() const;
 	void ParseCheats();
 	void CreateCheatFile();
@@ -68,4 +69,37 @@ private:
 	std::vector<CheatCode> cheats_;
 	std::string gameID_;
 	Path filename_;
+};
+
+class CheatFileParser {
+public:
+	CheatFileParser(const Path &filename, std::string_view gameID = "");
+	~CheatFileParser();
+
+	bool Parse();
+
+	const std::vector<std::string> &GetErrors() const { return errors_; }
+	const std::vector<CheatCode> &GetCheats() const { return cheats_; }
+	const std::vector<CheatFileInfo> &GetFileInfo() const { return cheatInfo_; }
+
+protected:
+	void Flush();
+	void FlushCheatInfo();
+	void AddError(const std::string &msg, int lineNumber);
+	void ParseLine(const std::string &line, int lineNumber);
+	void ParseDataLine(const std::string &line, int lineNumber);
+	bool ValidateGameID(std::string_view gameID);
+
+	FILE *fp_ = nullptr;
+	std::string validGameID_;
+
+	int games_ = 0;
+	std::vector<std::string> errors_;
+	std::vector<CheatFileInfo> cheatInfo_;
+	std::vector<CheatCode> cheats_;
+	std::vector<CheatLine> pendingLines_;
+	CheatFileInfo lastCheatInfo_;
+	bool gameEnabled_ = true;
+	bool gameRiskyEnabled_ = false;
+	bool cheatEnabled_ = false;
 };

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -24,14 +24,7 @@ struct CheatLine {
 	uint32_t part2;
 };
 
-enum class CheatCodeFormat {
-	UNDEFINED,
-	CWCHEAT,
-	TEMPAR,
-};
-
 struct CheatCode {
-	CheatCodeFormat fmt;
 	std::string name;
 	std::vector<CheatLine> lines;
 };
@@ -47,19 +40,25 @@ struct CheatOperation;
 class CWCheatEngine {
 public:
 	CWCheatEngine(const std::string &gameID);
-	std::vector<CheatFileInfo> FileInfo();
+	std::vector<CheatFileInfo> FileInfo() const;
 	void ParseCheats();
 	void CreateCheatFile();
-	Path CheatFilename();
+	const Path &CheatFilename() const {
+		return filename_;
+	}
 	void Run();
 	bool HasCheats();
+	static u32 GetAddress(u32 value) {
+		// TODO: This comment is weird:
+		// Returns static address used by ppsspp. Some games may not like this, and causes cheats to not work without offset
+		u32 address = (value + 0x08800000) & 0x3FFFFFFF;
+		return address;
+	}
+
 private:
 	void InvalidateICache(u32 addr, int size) const;
-	u32 GetAddress(u32 value);
 
-	CheatOperation InterpretNextOp(const CheatCode &cheat, size_t &i);
 	CheatOperation InterpretNextCwCheat(const CheatCode &cheat, size_t &i);
-	CheatOperation InterpretNextTempAR(const CheatCode &cheat, size_t &i);
 
 	void ExecuteOp(const CheatOperation &op, const CheatCode &cheat, size_t &i);
 	inline void ApplyMemoryOperator(const CheatOperation &op, uint32_t(*oper)(uint32_t, uint32_t));

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -240,7 +240,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName).pdb</ProgramDatabaseFile>
       <LargeAddressAware>true</LargeAddressAware>
-      <ShowProgress>NotSet</ShowProgress>
       <AdditionalOptions>/ignore:4049 /ignore:4217 %(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -276,7 +275,6 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName).pdb</ProgramDatabaseFile>
       <LargeAddressAware>true</LargeAddressAware>
-      <ShowProgress>LinkVerboseLib</ShowProgress>
       <AdditionalOptions>/ignore:4049 /ignore:4217 %(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Windows</SubSystem>
     </Link>


### PR DESCRIPTION
Removes some initial code for supporting TempAR - this won't likely happen.

Also exposes the CheatCodeParser and fixes a linker option for Windows ARM64.