### PR TITLE
don't use TLS on iOS (fixes asan)

### DIFF
--- a/ext/sol/config.hpp
+++ b/ext/sol/config.hpp
@@ -50,4 +50,8 @@ the build system, or the command line options of your compiler.
 
 // end of sol/config.hpp
 
+#if PPSSPP_PLATFORM(IOS)
+#define SOL_NO_THREAD_LOCAL 1
+#endif
+
 #endif // SOL_SINGLE_SOL_CONFIG_HPP


### PR DESCRIPTION
ASAN on iOS says there's a problem in the LuaContext initialization (some more details on that below). The lua context isn't used on libretro anyway. This is the smallest possible change I could make in order to avoid the problem.

```
AddressSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.
(lldb) thread info -s
thread #46: tid = 0xa611c, 0x000000010066db44 libclang_rt.asan_ios_dynamic.dylib`__asan::AsanDie(), name = 'ExecLoader', stop reason = Heap buffer overflow
{
  "access_size": 8,
  "access_type": 1,
  "address": 5238938336,
  "bp": 6184660208,
  "description": "heap-buffer-overflow",
  "instrumentation_class": "AddressSanitizer",
  "pc": 5412404848,
  "sp": 6184660200,
  "stop_type": "fatal_error"
}
(lldb) bt
* thread #46, name = 'ExecLoader', stop reason = Heap buffer overflow
  * frame #0: 0x000000010066db44 libclang_rt.asan_ios_dynamic.dylib`__asan::AsanDie()
    frame #1: 0x0000000100687a70 libclang_rt.asan_ios_dynamic.dylib`__sanitizer::Die() + 192
    frame #2: 0x000000010066b888 libclang_rt.asan_ios_dynamic.dylib`__asan::ScopedInErrorReport::~ScopedInErrorReport() + 1172
    frame #3: 0x000000010066aae4 libclang_rt.asan_ios_dynamic.dylib`__asan::ReportGenericError(unsigned long, unsigned long, unsigned long, unsigned long, bool, unsigned long, unsigned int, bool) + 1968
    frame #4: 0x000000010066c698 libclang_rt.asan_ios_dynamic.dylib`__asan_report_store8 + 64
    frame #5: 0x00000001429abe70 ppsspp.libretro`sol::set_default_state(lua_State*, int (*)(lua_State*), int (*)(lua_State*), int (*)(lua_State*, sol::optional<std::exception const&>, std::__1::basic_string_view<char, std::__1::char_traits<char>>)) + 600
    frame #6: 0x00000001429abb4c ppsspp.libretro`sol::state::state(int (*)(lua_State*)) + 352
    frame #7: 0x00000001429a8b58 ppsspp.libretro`LuaContext::Init() + 240
    frame #8: 0x0000000142eceb78 ppsspp.libretro`void* std::__1::__thread_proxy[abi:ne200100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, PSP_InitStart(CoreParameter const&)::$_0>>(void*) + 4120
    frame #9: 0x0000000100661214 libclang_rt.asan_ios_dynamic.dylib`asan_thread_start(void*) + 80
    frame #10: 0x00000001e7bd244c libsystem_pthread.dylib`_pthread_start + 136
```