### PR TITLE
Change color specification of US flag

### DIFF
--- a/assets/ui_images/images.svg
+++ b/assets/ui_images/images.svg
@@ -3941,14 +3941,14 @@
    id="I_FLAG_US"
    transform="matrix(8.4810893e-4,0,0,0.00107427,3.571875,87.312501)"><path
      d="M 0,0 H 7410 V 3900 H 0"
-     fill="#bf0a30"
+     fill="#b31942"
      id="path43" /><path
      d="m 0,450 h 7410 m 0,600 H 0 m 0,600 h 7410 m 0,600 H 0 m 0,600 h 7410 m 0,600 H 0"
      stroke="#ffffff"
      stroke-width="300"
      id="path44" /><path
      d="M 0,0 H 2964 V 2100 H 0"
-     fill="#002868"
+     fill="#0a3161"
      id="path45" /><g
      fill="#ffffff"
      id="g95"><path


### PR DESCRIPTION
... to the specification published in 2017 by the Bureau of Educational and Cultural Affairs (ECA) of the United States Department of State (DOS).

(I wanted to submit this independently of the other flag PR.)

Reference image: (where "current" is before this PR)
<img width="1240" height="1343" alt="image" src="https://github.com/user-attachments/assets/49d06ccd-25f9-4cf0-a648-ffdf9bf7e081" />
