### PR TITLE
UI: Convert rendering to use premultiplied alpha

### DIFF
--- a/Common/Common.h
+++ b/Common/Common.h
@@ -87,3 +87,6 @@
 
 #define __forceinline inline __attribute__((always_inline))
 #endif
+
+// Easy way to printf string_views (note: The formatting specifier is "%.*s", not "%s")
+#define STR_VIEW(sv) (int)(sv).size(), (sv).data()

--- a/Common/Data/Color/RGBAUtil.cpp
+++ b/Common/Data/Color/RGBAUtil.cpp
@@ -30,7 +30,7 @@ uint32_t colorAlpha(uint32_t rgb, float alpha) {
 }
 
 uint32_t colorBlend(uint32_t rgb1, uint32_t rgb2, float alpha) {
-	float invAlpha = (1.0f - alpha);
+	const float invAlpha = (1.0f - alpha);
 	int r = (int)(((rgb1 >> 0) & 0xFF) * alpha + ((rgb2 >> 0) & 0xFF) * invAlpha);
 	int g = (int)(((rgb1 >> 8) & 0xFF) * alpha + ((rgb2 >> 8) & 0xFF) * invAlpha);
 	int b = (int)(((rgb1 >> 16) & 0xFF) * alpha + ((rgb2 >> 16) & 0xFF) * invAlpha);

--- a/Common/Data/Convert/ColorConv.h
+++ b/Common/Data/Convert/ColorConv.h
@@ -166,3 +166,5 @@ void ConvertRGBA4444ToABGR4444(u16 *dst, const u16 *src, u32 numPixels);
 void ConvertRGBA5551ToABGR1555(u16 *dst, const u16 *src, u32 numPixels);
 void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, u32 numPixels);
 void ConvertBGRA5551ToABGR1555(u16 *dst, const u16 *src, u32 numPixels);
+
+void ConvertRGBA8888ToPremulAlpha(u32 *dst, const u32 *src, u32 numPixels);

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -807,7 +807,7 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanBarrierBatch *postBarriers, Vu
 	static const VkComponentMapping r8AsColor[4] = { {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ONE} };
 	static const VkComponentMapping r8AsPremulAlpha[4] = { {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R} };
 
-	VkComponentMapping *swizzle = nullptr;
+	const VkComponentMapping *swizzle = nullptr;
 	switch (desc.swizzle) {
 	case TextureSwizzle::R8_AS_ALPHA: swizzle = r8AsAlpha; break;
 	case TextureSwizzle::R8_AS_GRAYSCALE: swizzle = r8AsColor; break;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -803,13 +803,15 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanBarrierBatch *postBarriers, Vu
 		usageBits |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 	}
 
-	VkComponentMapping r8AsAlpha[4] = { {VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_R} };
-	VkComponentMapping r8AsColor[4] = { {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ONE} };
+	static const VkComponentMapping r8AsAlpha[4] = { {VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_R} };
+	static const VkComponentMapping r8AsColor[4] = { {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_ONE} };
+	static const VkComponentMapping r8AsPremulAlpha[4] = { {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_R} };
 
 	VkComponentMapping *swizzle = nullptr;
 	switch (desc.swizzle) {
 	case TextureSwizzle::R8_AS_ALPHA: swizzle = r8AsAlpha; break;
 	case TextureSwizzle::R8_AS_GRAYSCALE: swizzle = r8AsColor; break;
+	case TextureSwizzle::R8_AS_PREMUL_ALPHA: swizzle = r8AsPremulAlpha; break;
 	case TextureSwizzle::DEFAULT:
 		break;
 	}

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -181,7 +181,7 @@ static const std::vector<ShaderSource> fsTexCol = {
 	"varying vec4 oColor0;\n"
 	"varying vec2 oTexCoord0;\n"
 	"uniform sampler2D Sampler0;\n"
-	"void main() { gl_FragColor = texture2D(Sampler0, oTexCoord0) * oColor0; }\n"
+	"void main() { vec4 col = texture2D(Sampler0, oTexCoord0) * oColor0; col.rgb *= oColor0.a; gl_FragColor = col; }\n"
 	},
 	{ShaderLanguage::HLSL_D3D11,
 	"struct PS_INPUT { float4 color : COLOR0; float2 uv : TEXCOORD0; };\n"
@@ -189,6 +189,7 @@ static const std::vector<ShaderSource> fsTexCol = {
 	"Texture2D<float4> tex : register(t0);\n"
 	"float4 main(PS_INPUT input) : SV_Target {\n"
 	"  float4 col = input.color * tex.Sample(samp, input.uv);\n"
+	"  col.rgb *= input.color.a;\n"
 	"  return col;\n"
 	"}\n"
 	},
@@ -200,7 +201,7 @@ static const std::vector<ShaderSource> fsTexCol = {
 	"layout(location = 1) in vec2 oTexCoord0;\n"
 	"layout(location = 0) out vec4 fragColor0;\n"
 	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
-	"void main() { fragColor0 = texture(Sampler0, oTexCoord0) * oColor0; }\n"
+	"void main() { vec4 col = texture(Sampler0, oTexCoord0) * oColor0; col.rgb *= oColor0.a; fragColor0 = col; }\n"
 	}
 };
 
@@ -218,7 +219,7 @@ static const std::vector<ShaderSource> fsTexColRBSwizzle = {
 	"varying vec4 oColor0;\n"
 	"varying vec2 oTexCoord0;\n"
 	"uniform sampler2D Sampler0;\n"
-	"void main() { gl_FragColor = texture2D(Sampler0, oTexCoord0).zyxw * oColor0; }\n"
+	"void main() { vec4 col = texture2D(Sampler0, oTexCoord0).zyxw * oColor0; col.rgb *= oColor0.a; gl_FragColor = col; }\n"
 	},
 	{ShaderLanguage::HLSL_D3D11,
 	"struct PS_INPUT { float4 color : COLOR0; float2 uv : TEXCOORD0; };\n"
@@ -226,6 +227,7 @@ static const std::vector<ShaderSource> fsTexColRBSwizzle = {
 	"Texture2D<float4> tex : register(t0);\n"
 	"float4 main(PS_INPUT input) : SV_Target {\n"
 	"  float4 col = input.color * tex.Sample(samp, input.uv).bgra;\n"
+	"  col.rgb *= input.color.a;\n"
 	"  return col;\n"
 	"}\n"
 	},
@@ -237,7 +239,7 @@ static const std::vector<ShaderSource> fsTexColRBSwizzle = {
 	"layout(location = 1) in vec2 oTexCoord0;\n"
 	"layout(location = 0) out vec4 fragColor0\n;"
 	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
-	"void main() { fragColor0 = texture(Sampler0, oTexCoord0).bgra * oColor0; }\n"
+	"void main() { vec4 col = texture(Sampler0, oTexCoord0).bgra * oColor0; col.rgb *= oColor0.a; fragColor0 = col; }\n"
 	}
 };
 
