### PR TITLE
add more WM_USER messages

### DIFF
--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -669,9 +669,9 @@ namespace MainWindow
 
 		case WM_USER_GET_CURRENT_GAMEID:
 		{
-			// Return game ID packed as u64
-			// wParam: 0 = first 8 chars, 1 = next 7 chars
-			// Returns: packed u64 with 8 bytes of game ID
+			// Return game ID as four u32 values
+			// wParam: 0-3 = which u32 to return (chars 0-3, 4-7, 8-11, 12-15)
+			// Returns: packed u32 with 4 bytes of game ID
 			if (!PSP_IsInited())
 			{
 				return 0;
@@ -681,13 +681,15 @@ namespace MainWindow
 			{
 				return 0;
 			}
-			u64 packed = 0;
-			const size_t offset = (wParam == 0) ? 0 : 8;
-			const size_t maxLen = std::min(gameID.length() - offset, size_t(8));
-			for (size_t i = 0; i < maxLen; ++i)
+			const size_t offset = (wParam & 0x3) * 4;  // 0, 4, 8, 12
+			u32 packed = 0;
+			for (size_t i = 0; i < 4; ++i)
 			{
-				const u8 c = static_cast<const u8>(gameID[offset + i]);
-				packed |= ((u64)c << (i * 8));
+				if (offset + i < gameID.length())
+				{
+					const u8 c = static_cast<u8>(gameID[offset + i]);
+					packed |= ((u32)c << (i * 8));
+				}
 			}
 			return packed;
 		}

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -98,6 +98,8 @@ int verysleepy__useSendMessage = 1;
 const UINT WM_VERYSLEEPY_MSG = WM_APP + 0x3117;
 const UINT WM_USER_GET_BASE_POINTER = WM_APP + 0x3118;  // 0xB118
 const UINT WM_USER_GET_EMULATION_STATE = WM_APP + 0x3119;  // 0xB119
+const UINT WM_USER_GET_CURRENT_GAMEID = WM_APP + 0x311A;  // 0xB11A
+const UINT WM_USER_GET_MODULE_INFO = WM_APP + 0x311B;  // 0xB11B
 
 // Respond TRUE to a message with this param value to indicate support.
 const WPARAM VERYSLEEPY_WPARAM_SUPPORTED = 0;
@@ -664,6 +666,79 @@ namespace MainWindow
 
 		case WM_USER_GET_EMULATION_STATE:
 			return (u32)(Core_IsActive() && GetUIState() == UISTATE_INGAME);
+
+		case WM_USER_GET_CURRENT_GAMEID:
+		{
+			// Return game ID as a string
+			// wParam: pointer to buffer
+			// lParam: size of buffer
+			if (!PSP_IsInited())
+			{
+				return 0;
+			}
+			const std::string gameID = Reporting::CurrentGameID();
+			if (gameID.empty())
+			{
+				return 0;
+			}
+			char* buffer = reinterpret_cast<char*>(wParam);
+			const size_t bufferSize = static_cast<size_t>(lParam);
+			if (!buffer || bufferSize == 0)
+			{
+				// Return required size
+				return gameID.length() + 1;
+			}
+			// Copy the game ID to the buffer
+			const size_t copySize = std::min(bufferSize - 1, gameID.length());
+			std::copy(gameID.begin(), gameID.begin() + copySize, buffer);
+			buffer[copySize] = '\0';
+			return gameID.length();
+		}
+		break;
+		case WM_USER_GET_MODULE_INFO:
+		{
+			// Get module information by name
+			// wParam: pointer to module name (null-terminated string)
+			// lParam: 0 = address, 1 = size, 2 = active flag
+			// Returns: u64 packed with module info, or 0 if not found
+			if (!PSP_IsInited() || !g_symbolMap)
+			{
+				return 0;
+			}
+			const char* moduleName = reinterpret_cast<const char*>(wParam);
+			if (!moduleName)
+			{
+				return 0;
+			}
+			// Get all modules from symbol map
+			auto modules = g_symbolMap->getAllModules();
+			for (const auto& module : modules)
+			{
+				if (module.name == moduleName)
+				{
+					switch (lParam)
+					{
+					case 0:
+						// Return address as u32 (low 32 bits)
+						return (u64)module.address;
+					case 1:
+						// Return size as u32 (low 32 bits)
+						return (u64)module.size;
+					case 2:
+						// Return active flag in bit 0, padded with zeros
+						return (u64)(module.active ? 1 : 0);
+					case 3:
+						// Return all info packed: address (bits 0-31), size (bits 32-62), active (bit 63)
+						return ((u64)module.address) | (((u64)module.size) << 32) | (module.active ? (1ULL << 63) : 0);
+					default:
+						return 0;
+					}
+				}
+			}
+			// Module not found
+			return 0;
+		}
+		break;
 
 		// Hack to kill the white line underneath the menubar.
 		// From https://stackoverflow.com/questions/57177310/how-to-paint-over-white-line-between-menu-bar-and-client-area-of-window


### PR DESCRIPTION
- WM_USER_GET_CURRENT_GAMEID
- WM_USER_GET_MODULE_INFO

Usage:

### WM_USER_GET_CURRENT_GAMEID

```c
std::string gameID;
for (int part = 0; part < 4; ++part)
{
    uint32_t packed = SendMessage(hWndPPSSPP, WM_USER_GET_CURRENT_GAMEID, part, 0);
    for (int i = 0; i < 4; ++i)
    {
        uint8_t c = (packed >> (i * 8)) & 0xFF;
        if (c == '\0') break;
        gameID += (char)c;
    }
}
```

### WM_USER_GET_MODULE_INFO

```c
// Get only address
u32 addr = (u32)SendMessage(hwnd, WM_USER_GET_MODULE_INFO, (WPARAM)"SplinterCellPSP", 0);

// Get only size
u32 size = (u32)SendMessage(hwnd, WM_USER_GET_MODULE_INFO, (WPARAM)"SplinterCellPSP", 1);

// Get only active flag
bool active = SendMessage(hwnd, WM_USER_GET_MODULE_INFO, (WPARAM)"SplinterCellPSP", 2) != 0;

// Get all info packed (lParam=3)
u64 packed = SendMessage(hwnd, WM_USER_GET_MODULE_INFO, (WPARAM)"SplinterCellPSP", 3);
u32 addr = (u32)(packed & 0xFFFFFFFF);
u32 size = (u32)((packed >> 32) & 0x7FFFFFFF);
bool active = (packed >> 63) != 0;
```