### PR TITLE
Add a compatibility flag to apply sum2012's workaround for Ghost Recon: Predator

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -153,6 +153,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceHLEPsmf", &flags_.ForceHLEPsmf);
 	CheckSetting(iniFile, gameID, "SaveStatesNotRecommended", &flags_.SaveStatesNotRecommended);
 	CheckSetting(iniFile, gameID, "IgnoreEnqueue", &flags_.IgnoreEnqueue);
+	CheckSetting(iniFile, gameID, "MsgDialogAutoStatus", &flags_.MsgDialogAutoStatus);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -116,6 +116,7 @@ struct CompatFlags {
 	bool ForceHLEPsmf;
 	bool SaveStatesNotRecommended;
 	bool IgnoreEnqueue;
+	bool MsgDialogAutoStatus;
 };
 
 struct VRCompat {

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -27,6 +27,8 @@
 #include "Core/HLE/sceCtrl.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/Reporting.h"
+#include "Core/Compatibility.h"
+#include "Core/System.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Data/Encoding/Utf8.h"
 
@@ -41,6 +43,10 @@ PSPMsgDialog::PSPMsgDialog(UtilityDialogType type) : PSPDialog(type) {
 }
 
 PSPMsgDialog::~PSPMsgDialog() {
+}
+
+bool PSPMsgDialog::UseAutoStatus() {
+	return PSP_CoreParameter().compat.flags().MsgDialogAutoStatus;
 }
 
 int PSPMsgDialog::Init(unsigned int paramAddr) {

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -67,9 +67,7 @@ public:
 	int Abort();
 
 protected:
-	bool UseAutoStatus() override {
-		return false;
-	}
+	bool UseAutoStatus() override;
 
 private:
 	void FormatErrorCode(uint32_t code);
@@ -93,6 +91,5 @@ private:
 	pspMessageDialog messageDialog{};
 	int messageDialogAddr = 0;
 
-	char msgText[512];
+	char msgText[512]{};
 };
-

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2036,3 +2036,8 @@ UCJS18059 = true
 [IgnoreEnqueue]
 #Metal Gear Acid 2 Special Card Videos Can Crash PPSSPP Issue #10906
 ULUS10077 = true
+
+[MsgDialogAutoStatus]
+# Ghost Recon - Predator. See #20856
+ULUS10445 = true
+ULES01350 = True


### PR DESCRIPTION
Thanks @sum2012 

I'm not confident in the behavior here, so let's change it only for this game for now.

Replaces #20892

Fixes #20856