@@ -252,11 +254,13 @@ static const std::vector<ShaderSource> fsCol = {
 	"out vec4 fragColor0;\n"
 	"#endif\n"
 	"varying vec4 oColor0;\n"
-	"void main() { gl_FragColor = oColor0; }\n"
+	"void main() { vec4 col = oColor0; col.rgb *= oColor0.a; gl_FragColor = col; }\n"
 	},
 	{ ShaderLanguage::HLSL_D3D11,
 	"struct PS_INPUT { float4 color : COLOR0; };\n"
 	"float4 main(PS_INPUT input) : SV_Target {\n"
+	"  float4 col = input.color;\n"
+	"  col.rgb *= input.color.a;\n"
 	"  return input.color;\n"
 	"}\n"
 	},
@@ -266,7 +270,7 @@ static const std::vector<ShaderSource> fsCol = {
 	"#extension GL_ARB_shading_language_420pack : enable\n"
 	"layout(location = 0) in vec4 oColor0;\n"
 	"layout(location = 0) out vec4 fragColor0;\n"
-	"void main() { fragColor0 = oColor0; }\n"
+	"void main() { vec4 col = oColor0; col.rgb *= oColor0.a; fragColor0 = col; }\n"
 	}
 };
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -647,6 +647,7 @@ enum class TextureSwizzle {
 	DEFAULT,
 	R8_AS_ALPHA,
 	R8_AS_GRAYSCALE,
+	R8_AS_PREMUL_ALPHA,
 };
 
 struct TextureDesc {

--- a/Common/Render/AtlasGen.cpp
+++ b/Common/Render/AtlasGen.cpp
@@ -14,6 +14,7 @@
 #include "Common/Data/Format/PNGLoad.h"
 #include "Common/Data/Format/ZIMSave.h"
 #include "Common/Data/Color/RGBAUtil.h"
+#include "Common/Data/Convert/ColorConv.h"
 
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/File/VFS/VFS.h"
@@ -55,6 +56,10 @@ bool Image::LoadPNG(const char *png_name) {
 	memcpy(dat.data(), img_data, 4 * w * h);
 	free(img_data);
 	return true;
+}
+
+void Image::ConvertToPremultipliedAlpha() {
+	ConvertRGBA8888ToPremulAlpha(dat.data(), dat.data(), w * h);
 }
 
 void Image::SavePNG(const char *png_name) {

--- a/Common/Render/AtlasGen.cpp
+++ b/Common/Render/AtlasGen.cpp
@@ -231,6 +231,29 @@ static void blurAlpha(const std::vector<float> &src, std::vector<float> &dst, in
 	}
 }
 
+static inline uint32_t Over_ABGR(uint32_t front, uint32_t back) {
+	const uint32_t fr = front & 0xFFu;
+	const uint32_t fg = (front >> 8) & 0xFFu; // green
+	const uint32_t fb = (front >> 16) & 0xFFu;
+	const uint32_t fa = (front >> 24) & 0xFFu;
+
+	const uint32_t br = back & 0xFFu;
+	const uint32_t bg = (back >> 8) & 0xFFu; // green
+	const uint32_t bb = (back >> 16) & 0xFFu;
+	const uint32_t ba = (back >> 24) & 0xFFu;
+
+	const uint32_t invA = 255u - fa;
+
+	// multiply then divide by 255 with rounding equivalent to (x*invA + 127)/255
+	uint32_t outr = fr + (uint32_t)((br * invA + 127u) / 255u);
+	uint32_t outg = fg + (uint32_t)((bg * invA + 127u) / 255u);
+	uint32_t outb = fb + (uint32_t)((bb * invA + 127u) / 255u);
+	uint32_t outa = fa + (uint32_t)((ba * invA + 127u) / 255u);
+
+	// pack back to ABGR
+	return (outa << 24) | (outb << 16) | (outg << 8) | outr;
+}
+
 void AddDropShadow(Image &img, int shadowSize, float intensity) {
 	int radius = std::max(1, (int)(shadowSize * img.scale));
 
@@ -254,7 +277,7 @@ void AddDropShadow(Image &img, int shadowSize, float intensity) {
 	// Target buffer with transparent background
 	std::vector<u32> newData(newW * newH, 0);
 
-	// Draw the computed shadow first (black, blurred alpha)
+	// Draw the computed shadow first (black, blurred alpha - automatically premultiplied).
 	for (int y = 0; y < newH; y++) {
 		for (int x = 0; x < newW; x++) {
 			float a = blurred[y * newW + x];
@@ -269,10 +292,9 @@ void AddDropShadow(Image &img, int shadowSize, float intensity) {
 		for (int x = 0; x < img.w; x++) {
 			u32 c = img.dat[y * img.w + x];
 			if ((c >> 24) & 0xFF) {
-				float c_alpha = ((c >> 24) & 0xFF) * (1.0f / 255.0f);
 				int nx = x + radius;
 				int ny = y + radius;
-				newData[ny * newW + nx] = colorBlend(c, newData[ny * newW + nx], c_alpha);
+				newData[ny * newW + nx] = Over_ABGR(c, newData[ny * newW + nx]);
 			}
 		}
 	}

--- a/Common/Render/AtlasGen.cpp
+++ b/Common/Render/AtlasGen.cpp
@@ -254,7 +254,7 @@ void AddDropShadow(Image &img, int shadowSize, float intensity) {
 	// Target buffer with transparent background
 	std::vector<u32> newData(newW * newH, 0);
 
-	// Draw the computeed shadow first (black, blurred alpha)
+	// Draw the computed shadow first (black, blurred alpha)
 	for (int y = 0; y < newH; y++) {
 		for (int x = 0; x < newW; x++) {
 			float a = blurred[y * newW + x];

--- a/Common/Render/AtlasGen.h
+++ b/Common/Render/AtlasGen.h
@@ -67,6 +67,7 @@ struct Image {
 	void SavePNG(const char *png_name);
 	void SaveZIM(const char *zim_name, int zim_format);
 	bool IsEmpty() const { return dat.empty(); }
+	void ConvertToPremultipliedAlpha();
 // private:
 	std::vector<u32> dat;
 };

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -105,6 +105,7 @@ bool TempImage::LoadTextureLevelsFromFileData(const uint8_t *data, size_t size, 
 	case ImageFileType::ZIM:
 		numLevels = LoadZIMPtr((const uint8_t *)data, size, width, height, &zimFlags, levels);
 		fmt = ZimToT3DFormat(zimFlags & ZIM_FORMAT_MASK);
+		ConvertRGBA8888ToPremulAlpha((u32 *)levels[0], (const u32 *)levels[0], width[0] * height[0]);
 		break;
 
 	case ImageFileType::PNG:

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -18,6 +18,7 @@
 #include "Common/Render/ManagedTexture.h"
 #include "Common/Thread/ThreadManager.h"
 #include "Common/Thread/Waitable.h"
+#include "Common/Data/Convert/ColorConv.h"
 
 // TODO: It really feels like we should be able to simplify this.
 class TextureLoadTask : public Task {
@@ -114,6 +115,7 @@ bool TempImage::LoadTextureLevelsFromFileData(const uint8_t *data, size_t size, 
 				ERROR_LOG(Log::IO, "pngLoadPtr failed (input size = %d)", (int)size);
 				return false;
 			}
+			ConvertRGBA8888ToPremulAlpha((u32 *)levels[0], (const u32 *)levels[0], width[0] * height[0]);
 		} else {
 			ERROR_LOG(Log::IO, "PNG load failed");
 			_dbg_assert_(!levels[0]);

--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -98,7 +98,7 @@ void TextDrawer::DrawString(DrawBuffer &target, std::string_view str, float x, f
 		desc.depth = 1;
 		desc.mipLevels = 1;
 		desc.tag = "TextDrawer";
-		desc.swizzle = texFormat == Draw::DataFormat::R8_UNORM ? Draw::TextureSwizzle::R8_AS_ALPHA : Draw::TextureSwizzle::DEFAULT,
+		desc.swizzle = texFormat == Draw::DataFormat::R8_UNORM ? Draw::TextureSwizzle::R8_AS_PREMUL_ALPHA : Draw::TextureSwizzle::DEFAULT,
 		entry->texture = draw_->CreateTexture(desc);
 		cache_[key] = std::unique_ptr<TextStringEntry>(entry);
 	}

--- a/Common/Render/Text/draw_text.h
+++ b/Common/Render/Text/draw_text.h
@@ -85,6 +85,14 @@ protected:
 
 	void WrapString(std::string &out, std::string_view str, float maxWidth, int flags);
 
+	// v has the 8-bit alpha.
+	static u16 AlphaToPremul4444(u32 v) {
+		v = (v >> 4) & 0x0F;
+		v |= v << 4;
+		v |= v << 8;
+		return v;
+	}
+
 	struct CacheKey {
 		bool operator < (const CacheKey &other) const {
 			if (fontHash < other.fontHash)

--- a/Common/Render/Text/draw_text_android.cpp
+++ b/Common/Render/Text/draw_text_android.cpp
@@ -144,11 +144,12 @@ bool TextDrawerAndroid::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextS
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
 				uint32_t v = jimage[imageWidth * y + x];
-				v = 0xFFF0 | ((v >> 28) & 0xF);  // Grab the upper bits from the alpha channel, and put directly in the 16-bit alpha channel.
-				bitmapData16[entry.bmWidth * y + x] = (uint16_t)v;
+				// Premultiplied alpha: Put alpha in all four channels.
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(v >> 24);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::R8_UNORM) {
+		// We only get here if swizzle is possible, so we can duplicate the value to all four channels.
 		bitmapData.resize(entry.bmWidth * entry.bmHeight);
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {

--- a/Common/Render/Text/draw_text_cocoa.mm
+++ b/Common/Render/Text/draw_text_cocoa.mm
@@ -285,8 +285,8 @@ bool TextDrawerCocoa::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStr
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
-				uint8_t bAlpha = (uint8_t)((bitmap[bmWidth * y + x] & 0xff) >> 4);
-				bitmapData16[entry.bmWidth * y + x] = (bAlpha) | 0xfff0;
+				uint8_t bAlpha = (uint8_t)(bitmap[bmWidth * y + x] & 0xff);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(bAlpha);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::A4R4G4B4_UNORM_PACK16) {
@@ -295,8 +295,8 @@ bool TextDrawerCocoa::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStr
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
-				uint8_t bAlpha = (uint8_t)((bitmap[bmWidth * y + x] & 0xff) >> 4);
-				bitmapData16[entry.bmWidth * y + x] = (bAlpha << 12) | 0x0fff;
+				uint8_t bAlpha = (uint8_t)(bitmap[bmWidth * y + x] & 0xff);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(bAlpha);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::R8_UNORM) {

--- a/Common/Render/Text/draw_text_qt.cpp
+++ b/Common/Render/Text/draw_text_qt.cpp
@@ -96,7 +96,7 @@ bool TextDrawerQt::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextString
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int x = 0; x < entry.bmWidth; x++) {
 			for (int y = 0; y < entry.bmHeight; y++) {
-				bitmapData16[entry.bmWidth * y + x] = 0xfff0 | (image.pixel(x, y) >> 28);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(image.pixel(x, y) >> 24);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::R8_UNORM) {

--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -371,8 +371,9 @@ bool TextDrawerSDL::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStrin
 
 		for (int x = 0; x < entry.bmWidth; x++) {
 			for (int y = 0; y < entry.bmHeight; y++) {
-				uint64_t index = entry.bmWidth * y + x;
-				bitmapData16[index] = 0xfff0 | (imageData[pitch * y + x] >> 28);
+				const uint64_t index = entry.bmWidth * y + x;
+				const u16 alpha = AlphaToPremul4444(imageData[pitch * y + x]);
+				bitmapData16[index] = alpha;
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::R8_UNORM) {

--- a/Common/Render/Text/draw_text_uwp.cpp
+++ b/Common/Render/Text/draw_text_uwp.cpp
@@ -338,8 +338,8 @@ bool TextDrawerUWP::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStrin
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
-				uint8_t bAlpha = (uint8_t)((map.bits[map.pitch * y + x * 4] & 0xff) >> 4);
-				bitmapData16[entry.bmWidth * y + x] = (bAlpha) | 0xfff0;
+				uint8_t bAlpha = (uint8_t)(map.bits[map.pitch * y + x * 4] & 0xff);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(bAlpha);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::A4R4G4B4_UNORM_PACK16) {
@@ -348,8 +348,8 @@ bool TextDrawerUWP::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStrin
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
-				uint8_t bAlpha = (uint8_t)((map.bits[map.pitch * y + x * 4] & 0xff) >> 4);
-				bitmapData16[entry.bmWidth * y + x] = (bAlpha << 12) | 0x0fff;
+				uint8_t bAlpha = (uint8_t)(map.bits[map.pitch * y + x * 4] & 0xff);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(bAlpha);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::R8_UNORM) {

--- a/Common/Render/Text/draw_text_win.cpp
+++ b/Common/Render/Text/draw_text_win.cpp
@@ -220,8 +220,8 @@ bool TextDrawerWin32::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStr
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
-				uint8_t bAlpha = (uint8_t)((ctx_->pBitmapBits[MAX_TEXT_WIDTH * y + x] & 0xff) >> 4);
-				bitmapData16[entry.bmWidth * y + x] = (bAlpha) | 0xfff0;
+				uint8_t bAlpha = (uint8_t)(ctx_->pBitmapBits[MAX_TEXT_WIDTH * y + x] & 0xff);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(bAlpha);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::A4R4G4B4_UNORM_PACK16) {
@@ -229,8 +229,8 @@ bool TextDrawerWin32::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStr
 		uint16_t *bitmapData16 = (uint16_t *)&bitmapData[0];
 		for (int y = 0; y < entry.bmHeight; y++) {
 			for (int x = 0; x < entry.bmWidth; x++) {
-				uint8_t bAlpha = (uint8_t)((ctx_->pBitmapBits[MAX_TEXT_WIDTH * y + x] & 0xff) >> 4);
-				bitmapData16[entry.bmWidth * y + x] = (bAlpha << 12) | 0x0fff;
+				uint8_t bAlpha = (uint8_t)(ctx_->pBitmapBits[MAX_TEXT_WIDTH * y + x] & 0xff);
+				bitmapData16[entry.bmWidth * y + x] = AlphaToPremul4444(bAlpha);
 			}
 		}
 	} else if (texFormat == Draw::DataFormat::R8_UNORM) {

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -1329,7 +1329,7 @@ void PPGeSetTexture(u32 dataAddr, int width, int height)
 	WriteCmd(GE_CMD_TEXSIZE0, wp2 | (hp2 << 8));
 	WriteCmd(GE_CMD_TEXMAPMODE, 0 | (1 << 8));
 	WriteCmd(GE_CMD_TEXMODE, 0);
-	WriteCmd(GE_CMD_TEXFORMAT, GE_TFMT_8888);  // 4444
+	WriteCmd(GE_CMD_TEXFORMAT, GE_TFMT_8888);
 	WriteCmd(GE_CMD_TEXFILTER, (1 << 8) | 1);   // mag = LINEAR min = LINEAR
 	WriteCmd(GE_CMD_TEXWRAP, (1 << 8) | 1);  // clamp texture wrapping
 	WriteCmd(GE_CMD_TEXFUNC, (0 << 16) | (1 << 8) | 0);  // RGBA texture reads, modulate, no color doubling

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -982,6 +982,26 @@ void CreditsScreen::update() {
 	UpdateUIState(UISTATE_MENU);
 }
 
+void CreditsScreen::touch(const TouchInput &touch) {
+	UIScreen::touch(touch);
+	if (touch.id != 0)
+		return;
+
+	if (touch.flags & TOUCH_DOWN) {
+		dragYStart_ = touch.y;
+		dragYOffsetStart_ = dragOffset_;
+	}
+	if (touch.flags & TOUCH_UP) {
+		dragYStart_ = -1.0f;
+	}
+	if (touch.flags & TOUCH_MOVE) {
+		if (dragYStart_ >= 0.0f) {
+			dragOffset_ = dragYOffsetStart_ + (touch.y - dragYStart_);
+		}
+	}
+}
+
+
 void CreditsScreen::DrawForeground(UIContext &dc) {
 	auto cr = GetI18NCategory(I18NCat::PSPCREDITS);
 
@@ -1148,7 +1168,7 @@ void CreditsScreen::DrawForeground(UIContext &dc) {
 
 	float t = (float)(time_now_d() - startTime_) * 60.0;
 
-	float y = bounds.y2() - fmodf(t, (float)totalHeight);
+	float y = bounds.y2() - fmodf(t - dragOffset_, (float)totalHeight);
 	for (int i = 0; i < numItems; i++) {
 		float alpha = linearInOut(y+32, 64, bounds.y2() - 192, 64);
 		uint32_t textColor = colorAlpha(dc.GetTheme().infoStyle.fgColor, alpha);

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -161,6 +161,7 @@ public:
 	CreditsScreen();
 	void update() override;
 	void DrawForeground(UIContext &ui) override;
+	void touch(const TouchInput &touch) override;
 
 	void CreateViews() override;
 
@@ -175,6 +176,9 @@ private:
 	void OnX(UI::EventParams &e);
 
 	double startTime_ = 0.0;
+	double dragYStart_ = -1.0;
+	double dragOffset_ = 0.0;
+	double dragYOffsetStart_ = 0.0;
 };
 
 class SettingInfoMessage : public UI::LinearLayout {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -919,7 +919,7 @@ bool CreateGlobalPipelines() {
 	}
 
 	InputLayout *inputLayout = ui_draw2d.CreateInputLayout(g_draw);
-	BlendState *blendNormal = g_draw->CreateBlendState({ true, 0xF, BlendFactor::SRC_ALPHA, BlendFactor::ONE_MINUS_SRC_ALPHA });
+	BlendState *blendNormal = g_draw->CreateBlendState({ true, 0xF, BlendFactor::ONE, BlendFactor::ONE_MINUS_SRC_ALPHA });
 	DepthStencilState *depth = g_draw->CreateDepthStencilState({ false, false, Comparison::LESS });
 	RasterState *rasterNoCull = g_draw->CreateRasterState({});
 

--- a/UI/UIAtlas.cpp
+++ b/UI/UIAtlas.cpp
@@ -32,94 +32,102 @@ Atlas *GetUIAtlas() {
 	return &ui_atlas;
 }
 
-static const std::string imageIDs[] = {
-	"I_SOLIDWHITE",
-	"I_CROSS",
-	"I_CIRCLE",
-	"I_SQUARE",
-	"I_TRIANGLE",
-	"I_SELECT",
-	"I_START",
-	"I_ARROW",
-	"I_ROUND",
-	"I_ROUND_LINE",
-	"I_RECT",
-	"I_RECT_LINE",
-	"I_STICK",
-	"I_STICK_BG",
-	"I_STICK_LINE",
-	"I_STICK_BG_LINE",
-	"I_SHOULDER",
-	"I_SHOULDER_LINE",
-	"I_DIR",
-	"I_DIR_LINE",
-	"I_SQUARE_SHAPE",
-	"I_SQUARE_SHAPE_LINE",
-	"I_CHECKEDBOX",
-	"I_UNCHECKEDBOX",
-	"I_BG",
-	"I_L",
-	"I_R",
-	"I_DROP_SHADOW",
-	"I_LINES",
-	"I_GRID",
-	"I_LOGO",
-	"I_ICON",
-	"I_ICON_GOLD",
-	"I_FOLDER",
-	"I_UP_DIRECTORY",
-	"I_GEAR",
-	"I_1",
-	"I_2",
-	"I_3",
-	"I_4",
-	"I_5",
-	"I_6",
-	"I_PSP_DISPLAY",
-	"I_FLAG_JP",
-	"I_FLAG_US",
-	"I_FLAG_EU",
-	"I_FLAG_HK",
-	"I_FLAG_AS",
-	"I_FLAG_KO",
-	"I_FULLSCREEN",
-	"I_RESTORE",
-	"I_SDCARD",
-	"I_HOME",
-	"I_A",
-	"I_B",
-	"I_C",
-	"I_D",
-	"I_E",
-	"I_F",
-	"I_FOLDER_OPEN",
-	"I_WARNING",
-	"I_TRASHCAN",
-	"I_PLUS",
-	"I_ROTATE_LEFT",
-	"I_ROTATE_RIGHT",
-	"I_ARROW_LEFT",
-	"I_ARROW_RIGHT",
-	"I_ARROW_UP",
-	"I_ARROW_DOWN",
-	"I_SLIDERS",
-	"I_THREE_DOTS",
-	"I_INFO",
-	"I_RETROACHIEVEMENTS_LOGO",
-	"I_CHECKMARK",
-	"I_PLAY",
-	"I_STOP",
-	"I_PAUSE",
-	"I_FAST_FORWARD",
-	"I_RECORD",
-	"I_SPEAKER",
-	"I_SPEAKER_MAX",
-	"I_SPEAKER_OFF",
-	"I_WINNER_CUP",
-	"I_EMPTY",
-	"I_PIN",
-	"I_UNPIN",
-	"I_FOLDER_PINNED",
+struct ImageMeta {
+	std::string_view id;
+	bool addShadow = false;
+};
+
+// We add shadows to all line-art images that are used for buttons, to improve visibility.
+// However, some images are dual-used as general UI elemnts and also as custom button images. This is a problem. (I_ROTATE_LEFT, I_ROTATE_RIGHT, I_THREE_DOTS).
+// I've added shadows to most of those for now. See customKeyImages in GamepadEmu.h.
+static const ImageMeta imageIDs[] = {
+	{"I_SOLIDWHITE", false},
+	{"I_CROSS", true},
+	{"I_CIRCLE", true},
+	{"I_SQUARE", true},
+	{"I_TRIANGLE", true},
+	{"I_SELECT", true},
+	{"I_START", true},
+	{"I_ARROW", false},
+	{"I_ROUND", false},
+	{"I_ROUND_LINE", true},
+	{"I_RECT", false},
+	{"I_RECT_LINE", true},
+	{"I_STICK", false},
+	{"I_STICK_BG", false},
+	{"I_STICK_LINE", true},
+	{"I_STICK_BG_LINE", true},
+	{"I_SHOULDER", false},
+	{"I_SHOULDER_LINE", true},
+	{"I_DIR", false},
+	{"I_DIR_LINE", false},
+	{"I_SQUARE_SHAPE", false},
+	{"I_SQUARE_SHAPE_LINE", true},
+	{"I_CHECKEDBOX", false},
+	{"I_UNCHECKEDBOX", false},
+	{"I_BG", false},
+	{"I_L", true},
+	{"I_R", true},
+	{"I_DROP_SHADOW", false},
+	{"I_LINES", false},
+	{"I_GRID", false},
+	{"I_LOGO", false},
+	{"I_ICON", false},
+	{"I_ICON_GOLD", false},
+	{"I_FOLDER", false},
+	{"I_UP_DIRECTORY", false},
+	{"I_GEAR", false},
+	{"I_1", true},
+	{"I_2", true},
+	{"I_3", true},
+	{"I_4", true},
+	{"I_5", true},
+	{"I_6", true},
+	{"I_PSP_DISPLAY", false},
+	{"I_FLAG_JP", false},
+	{"I_FLAG_US", false},
+	{"I_FLAG_EU", false},
+	{"I_FLAG_HK", false},
+	{"I_FLAG_AS", false},
+	{"I_FLAG_KO", false},
+	{"I_FULLSCREEN", false},
+	{"I_RESTORE", false},
+	{"I_SDCARD", false},
+	{"I_HOME", false},
+	{"I_A", true},
+	{"I_B", true},
+	{"I_C", true},
+	{"I_D", true},
+	{"I_E", true},
+	{"I_F", true},
+	{"I_FOLDER_OPEN", false},
+	{"I_WARNING", false},
+	{"I_TRASHCAN", false},
+	{"I_PLUS", false},
+	{"I_ROTATE_LEFT", true},
+	{"I_ROTATE_RIGHT", true},
+	{"I_ARROW_LEFT", true},
+	{"I_ARROW_RIGHT", true},
+	{"I_ARROW_UP", true},
+	{"I_ARROW_DOWN", true},
+	{"I_SLIDERS", false},
+	{"I_THREE_DOTS", true},
+	{"I_INFO", false},
+	{"I_RETROACHIEVEMENTS_LOGO", false},
+	{"I_CHECKMARK", false},
+	{"I_PLAY", false},
+	{"I_STOP", false},
+	{"I_PAUSE", false},
+	{"I_FAST_FORWARD", false},
+	{"I_RECORD", false},
+	{"I_SPEAKER", false},
+	{"I_SPEAKER_MAX", false},
+	{"I_SPEAKER_OFF", false},
+	{"I_WINNER_CUP", false},
+	{"I_EMPTY", false},
+	{"I_PIN", false},
+	{"I_UNPIN", false},
+	{"I_FOLDER_PINNED", false},
 };
 
 static std::string PNGNameFromID(std::string_view id) {
@@ -134,7 +142,7 @@ static std::string PNGNameFromID(std::string_view id) {
 
 static int GetImageIndex(std::string_view id) {
 	for (int i = 0; i < ARRAY_SIZE(imageIDs); i++) {
-		if (equals(id, imageIDs[i])) {
+		if (equals(id, imageIDs[i].id)) {
 			return i;
 		}
 	}
@@ -273,7 +281,10 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 	for (int i = 0; i < (int)images.size(); i++) {
 		// Here we could exclude some images from the drop shadow, if desired.
 		if (!images[i].IsEmpty()) {
-			AddDropShadow(images[i], 3, 0.66f);
+			if (imageIDs[i].addShadow) {
+				DEBUG_LOG(Log::G3D, "Adding drop shadow to %.*s", STR_VIEW(imageIDs[i].id));
+				AddDropShadow(images[i], 3, 0.66f);
+			}
 		}
 	}
 
@@ -290,20 +301,20 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 
 		if (!img.IsEmpty()) {
 			// Was already loaded from SVG.
-			DEBUG_LOG(Log::G3D, "Skipping image %s, already loaded from SVG", imageIDs[i].c_str());
+			DEBUG_LOG(Log::G3D, "Skipping image %.*s, already loaded from SVG", STR_VIEW(imageIDs[i].id));
 			continue;
 		}
 
 		bool success = true;
-		if (equals(imageIDs[i], "I_SOLIDWHITE")) {
+		if (equals(imageIDs[i].id, "I_SOLIDWHITE")) {
 			img.resize(16, 16);
 			img.fill(0xFFFFFFFF);
-		} else if (equals(imageIDs[i], "I_EMPTY")) {
+		} else if (equals(imageIDs[i].id, "I_EMPTY")) {
 			img.resize(16, 16);
 			img.fill(0);
 		} else {
 			std::string name = "ui_images/";
-			std::string pngName = PNGNameFromID(imageIDs[i]);
+			std::string pngName = PNGNameFromID(imageIDs[i].id);
 			name.append(pngName);
 			bool success = img.LoadPNG(name.c_str());
 			if (!success) {
@@ -337,7 +348,7 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 	std::vector<AtlasImage> genAtlasImages;
 	genAtlasImages.reserve(ARRAY_SIZE(imageIDs));
 	for (int i = 0; i < ARRAY_SIZE(imageIDs); i++) {
-		genAtlasImages.push_back(ToAtlasImage(resultIds[i], imageIDs[i], (float)dest.width(), (float)dest.height(), results));
+		genAtlasImages.push_back(ToAtlasImage(resultIds[i], imageIDs[i].id, (float)dest.width(), (float)dest.height(), results));
 	}
 
 	atlas->Clear();

--- a/UI/UIAtlas.cpp
+++ b/UI/UIAtlas.cpp
@@ -11,6 +11,7 @@
 #include "Common/Render/ManagedTexture.h"
 #include "Common/Common.h"
 #include "Common/Log.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "UI/UIAtlas.h"
 
 #define NANOSVG_IMPLEMENTATION
@@ -235,6 +236,7 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 					continue;
 				}
 				img.resize(w, h);
+
 				for (int y = 0; y < h; y++) {
 					for (int x = 0; x < w; x++) {
 						int sx = minX + x;
@@ -314,6 +316,9 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 	INFO_LOG(Log::G3D, " - Loaded %d png images in %.2f ms", pngsLoaded, pngStart.ElapsedMs());
 
 	Instant addStart = Instant::Now();
+	for (int i = 0; i < images.size(); i++) {
+		images[i].ConvertToPremultipliedAlpha();
+	}
 	for (int i = 0; i < images.size(); i++) {
 		bucket.AddImage(std::move(images[i]), i);
 	}

--- a/UI/UIAtlas.cpp
+++ b/UI/UIAtlas.cpp
@@ -60,7 +60,7 @@ static const ImageMeta imageIDs[] = {
 	{"I_SHOULDER", false},
 	{"I_SHOULDER_LINE", true},
 	{"I_DIR", false},
-	{"I_DIR_LINE", false},
+	{"I_DIR_LINE", true},
 	{"I_SQUARE_SHAPE", false},
 	{"I_SQUARE_SHAPE_LINE", true},
 	{"I_CHECKEDBOX", false},
@@ -260,6 +260,8 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 				if (SAVE_DEBUG_IMAGES) {
 					pngSave(Path(std::string("../buttons_") + PNGNameFromID(shapeId)), img.data(), img.width(), img.height(), 4);
 				}
+
+				img.ConvertToPremultipliedAlpha();
 			}
 
 			shapeCount = (int)usedShapes.size();
@@ -321,15 +323,13 @@ Draw::Texture *GenerateUIAtlas(Draw::DrawContext *draw, Atlas *atlas, float dpiS
 				ERROR_LOG(Log::G3D, "Failed to load %s", name.c_str());
 			} else {
 				pngsLoaded++;
+				img.ConvertToPremultipliedAlpha();
 			}
 		}
 	}
 	INFO_LOG(Log::G3D, " - Loaded %d png images in %.2f ms", pngsLoaded, pngStart.ElapsedMs());
 
 	Instant addStart = Instant::Now();
-	for (int i = 0; i < images.size(); i++) {
-		images[i].ConvertToPremultipliedAlpha();
-	}
 	for (int i = 0; i < images.size(); i++) {
 		bucket.AddImage(std::move(images[i]), i);
 	}

--- a/assets/ui_images/images.svg
+++ b/assets/ui_images/images.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 211.66667 158.75"
    version="1.1"
    id="svg1"
-   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    sodipodi:docname="images.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -24,15 +24,16 @@
      inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="px"
-     inkscape:zoom="1.4943524"
-     inkscape:cx="548.0635"
-     inkscape:cy="279.38524"
-     inkscape:window-width="1920"
-     inkscape:window-height="1129"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="161.5739"
+     inkscape:cy="317.31417"
+     inkscape:window-width="3840"
+     inkscape:window-height="2071"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     showgrid="false" />
   <defs
      id="defs1">
     <pattern
@@ -3583,9 +3584,10 @@
          style="font-size:12px;line-height:125%;fill:#ffffff;fill-opacity:1"
          id="path3940" />
       <path
-         d="M 97.605728,69.231224 V 60.64138 h 6.210942 v 1.013672 h -5.074223 v 2.63086 h 4.751953 v 1.007812 h -4.751953 v 2.923828 h 5.273433 v 1.013672 z"
+         d="M 97.605728,69.231224 V 60.64138 h 6.210942 v 1.013672 c 0,0 -4.948196,0.18575 -5.074223,0 -0.126027,-0.18575 0,2.63086 0,2.63086 h 4.751953 v 1.007812 h -4.751953 v 2.923828 h 5.273433 v 1.013672 z"
          style="font-size:12px;line-height:125%;fill:#ffffff;fill-opacity:1"
-         id="path3942" />
+         id="path3942"
+         sodipodi:nodetypes="ccccscccccccc" />
       <path
          d="M 105.55104,69.231224 V 60.64138 h 1.13672 v 7.576172 h 4.23047 v 1.013672 z"
          style="font-size:12px;line-height:125%;fill:#ffffff;fill-opacity:1"
@@ -3662,7 +3664,7 @@
     </g>
     <path
        style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-       d="m 46.03125,41.5625 -1.123047,2.205078 v 8.189453 h 11.548828 v -8.34375 L 55.953125,43.265625 H 51.435547 L 50.599609,41.5625 Z m 0.357422,0.583984 h 3.847656 l 0.833984,1.705078 h 4.701172 l 0.101563,0.06836 v 7.451172 H 45.494141 v -7.466797 z"
+       d="m 45.101709,56.74501 -1.123047,2.205078 v 8.189453 H 55.52749 v -8.34375 L 55.023584,58.448135 H 50.506006 L 49.670068,56.74501 Z m 0.357422,0.583984 h 3.847656 l 0.833984,1.705078 h 4.701172 l 0.101563,0.06836 v 7.451172 H 44.5646 v -7.466797 z"
        id="I_FOLDER" />
     <g
        transform="matrix(0.38952161,0,0,0.38952161,-88.556132,-53.317315)"
@@ -3727,10 +3729,10 @@
          d="M -23.732181,30.229779 V 49.775586 H -4.4463411 V 30.229779 Z m 2.49666,2.529991 H -6.9405211 V 47.245604 H -21.235521 Z"
          style="fill:#ffffff;fill-opacity:1;stroke:none" />
       <path
-         inkscape:connector-curvature="0"
+         style="color:#000000;fill:#ffffff;-inkscape-stroke:none"
+         d="m -10.869141,33.775391 -4.3125,6.90039 -2.267578,-2.503906 -2.063143,2.538435 4.770174,4.920549 6.4179692,-10.265625 z"
          id="path5326"
-         d="m -18.561551,39.179179 3.59867,4.545687 5.3664299,-9.154508"
-         style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         sodipodi:nodetypes="ccccccc" />
     </g>
     <path
        inkscape:export-ydpi="135"
@@ -3738,9 +3740,8 @@
        inkscape:export-filename="C:\dev\ppsspp\source_assets\image\square.png"
        inkscape:connector-curvature="0"
        id="I_UNCHECKEDBOX"
-       d="M -23.732181,30.229779 V 49.775586 H -4.4463411 V 30.229779 Z m 2.49666,2.529991 H -6.9405211 V 47.245604 H -21.235521 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       transform="matrix(0.38768981,0,0,0.38768981,58.043664,46.774929)" />
+       d="m 45.611676,42.825293 v 7.57771 H 53.0886 v -7.57771 z m 0.96793,0.980852 h 5.542026 v 5.61601 h -5.542026 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.38769" />
     <path
        style="font-size:11.2889px;line-height:125%;font-family:Tahoma;-inkscape-font-specification:'Tahoma, Normal';letter-spacing:0px;word-spacing:0px;fill:#ffffff;stroke-width:0.397773px"
        d="m 64.549735,11.853782 h -4.001822 v -0.837848 h 1.488281 V 5.514806 H 60.547913 V 4.7651532 q 0.843359,0 1.240234,-0.2370226 0.402387,-0.2425347 0.451996,-0.9095052 h 0.854384 v 7.3973086 h 1.455208 z"
@@ -3778,19 +3779,14 @@
        inkscape:export-ydpi="96"
        transform="matrix(0.26458333,0,0,0.26458333,5.0473301,79.356161)">
       <path
-         sodipodi:nodetypes="cccccccc"
-         inkscape:connector-curvature="0"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 141.9061,237.33742 -15.09375,15.125 h 4.19416 v 16.09724 h 21.54664 v -16.09724 h 4.4467 z"
+         style="color:#000000;fill:#ffffff;-inkscape-stroke:none"
+         d="m 154.41016,251.21289 h -3.10743 v 16.09766 h -19.04687 v -16.09766 h -2.42969 c 0,0 11.30045,-11.07641 12.1072,-11.88316 z m -12.47434,-15.43751 -18.13699,17.93751 h 5.95703 v 16.09766 h 24.04687 v -16.09766 h 6.21094 z"
          id="path5204"
-         inkscape:export-filename="C:\dev\ppsspp\source_assets\image\up_line.png"
-         inkscape:export-xdpi="135"
-         inkscape:export-ydpi="135" />
+         sodipodi:nodetypes="cccccccccccccccc" />
       <path
-         inkscape:connector-curvature="0"
-         id="path1162"
-         d="M 147.32143,242.67857 V 237.5 h 4.82143 v 9.64286"
-         style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1" />
+         style="color:#000000;fill:#ffffff;-inkscape-stroke:none"
+         d="m 146.07227,236.25 v 6.42773 h 2.5 V 238.75 h 2.32031 v 8.39258 h 2.5 V 236.25 Z"
+         id="path1162" />
       <rect
          y="253.89793"
          x="139.4157"
@@ -3850,7 +3846,8 @@
       <path
          style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
          d="m 303.35742,289.48633 c -7.50613,0 -13.60742,6.10129 -13.60742,13.60742 0,7.50613 6.10129,13.60742 13.60742,13.60742 7.50614,0 13.60742,-6.10129 13.60742,-13.60742 0,-7.50613 -6.10128,-13.60742 -13.60742,-13.60742 z m 0,1.5 c 6.69548,0 12.10742,5.41195 12.10742,12.10742 0,6.69547 -5.41194,12.10742 -12.10742,12.10742 -6.69547,0 -12.10742,-5.41195 -12.10742,-12.10742 0,-6.69547 5.41195,-12.10742 12.10742,-12.10742 z"
-         id="path1285" />
+         id="path1285"
+         sodipodi:nodetypes="ssssssssss" />
       <rect
          y="299.79086"
          x="301.66043"
@@ -4018,27 +4015,23 @@
          d="m 170.07857,308.70517 -31.1872,0.0883 15.87529,-26.43907 z"
          inkscape:transform-center-y="1.0887229"
          inkscape:transform-center-x="-0.22015132"
-         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-      <ellipse
-         ry="1.8514199"
-         rx="1.7191756"
-         cy="304.12402"
-         cx="154.7699"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:2.00690076;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <g
          id="path6660"
-         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.7;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+         transform="translate(-0.01483361,0.34117308)">
+        <path
+           style="color:#000000;fill:#ffffff;stroke:none;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+           d="m 156.48907,304.12402 a 1.7191756,1.8514199 0 0 1 -1.71917,1.85142 1.7191756,1.8514199 0 0 1 -1.71918,-1.85142 1.7191756,1.8514199 0 0 1 1.71918,-1.85142 1.7191756,1.8514199 0 0 1 1.71917,1.85142 z"
+           id="path96" />
+        <path
+           style="color:#000000;fill:#ffffff;-inkscape-stroke:none"
+           d="m 154.76953,301.92187 c -1.15318,0 -2.06836,1.00302 -2.06836,2.20118 0,1.19815 0.91518,2.20313 2.06836,2.20312 1.15318,0 2.07031,-1.00497 2.07031,-2.20312 0,-1.19815 -0.91713,-2.20117 -2.07031,-2.20118 z m 0,0.70118 c 0.74577,0 1.36914,0.65313 1.36914,1.5 0,0.84686 -0.62337,1.50195 -1.36914,1.50195 -0.74577,0 -1.36914,-0.65508 -1.36914,-1.50195 0,-0.84687 0.62337,-1.50001 1.36914,-1.5 z"
+           id="path97" />
+      </g>
       <path
-         d="m 155.36996,292.41068 a 1.5698651,1.3825837 0 0 1 -1.56512,1.38257 1.5698651,1.3825837 0 0 1 -1.57458,-1.37421 1.5698651,1.3825837 0 0 1 1.55559,-1.39089 1.5698651,1.3825837 0 0 1 1.58399,1.3658 l -1.56975,0.0167 z"
-         sodipodi:end="6.2710851"
-         sodipodi:start="0"
-         sodipodi:ry="1.3825837"
-         sodipodi:rx="1.5698651"
-         sodipodi:cy="292.41068"
-         sodipodi:cx="153.80009"
-         sodipodi:type="arc"
-         transform="matrix(0.86714358,0,0,3.1461971,21.314959,-625.68775)"
-         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-         id="ellipse6694"
-         sodipodi:arc-type="slice" />
+         id="rect8"
+         style="fill:#ffffff;stroke-width:2.0069"
+         d="m 153.47141,289.76429 h 2.55931 v 11.37002 h -2.55931 z" />
     </g>
     <g
        id="I_TRASHCAN"
@@ -4067,33 +4060,11 @@
          x="175.51323"
          y="330.54053" />
       <path
-         transform="matrix(0.93415882,0,0,0.87040224,11.368845,44.781213)"
-         inkscape:export-ydpi="133.41901"
-         inkscape:export-xdpi="133.41901"
-         inkscape:export-filename="C:\dev\ppsspp\source_assets\image\folder_line.png"
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
          id="path5040"
-         d="m 164.82396,325.44548 15.69353,-0.11451 -0.0486,20.08278 -15.64493,0.12627 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-      <path
-         transform="matrix(1,0,0,1.3969583,-0.059574,-130.17522)"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         d="m 170.46367,324.75718 4.70812,0.0118 2.91873,3.06802 -10.72044,0.0947 z"
-         id="path5057"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         inkscape:export-filename="C:\dev\ppsspp\source_assets\image\folder_line.png"
-         inkscape:export-xdpi="133.41901"
-         inkscape:export-ydpi="133.41901" />
-      <rect
-         transform="matrix(0,1,-1.7569537,0,761.80772,171.85765)"
-         y="329.60303"
-         x="154.97752"
-         height="11.428567"
-         width="1.6071385"
-         id="rect5059"
-         style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+         style="color:#000000;fill:#ffffff;-inkscape-stroke:none"
+         d="m 169.90735,319.00837 -3.27724,5.04171 h -4.70603 v 1.84677 h 2.1502 v 20.40031 l 17.1427,-0.13858 0.0491,-20.26173 h 2.15161 v -1.84677 h -4.60497 l -3.18321,-5.01911 z m 0.67509,2.41165 4.35656,0.0151 1.61405,2.54571 c -2.56047,0.0453 -5.12078,0.0693 -7.68151,0.0693 z m 9.18329,4.92421 -0.0449,18.32609 -14.14616,0.11448 v -18.25378 z"
+         transform="matrix(0.93415882,0,0,0.87040224,11.368845,44.781213)"
+         sodipodi:nodetypes="ccccccccccccccccccccccc" />
     </g>
     <g
        id="I_THREE_DOTS"
@@ -4659,7 +4630,7 @@
     </g>
     <g
        id="I_FLAG_ZZ"
-       transform="matrix(0.03230252,0,0,0.03217926,172.66291,41.959725)">
+       transform="matrix(0.02084888,0,0,0.02076933,175.05917,37.12625)">
       <rect
          x="267.82452"
          y="105.90099"
@@ -4676,7 +4647,7 @@
     </g>
     <g
        id="I_FLAG_HB"
-       transform="matrix(0.02028523,0,0,0.02253914,181.31433,31.844057)">
+       transform="matrix(0.01309261,0,0,0.01454735,180.64302,30.597337)">
       <rect
          width="144"
          height="288"
@@ -4725,7 +4696,7 @@
     </g>
     <g
        id="I_FLAG_KO"
-       transform="matrix(0.06761742,0,0,0.06761742,186.18277,21.566207)">
+       transform="matrix(0.04364203,0,0,0.04364203,183.78524,23.963747)">
       <path
          d="M -72,-48 V 48 H 72 v -96 z"
          fill="#ffffff"
@@ -4758,7 +4729,7 @@
     </g>
     <g
        id="I_FLAG_AS"
-       transform="matrix(0.01081879,0,0,0.01081879,181.31433,4.7970876)">
+       transform="matrix(0.00698273,0,0,0.00698273,180.64302,13.140524)">
       <path
          d="M 0,0 H 900 V 600 H 0"
          fill="#ee1c25"
@@ -4789,7 +4760,7 @@
     </g>
     <g
        id="I_FLAG_HK"
-       transform="matrix(0.01081879,0,0,0.01081879,167.79085,45.36754)"
+       transform="matrix(0.00698273,0,0,0.00698273,171.91461,39.325742)"
        fill="#ee1c25">
       <path
          d="M 0,0 H 900 V 600 H 0 Z"
@@ -4831,7 +4802,7 @@
     </g>
     <g
        id="I_FLAG_EU"
-       transform="matrix(0.01202087,0,0,0.01202087,167.79085,31.844057)">
+       transform="matrix(0.00775858,0,0,0.00775858,171.91461,30.597337)">
       <rect
          width="810"
          height="540"
@@ -4883,7 +4854,7 @@
     </g>
     <g
        id="I_FLAG_US"
-       transform="matrix(0.00131403,0,0,0.00166443,167.79085,18.320573)">
+       transform="matrix(8.4810893e-4,0,0,0.00107427,171.91461,21.868931)">
       <path
          d="M 0,0 H 7410 V 3900 H 0"
          fill="#bf0a30"
@@ -5054,7 +5025,7 @@
     </g>
     <g
        id="I_FLAG_JP"
-       transform="matrix(0.01081879,0,0,0.01081879,167.79085,4.7970876)">
+       transform="matrix(0.00698273,0,0,0.00698273,171.91461,13.140524)">
       <rect
          width="900"
          height="600"


### PR DESCRIPTION
This will allow stretching of all kinds of UI graphics without creating additional black fringing.

This also turns off shadowing on many UI graphics, so we can now see that they look fine (without any artificial shadows added by filtering). Plus, it fixes the shadow blending, which was wrong before.

We still have slight blurriness problems in the UI because we don't have pixel-perfect positioning at DPIs other than 1:1, though :( This will take a major re-work, not happening now.

Also shrinks the flags a bit.