### PR TITLE
Enable exception handling on Windows ARM64

### DIFF
--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -55,6 +55,8 @@ typedef CONTEXT SContext;
 
 #elif PPSSPP_ARCH(ARM64)
 
+#define MACHINE_CONTEXT_SUPPORTED
+
 #define CTX_REG(x) X[x]
 #define CTX_SP Sp
 #define CTX_PC Pc


### PR DESCRIPTION
Simpler than expected. We don't really make any advanced use of the context currently so I guess it makes sense.

See #20854