### PR TITLE
iOS portrait mode work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1568,6 +1568,8 @@ list(APPEND NativeAppSource
 	UI/MainScreen.cpp
 	UI/MiscScreens.h
 	UI/MiscScreens.cpp
+	UI/MiscViews.h
+	UI/MiscViews.cpp
 	UI/PauseScreen.h
 	UI/PauseScreen.cpp
 	UI/TabbedDialogScreen.h

--- a/Common/Math/geom2d.h
+++ b/Common/Math/geom2d.h
@@ -25,6 +25,11 @@ struct Point2D {
 	}*/
 };
 
+// Moved here from UI, it has general uses too.
+enum Orientation {
+	ORIENT_HORIZONTAL,
+	ORIENT_VERTICAL,
+};
 
 // Resolved bounds on screen after layout.
 struct Bounds {
@@ -33,6 +38,10 @@ struct Bounds {
 
 	static Bounds FromCenter(float x_, float y_, float radius) {
 		return Bounds(x_ - radius, y_ - radius, radius * 2.0f, radius * 2.0f);
+	}
+
+	float GetSize(Orientation o) const {
+		return (o == ORIENT_HORIZONTAL) ? w : h;
 	}
 
 	bool Contains(float px, float py) const {

--- a/Common/Math/geom2d.h
+++ b/Common/Math/geom2d.h
@@ -31,6 +31,13 @@ enum Orientation {
 	ORIENT_VERTICAL,
 };
 
+// Workaround for X header, ugh.
+#undef Opposite
+
+inline constexpr Orientation Opposite(Orientation o) {
+	return (o == ORIENT_HORIZONTAL) ? ORIENT_VERTICAL : ORIENT_HORIZONTAL;
+}
+
 // Resolved bounds on screen after layout.
 struct Bounds {
 	Bounds() : x(0.0f), y(0.0f), w(0.0f), h(0.0f) {}

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -137,13 +137,16 @@ Bounds UIContext::GetScissorBounds() {
 		return bounds_;
 }
 
-Bounds UIContext::GetLayoutBounds() const {
+Bounds UIContext::GetLayoutBounds(bool ignoreBottomInset) const {
 	Bounds bounds = GetBounds();
 
 	float left = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
 	float right = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_RIGHT);
 	float top = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP);
-	// float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM);
+	float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM);
+	if (ignoreBottomInset) {
+		bottom = 0.0f;
+	}
 
 	// Note that we ignore bottom here, to let lists etc. extend to the bottom of the screen.
 	// However, we will add the same space to the bottom of scrolled lists, so that you don't have to
@@ -153,7 +156,7 @@ Bounds UIContext::GetLayoutBounds() const {
 	bounds.x += left;
 	bounds.w -= (left + right);
 	bounds.y += top;
-	bounds.h -= top;
+	bounds.h -= (top + bottom);
 	return bounds;
 }
 

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -143,14 +143,17 @@ Bounds UIContext::GetLayoutBounds() const {
 	float left = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
 	float right = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_RIGHT);
 	float top = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP);
-	float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM);
+	// float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM);
+
+	// Note that we ignore bottom here, to let lists etc. extend to the bottom of the screen.
+	// However, we will add the same space to the bottom of scrolled lists, so that you don't have to
+	// touch things below the safe inset.
 
 	// Adjust left edge to compensate for cutouts (notches) if any.
 	bounds.x += left;
 	bounds.w -= (left + right);
 	bounds.y += top;
-	bounds.h -= (top + bottom);
-
+	bounds.h -= top;
 	return bounds;
 }
 

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -113,7 +113,7 @@ public:
 	// in dps, like dp_xres and dp_yres
 	void SetBounds(const Bounds &b) { bounds_ = b; }
 	const Bounds &GetBounds() const { return bounds_; }
-	Bounds GetLayoutBounds() const;
+	Bounds GetLayoutBounds(bool ignoreBottomInset = false) const;
 	Draw::DrawContext *GetDrawContext() { return draw_; }
 	const UI::Theme &GetTheme() const {
 		return *theme;
@@ -130,8 +130,6 @@ public:
 		atlasInvalid_ = true;  // will cause it to be reloaded on the next frame.
 	}
 private:
-	void GenerateUIAtlas();
-
 	Draw::DrawContext *draw_ = nullptr;
 	Bounds bounds_;
 

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -100,8 +100,8 @@ bool IsFocusMovementEnabled() {
 	return focusMovementEnabled;
 }
 
-void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets) {
-	Bounds rootBounds = ignoreInsets ? dc.GetBounds() : dc.GetLayoutBounds();
+void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets, bool ignoreBottomInset) {
+	Bounds rootBounds = ignoreInsets ? dc.GetBounds() : dc.GetLayoutBounds(ignoreBottomInset);
 
 	MeasureSpec horiz(EXACTLY, rootBounds.w);
 	MeasureSpec vert(EXACTLY, rootBounds.h);

--- a/Common/UI/Root.h
+++ b/Common/UI/Root.h
@@ -22,7 +22,7 @@ DialogResult DispatchEvents();
 
 class ViewGroup;
 
-void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets);
+void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets, bool ignoreBottomInset);
 DialogResult UpdateViewHierarchy(ViewGroup *root);
 
 enum class KeyEventResult {

--- a/Common/UI/ScrollView.h
+++ b/Common/UI/ScrollView.h
@@ -47,6 +47,7 @@ public:
 	NeighborResult FindScrollNeighbor(View *view, const Point2D &target, FocusDirection direction, NeighborResult best) override;
 
 private:
+	float ChildSize() const;  // in the scrolled direction
 	float HardClampedScrollPos(float pos) const;
 
 	// TODO: Don't adjust pull_ within this!

--- a/Common/UI/TabHolder.cpp
+++ b/Common/UI/TabHolder.cpp
@@ -58,7 +58,7 @@ TabHolder::TabHolder(Orientation orientation, float stripSize, TabHolderFlags fl
 void TabHolder::AddBack(UIScreen *parent) {
 	if (tabContainer_) {
 		auto di = GetI18NCategory(I18NCat::DIALOG);
-		tabContainer_->Add(new Choice(di->T("Back"), "", false, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 0.0f, Margins(0, 0, 10, 10))))->OnClick.Handle<UIScreen>(parent, &UIScreen::OnBack);
+		tabContainer_->Add(new Choice(di->T("Back"), ImageID("I_NAVIGATE_BACK"), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 0.0f, Margins(0, 0, 10, 10))))->OnClick.Handle<UIScreen>(parent, &UIScreen::OnBack);
 	}
 }
 

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -56,7 +56,7 @@ void UIScreen::DoRecreateViews() {
 
 		// Update layout and refocus so things scroll into view.
 		// This is for resizing down, when focused on something now offscreen.
-		UI::LayoutViewHierarchy(*screenManager()->getUIContext(), root_, ignoreInsets_);
+		UI::LayoutViewHierarchy(*screenManager()->getUIContext(), root_, ignoreInsets_, ignoreBottomInset_);
 		UI::View *focused = UI::GetFocusedView();
 		if (focused) {
 			root_->SubviewFocused(focused);
@@ -229,7 +229,7 @@ ScreenRenderFlags UIScreen::render(ScreenRenderMode mode) {
 
 	UIContext &uiContext = *screenManager()->getUIContext();
 	if (root_) {
-		UI::LayoutViewHierarchy(uiContext, root_, ignoreInsets_);
+		UI::LayoutViewHierarchy(uiContext, root_, ignoreInsets_, ignoreBottomInset_);
 	}
 
 	uiContext.PushTransform({translation_, scale_, alpha_});

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -68,6 +68,7 @@ protected:
 	Vec3 scale_ = Vec3(1.0f);
 	float alpha_ = 1.0f;
 	bool ignoreInsets_ = false;
+	bool ignoreBottomInset_ = false;
 	bool ignoreInput_ = false;
 
 protected:

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -184,11 +184,6 @@ enum class BorderStyle {
 	ITEM_DOWN_BG,
 };
 
-enum Orientation {
-	ORIENT_HORIZONTAL,
-	ORIENT_VERTICAL,
-};
-
 inline Orientation Opposite(Orientation o) {
 	if (o == ORIENT_HORIZONTAL) return ORIENT_VERTICAL; else return ORIENT_HORIZONTAL;
 }

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -184,10 +184,6 @@ enum class BorderStyle {
 	ITEM_DOWN_BG,
 };
 
-inline Orientation Opposite(Orientation o) {
-	if (o == ORIENT_HORIZONTAL) return ORIENT_VERTICAL; else return ORIENT_HORIZONTAL;
-}
-
 inline FocusDirection Opposite(FocusDirection d) {
 	switch (d) {
 	case FOCUS_UP: return FOCUS_DOWN;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -91,7 +91,7 @@ private:
 };
 
 SingleControlMapper::SingleControlMapper(int pspKey, std::string keyName, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams)
-	: UI::LinearLayout(UI::ORIENT_VERTICAL, layoutParams), pspKey_(pspKey), keyName_(keyName), scrm_(scrm) {
+	: UI::LinearLayout(ORIENT_VERTICAL, layoutParams), pspKey_(pspKey), keyName_(keyName), scrm_(scrm) {
 	Refresh();
 }
 

--- a/UI/DriverManagerScreen.cpp
+++ b/UI/DriverManagerScreen.cpp
@@ -79,7 +79,7 @@ public:
 	std::string name_;
 };
 
-DriverChoice::DriverChoice(const std::string &driverName, bool current, UI::LayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_VERTICAL, layoutParams), name_(driverName) {
+DriverChoice::DriverChoice(const std::string &driverName, bool current, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_VERTICAL, layoutParams), name_(driverName) {
 	using namespace UI;
 	SetSpacing(2.0f);
 	if (!layoutParams) {
@@ -116,7 +116,7 @@ DriverChoice::DriverChoice(const std::string &driverName, bool current, UI::Layo
 		Add(new NoticeView(NoticeLevel::SUCCESS, gr->T("Current GPU driver"), ""));
 	}
 
-	auto horizBar = Add(new UI::LinearLayout(UI::ORIENT_HORIZONTAL));
+	auto horizBar = Add(new UI::LinearLayout(ORIENT_HORIZONTAL));
 	std::string desc = meta.description;
 	if (!desc.empty()) desc += "\n";
 	if (!isDefault)

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1941,7 +1941,7 @@ void EmuScreen::renderUI() {
 	thin3d->SetViewport(viewport);
 
 	if (root_) {
-		UI::LayoutViewHierarchy(*ctx, root_, false);
+		UI::LayoutViewHierarchy(*ctx, root_, false, false);
 		root_->Draw(*ctx);
 	}
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -936,7 +936,7 @@ public:
 	MacAddressChooser(RequesterToken token, Path gamePath, std::string *value, std::string_view title, ScreenManager *screenManager, UI::LayoutParams *layoutParams = nullptr);
 };
 
-MacAddressChooser::MacAddressChooser(RequesterToken token, Path gamePath_, std::string *value, std::string_view title, ScreenManager *screenManager, UI::LayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_HORIZONTAL, layoutParams) {
+MacAddressChooser::MacAddressChooser(RequesterToken token, Path gamePath_, std::string *value, std::string_view title, ScreenManager *screenManager, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
 	using namespace UI;
 	SetSpacing(5.0f);
 	if (!layoutParams) {

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -138,8 +138,8 @@ void InstallZipScreen::CreateViews() {
 
 			int columnWidth = 300;
 
-			LinearLayout *compareColumns = leftColumn->Add(new LinearLayout(UI::ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-			LinearLayout *leftCompare = new LinearLayout(UI::ORIENT_VERTICAL);
+			LinearLayout *compareColumns = leftColumn->Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+			LinearLayout *leftCompare = new LinearLayout(ORIENT_VERTICAL);
 			leftCompare->Add(new TextView(iz->T("Data to import")));
 			compareColumns->Add(leftCompare);
 			leftCompare->Add(new SavedataView(*screenManager()->getUIContext(), Path(), IdentifiedFileType::PSP_SAVEDATA_DIRECTORY,
@@ -150,7 +150,7 @@ void InstallZipScreen::CreateViews() {
 				savedataToOverwrite_ = savedataDir / zipFileInfo_.savedataDir;
 				std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), savedataToOverwrite_, GameInfoFlags::FILE_TYPE | GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::SIZE);
 
-				LinearLayout *rightCompare = new LinearLayout(UI::ORIENT_VERTICAL);
+				LinearLayout *rightCompare = new LinearLayout(ORIENT_VERTICAL);
 				rightCompare->Add(new TextView(iz->T("Existing data")));
 
 				compareColumns->Add(rightCompare);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -777,7 +777,7 @@ void GameBrowser::Refresh() {
 	// No topbar on recent screen
 	gameList_ = nullptr;
 	if (DisplayTopBar()) {
-		LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(8, 0, 8, 0)));
 		if (browseFlags_ & BrowseFlags::NAVIGATE) {
 			topBar->Add(new Spacer(2.0f));
 			topBar->Add(new TextView(path_.GetFriendlyPath(), ALIGN_VCENTER | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
@@ -796,7 +796,7 @@ void GameBrowser::Refresh() {
 #else
 			if ((browseFlags_ & BrowseFlags::BROWSE) && System_GetPropertyBool(SYSPROP_HAS_FOLDER_BROWSER)) {
 				// Collapse the button title on very small screens (Retroid Pocket) or portrait mode.
-				std::string_view browseTitle = g_display.pixel_xres <= 640 ? "" : mm->T("Browse");
+				std::string_view browseTitle = g_display.pixel_xres <= 550 ? "" : mm->T("Browse");
 				topBar->Add(new Choice(browseTitle, ImageID("I_FOLDER_OPEN"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::BrowseClick);
 			}
 			if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_TV) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -795,7 +795,7 @@ void GameBrowser::Refresh() {
 			topBar->Add(new Choice(ImageID("I_FOLDER_OPEN"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::BrowseClick);
 #else
 			if ((browseFlags_ & BrowseFlags::BROWSE) && System_GetPropertyBool(SYSPROP_HAS_FOLDER_BROWSER)) {
-				// Collapse the button title on very small screens (Retroid Pocket).
+				// Collapse the button title on very small screens (Retroid Pocket) or portrait mode.
 				std::string_view browseTitle = g_display.pixel_xres <= 640 ? "" : mm->T("Browse");
 				topBar->Add(new Choice(browseTitle, ImageID("I_FOLDER_OPEN"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::BrowseClick);
 			}
@@ -1069,6 +1069,7 @@ void GameBrowser::OnHomebrewStore(UI::EventParams &e) {
 
 MainScreen::MainScreen() {
 	g_BackgroundAudio.SetGame(Path());
+	ignoreBottomInset_ = true;
 }
 
 MainScreen::~MainScreen() {
@@ -1090,9 +1091,11 @@ void MainScreen::CreateRecentTab() {
 
 	ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollRecentGames->SetTag("MainScreenRecentGames");
+
 	GameBrowser *tabRecentGames = new GameBrowser(GetRequesterToken(),
 		Path("!RECENT"), BrowseFlags::NONE, &g_Config.bGridView1, screenManager(), "", "",
-		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+
 	scrollRecentGames->Add(tabRecentGames);
 	gameBrowsers_.push_back(tabRecentGames);
 
@@ -1111,7 +1114,7 @@ GameBrowser *MainScreen::CreateBrowserTab(const Path &path, std::string_view tit
 
 	GameBrowser *gameBrowser = new GameBrowser(GetRequesterToken(), path, browseFlags, bGridView, screenManager(),
 		mm->T(howToTitle), howToUri,
-		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 
 	scrollView->Add(gameBrowser);
 	gameBrowsers_.push_back(gameBrowser);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -516,7 +516,7 @@ void DirButton::Draw(UIContext &dc) {
 }
 
 GameBrowser::GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams)
-	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), gridStyle_(gridStyle), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink), screenManager_(screenManager), token_(token) {
+	: LinearLayout(ORIENT_VERTICAL, layoutParams), gridStyle_(gridStyle), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink), screenManager_(screenManager), token_(token) {
 	using namespace UI;
 	path_.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
 	Path memstickRoot = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT);
@@ -837,7 +837,7 @@ void GameBrowser::Refresh() {
 		if (*gridStyle_) {
 			gameList_ = new UI::GridLayoutList(UI::GridLayoutSettings(150*g_Config.fGameGridScale, 85*g_Config.fGameGridScale), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(10, 0, 0, 0)));
 		} else {
-			UI::LinearLayout *gl = new UI::LinearLayoutList(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+			UI::LinearLayout *gl = new UI::LinearLayoutList(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 			gl->SetSpacing(4.0f);
 			gameList_ = gl;
 		}
@@ -845,7 +845,7 @@ void GameBrowser::Refresh() {
 		if (*gridStyle_) {
 			gameList_ = new UI::GridLayoutList(UI::GridLayoutSettings(150*g_Config.fGameGridScale, 85*g_Config.fGameGridScale), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(10, 0, 0, 0)));
 		} else {
-			UI::LinearLayout *gl = new UI::LinearLayout(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+			UI::LinearLayout *gl = new UI::LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 			gl->SetSpacing(4.0f);
 			gameList_ = gl;
 		}
@@ -905,7 +905,7 @@ void GameBrowser::Refresh() {
 			fileInfo.clear();
 			path_.GetListing(fileInfo, "zip:rar:r01:7z:");
 			if (!fileInfo.empty()) {
-				UI::LinearLayout *zl = new UI::LinearLayoutList(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+				UI::LinearLayout *zl = new UI::LinearLayoutList(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 				zl->SetSpacing(4.0f);
 				Add(zl);
 				for (size_t i = 0; i < fileInfo.size(); i++) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1296,11 +1296,11 @@ void MainScreen::CreateViews() {
 	}
 
 	if (vertical) {
-		LinearLayout *header = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(0, 16, 0, 8)));
+		LinearLayout *header = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(8, 8, 8, 16)));
 		header->SetSpacing(5.0f);
 		header->Add(CreateLogoView(true, new LinearLayoutParams(WRAP_CONTENT, 80.0f, false)));
 
-		LinearLayout *buttonGroup = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f, UI::Gravity::G_VCENTER, UI::Margins(0,0,8,0)));
+		LinearLayout *buttonGroup = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f, UI::Gravity::G_VCENTER));
 
 		CreateMainButtons(buttonGroup, vertical);
 		header->Add(buttonGroup);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -937,6 +937,9 @@ private:
 
 void CreditsScreen::CreateViews() {
 	using namespace UI;
+
+	ignoreBottomInset_ = false;
+
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 	auto cr = GetI18NCategory(I18NCat::PSPCREDITS);
 	auto mm = GetI18NCategory(I18NCat::MAINMENU);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -1193,12 +1193,12 @@ void CreditsScroller::Draw(UIContext &dc) {
 }
 
 SettingInfoMessage::SettingInfoMessage(int align, float cutOffY, UI::AnchorLayoutParams *lp)
-	: UI::LinearLayout(UI::ORIENT_HORIZONTAL, lp), cutOffY_(cutOffY) {
+	: UI::LinearLayout(ORIENT_HORIZONTAL, lp), cutOffY_(cutOffY) {
 	using namespace UI;
 	SetSpacing(0.0f);
-	Add(new UI::Spacer(10.0f));
-	text_ = Add(new UI::TextView("", align, false, new LinearLayoutParams(1.0, Margins(0, 10))));
-	Add(new UI::Spacer(10.0f));
+	Add(new Spacer(10.0f));
+	text_ = Add(new TextView("", align, false, new LinearLayoutParams(1.0, Margins(0, 10))));
+	Add(new Spacer(10.0f));
 }
 
 void SettingInfoMessage::Show(std::string_view text, const UI::View *refView) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -927,7 +927,7 @@ public:
 		}
 		return true;
 	}
-	void Draw(UIContext &dc);
+	void Draw(UIContext &dc) override;
 private:
 	Instant startTime_ = Instant::Now();
 	double dragYStart_ = -1.0;
@@ -974,24 +974,24 @@ void CreditsScreen::CreateViews() {
 		});
 		rightYOffset = 74;
 	}
-	left->Add(new Choice(cr->T("PPSSPP Forums"), ImageID("I_LINK_OUT")))->OnClick.Add([this](UI::EventParams &e) {
+	left->Add(new Choice(cr->T("PPSSPP Forums"), ImageID("I_LINK_OUT")))->OnClick.Add([](UI::EventParams &e) {
 		System_LaunchUrl(LaunchUrlType::BROWSER_URL, "https://forums.ppsspp.org");
 	});
-	left->Add(new Choice(cr->T("Discord"), ImageID("I_LOGO_DISCORD")))->OnClick.Add([this](UI::EventParams &e) {
+	left->Add(new Choice(cr->T("Discord"), ImageID("I_LOGO_DISCORD")))->OnClick.Add([](UI::EventParams &e) {
 		System_LaunchUrl(LaunchUrlType::BROWSER_URL, "https://discord.gg/5NJB6dD");
 	});
-	left->Add(new Choice("www.ppsspp.org", ImageID("I_LINK_OUT")))->OnClick.Add([this](UI::EventParams &e) {
+	left->Add(new Choice("www.ppsspp.org", ImageID("I_LINK_OUT")))->OnClick.Add([](UI::EventParams &e) {
 		System_LaunchUrl(LaunchUrlType::BROWSER_URL, "https://www.ppsspp.org");
 	});
-	right->Add(new Choice(cr->T("Privacy Policy"), ImageID("I_LINK_OUT")))->OnClick.Add([this](UI::EventParams &e) {
+	right->Add(new Choice(cr->T("Privacy Policy"), ImageID("I_LINK_OUT")))->OnClick.Add([](UI::EventParams &e) {
 		System_LaunchUrl(LaunchUrlType::BROWSER_URL, "https://www.ppsspp.org/privacy");
 	});
-	right->Add(new Choice(cr->T("@PPSSPP_emu"), ImageID("I_LOGO_X")))->OnClick.Add([this](UI::EventParams &e) {
+	right->Add(new Choice(cr->T("@PPSSPP_emu"), ImageID("I_LOGO_X")))->OnClick.Add([](UI::EventParams &e) {
 		System_LaunchUrl(LaunchUrlType::BROWSER_URL, "https://x.com/PPSSPP_emu");
 	});
 
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_SHARE_TEXT)) {
-		right->Add(new Choice(cr->T("Share PPSSPP"), ImageID("I_SHARE")))->OnClick.Add([this](UI::EventParams &e) {
+		right->Add(new Choice(cr->T("Share PPSSPP"), ImageID("I_SHARE")))->OnClick.Add([](UI::EventParams &e) {
 			auto cr = GetI18NCategory(I18NCat::PSPCREDITS);
 			System_ShareText(cr->T("CheckOutPPSSPP", "Check out PPSSPP, the awesome PSP emulator: https://www.ppsspp.org/"));
 		});

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -59,6 +59,7 @@
 #include "UI/MainScreen.h"
 #include "UI/MiscScreens.h"
 #include "UI/MemStickScreen.h"
+#include "UI/MiscViews.h"
 
 #ifdef _MSC_VER
 #pragma execution_character_set("utf-8")
@@ -948,9 +949,8 @@ void CreditsScreen::CreateViews() {
 
 	root_ = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, FILL_PARENT));
 
-	Button *back = root_->Add(new Button(di->T("Back")));
-	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnOK);
-	root_->SetDefaultFocusView(back);
+	TopBar *topBar = root_->Add(new TopBar(mm->T("About PPSSPP")));
+	root_->SetDefaultFocusView(topBar->GetBackButton());
 
 	const bool gold = System_GetPropertyBool(SYSPROP_APP_GOLD);
 
@@ -965,9 +965,9 @@ void CreditsScreen::CreateViews() {
 
 	LinearLayout *columns = root_->Add(new LinearLayout(ORIENT_HORIZONTAL));
 
-	LinearLayout *left = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT)));
+	LinearLayout *left = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT, Margins(10))));
 	LinearLayout *middle = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
-	LinearLayout *right = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT)));
+	LinearLayout *right = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT, Margins(10))));
 
 	int rightYOffset = 0;
 	if (!System_GetPropertyBool(SYSPROP_APP_GOLD)) {

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -1,0 +1,55 @@
+#include "Common/UI/View.h"
+#include "Common/Render/DrawBuffer.h"
+#include "Common/System/Request.h"
+#include "UI/MiscViews.h"
+
+TextWithImage::TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
+	using namespace UI;
+	SetSpacing(8.0f);
+	if (!layoutParams) {
+		layoutParams_->width = FILL_PARENT;
+		layoutParams_->height = ITEM_HEIGHT;
+	}
+	if (imageID.isValid()) {
+		Add(new ImageView(imageID, "", UI::IS_DEFAULT, new LinearLayoutParams(0.0f, UI::Gravity::G_VCENTER)));
+	}
+	Add(new TextView(text, new LinearLayoutParams(1.0f, UI::Gravity::G_VCENTER)));
+}
+
+CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
+	using namespace UI;
+	SetSpacing(8.0f);
+	if (!layoutParams) {
+		layoutParams_->width = FILL_PARENT;
+		layoutParams_->height = ITEM_HEIGHT;
+	}
+	if (imageID.isValid()) {
+		Add(new ImageView(imageID, "", UI::IS_DEFAULT, new LinearLayoutParams(0.0f, UI::Gravity::G_VCENTER)));
+	}
+	Add(new TextView(text, new LinearLayoutParams(1.0f, UI::Gravity::G_VCENTER)))->SetBig(true);
+
+	std::string textStr(text);  // We need to store the text in the lambda context.
+	Add(new Choice(ImageID("I_FILE_COPY"), new LinearLayoutParams()))->OnClick.Add([textStr](UI::EventParams &) {
+		System_CopyStringToClipboard(textStr);
+	});
+}
+
+TopBar::TopBar(std::string_view title, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
+	using namespace UI;
+	SetSpacing(10.0f);
+	if (!layoutParams) {
+		layoutParams_->width = UI::FILL_PARENT;
+		layoutParams_->height = 64.0f;
+	}
+
+	backButton_ = Add(new Choice(ImageID("I_NAVIGATE_BACK"), new LinearLayoutParams()));
+	backButton_ ->OnClick.Add([](UI::EventParams &e) {
+		e.bubbleResult = DR_BACK;
+	});
+
+	if (!title.empty()) {
+		Add(new TextView(title, ALIGN_CENTER | FLAG_WRAP_TEXT, false, new LinearLayoutParams(1.0f, G_VCENTER)));
+		// To balance the centering, add a spacer on the right.
+		Add(new Spacer(50.0f));
+	}
+}

--- a/UI/MiscViews.h
+++ b/UI/MiscViews.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Common/UI/View.h"
+#include "UI/ViewGroup.h"
+
+// Compound view, showing a text with an icon.
+class TextWithImage : public UI::LinearLayout {
+public:
+	TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
+};
+
+// Compound view, showing a copyable string.
+class CopyableText : public UI::LinearLayout {
+public:
+	CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
+};
+
+class TopBar : public UI::LinearLayout {
+public:
+	TopBar(std::string_view title, UI::LayoutParams *layoutParams = nullptr);
+	UI::View *GetBackButton() const { return backButton_; }
+private:
+	UI::Choice *backButton_ = nullptr;
+};

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -221,7 +221,7 @@ private:
 	Path screenshotFilename_;
 };
 
-SaveSlotView::SaveSlotView(const Path &gameFilename, int slot, bool vertical, UI::LayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_HORIZONTAL, layoutParams), slot_(slot), gamePath_(gameFilename) {
+SaveSlotView::SaveSlotView(const Path &gameFilename, int slot, bool vertical, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams), slot_(slot), gamePath_(gameFilename) {
 	using namespace UI;
 
 	screenshotFilename_ = SaveState::GenerateSaveSlotFilename(gamePath_, slot, SaveState::SCREENSHOT_EXTENSION);
@@ -475,7 +475,7 @@ void GamePauseScreen::CreateViews() {
 	if (showSavestateControls) {
 		if (PSP_CoreParameter().compat.flags().SaveStatesNotRecommended) {
 			bannerAdded = true;
-			LinearLayout *horiz = new LinearLayout(UI::ORIENT_HORIZONTAL);
+			LinearLayout *horiz = new LinearLayout(ORIENT_HORIZONTAL);
 			leftColumnItems->Add(horiz);
 			horiz->Add(new NoticeView(NoticeLevel::WARN, pa->T("Using save states is not recommended in this game"), "", new LinearLayoutParams(1.0f)));
 			horiz->Add(new Button(di->T("More info")))->OnClick.Add([](UI::EventParams &e) {

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -309,8 +309,8 @@ void ReportScreen::CreateViews() {
 	overallDescription_ = leftColumnItems->Add(new TextView("", FLAG_WRAP_TEXT, false, new LinearLayoutParams(Margins(10, 0))));
 	overallDescription_->SetShadow(true);
 
-	UI::Orientation ratingsOrient = leftColumnWidth >= 750.0f ? ORIENT_HORIZONTAL : ORIENT_VERTICAL;
-	UI::LinearLayout *ratingsHolder = new LinearLayoutList(ratingsOrient, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
+	Orientation ratingsOrient = leftColumnWidth >= 750.0f ? ORIENT_HORIZONTAL : ORIENT_VERTICAL;
+	LinearLayout *ratingsHolder = new LinearLayoutList(ratingsOrient, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
 	leftColumnItems->Add(ratingsHolder);
 	ratingsHolder->Add(new RatingChoice("Graphics", &graphics_))->SetEnabledPtrs(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);
 	ratingsHolder->Add(new RatingChoice("Speed", &speed_))->SetEnabledPtrs(&ratingEnabled_)->OnChoice.Handle(this, &ReportScreen::HandleChoice);

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -27,7 +27,7 @@ public:
 	UI::UISound sound_;
 };
 
-AudioFileChooser::AudioFileChooser(RequesterToken token, std::string *value, std::string_view title, UI::UISound sound, UI::LayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_HORIZONTAL, layoutParams), sound_(sound) {
+AudioFileChooser::AudioFileChooser(RequesterToken token, std::string *value, std::string_view title, UI::UISound sound, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams), sound_(sound) {
 	using namespace UI;
 	SetSpacing(2.0f);
 	if (!layoutParams) {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -48,7 +48,7 @@
 class SavedataButton;
 
 SavedataView::SavedataView(UIContext &dc, const Path &savePath, IdentifiedFileType type, std::string_view title, std::string_view savedataTitle, std::string_view savedataDetail, std::string_view fileSize, std::string_view mtime, bool showIcon, UI::LayoutParams *layoutParams)
-	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams)
+	: LinearLayout(ORIENT_VERTICAL, layoutParams)
 {
 	using namespace UI;
 
@@ -205,7 +205,7 @@ public:
 	typedef std::function<void(View *)> PrepFunc;
 	typedef std::function<bool(const View *, const View *)> CompareFunc;
 
-	SortedLinearLayout(UI::Orientation orientation, UI::LayoutParams *layoutParams = nullptr)
+	SortedLinearLayout(Orientation orientation, UI::LayoutParams *layoutParams = nullptr)
 		: UI::LinearLayoutList(orientation, layoutParams) {
 	}
 
@@ -418,7 +418,7 @@ std::string SavedataButton::DescribeText() const {
 }
 
 SavedataBrowser::SavedataBrowser(const Path &path, UI::LayoutParams *layoutParams)
-	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), path_(path) {
+	: LinearLayout(ORIENT_VERTICAL, layoutParams), path_(path) {
 	Refresh();
 }
 
@@ -578,7 +578,7 @@ void SavedataBrowser::Refresh() {
 		searchingView_ = group->Add(new TextView(sa->T("Showing matches for '%1'")));
 		searchingView_->SetVisibility(UI::V_GONE);
 
-		SortedLinearLayout *gl = new SortedLinearLayout(UI::ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+		SortedLinearLayout *gl = new SortedLinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		gl->SetSpacing(4.0f);
 		gameList_ = gl;
 		Add(gameList_);

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -254,7 +254,7 @@ private:
 class ProductView : public UI::LinearLayout {
 public:
 	ProductView(const StoreEntry &entry)
-		: LinearLayout(UI::ORIENT_VERTICAL), entry_(entry) {
+		: LinearLayout(ORIENT_VERTICAL), entry_(entry) {
 		CreateViews();
 	}
 

--- a/UI/TabbedDialogScreen.h
+++ b/UI/TabbedDialogScreen.h
@@ -20,7 +20,9 @@ ENUM_CLASS_BITOPS(TabFlags);
 
 class TabbedUIDialogScreenWithGameBackground : public UIDialogScreenWithGameBackground {
 public:
-	TabbedUIDialogScreenWithGameBackground(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
+	TabbedUIDialogScreenWithGameBackground(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
+		ignoreBottomInset_ = true;
+	}
 
 	void AddTab(const char *tag, std::string_view title, std::function<void(UI::LinearLayout *)> createCallback, TabFlags flags = TabFlags::Default);
 	void CreateViews() override;

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="MainScreen.cpp" />
     <ClCompile Include="MemStickScreen.cpp" />
     <ClCompile Include="MiscScreens.cpp" />
+    <ClCompile Include="MiscViews.cpp" />
     <ClCompile Include="NativeApp.cpp" />
     <ClCompile Include="OnScreenDisplay.cpp" />
     <ClCompile Include="PauseScreen.cpp" />
@@ -109,6 +110,7 @@
     <ClInclude Include="MainScreen.h" />
     <ClInclude Include="MemStickScreen.h" />
     <ClInclude Include="MiscScreens.h" />
+    <ClInclude Include="MiscViews.h" />
     <ClInclude Include="OnScreenDisplay.h" />
     <ClInclude Include="PauseScreen.h" />
     <ClInclude Include="ProfilerDraw.h" />

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClCompile Include="UploadScreen.cpp">
       <Filter>Screens</Filter>
     </ClCompile>
+    <ClCompile Include="MiscViews.cpp">
+      <Filter>Views</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameInfoCache.h" />
@@ -263,6 +266,9 @@
     </ClInclude>
     <ClInclude Include="UploadScreen.h">
       <Filter>Screens</Filter>
+    </ClInclude>
+    <ClInclude Include="MiscViews.h">
+      <Filter>Views</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/UI/UploadScreen.cpp
+++ b/UI/UploadScreen.cpp
@@ -6,47 +6,7 @@
 #include "Common/Data/Text/Parsers.h"
 #include "Core/WebServer.h"
 #include "UI/UploadScreen.h"
-
-// Compound view, showing a text with an icon.
-class TextWithImage : public UI::LinearLayout {
-public:
-	TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
-};
-
-TextWithImage::TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
-	using namespace UI;
-	SetSpacing(8.0f);
-	if (!layoutParams) {
-		layoutParams_->width = FILL_PARENT;
-		layoutParams_->height = ITEM_HEIGHT;
-	}
-	if (imageID.isValid()) {
-		Add(new ImageView(imageID, "", UI::IS_DEFAULT, new LinearLayoutParams(0.0f, UI::Gravity::G_VCENTER)));
-	}
-	Add(new TextView(text, new LinearLayoutParams(1.0f, UI::Gravity::G_VCENTER)));
-}
-
-// Compound view, showing a copyable string.
-class CopyableText : public UI::LinearLayout {
-public:
-	CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
-};
-
-CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
-	using namespace UI;
-	SetSpacing(8.0f);
-	if (!layoutParams) {
-		layoutParams_->width = FILL_PARENT;
-		layoutParams_->height = ITEM_HEIGHT;
-	}
-	if (imageID.isValid()) {
-		Add(new ImageView(imageID, "", UI::IS_DEFAULT, new LinearLayoutParams(0.0f, UI::Gravity::G_VCENTER)));
-	}
-	Add(new TextView(text, new LinearLayoutParams(1.0f, UI::Gravity::G_VCENTER)))->SetBig(true);
-	Add(new Choice(ImageID("I_FILE_COPY"), new LinearLayoutParams()))->OnClick.Add([text](UI::EventParams &) {
-		System_CopyStringToClipboard(text);
-	});
-}
+#include "UI/MiscViews.h"
 
 UploadScreen::UploadScreen(const Path &targetFolder) : targetFolder_(targetFolder) {
 	std::vector<std::string> ips;
@@ -70,10 +30,7 @@ void UploadScreen::CreateViews() {
 	auto n = GetI18NCategory(I18NCat::NETWORKING);
 	root_ = new LinearLayout(ORIENT_VERTICAL);
 
-	LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
-	root_->Add(topBar);
-
-	topBar->Add(new Choice(ImageID("I_NAVIGATE_BACK"), new LinearLayoutParams()))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
+	root_->Add(new TopBar(""));
 
 	LinearLayout *container = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(500, FILL_PARENT, 0.0f, UI::Gravity::G_HCENTER, Margins(10)));
 	root_->Add(container);

--- a/UI/UploadScreen.cpp
+++ b/UI/UploadScreen.cpp
@@ -13,7 +13,7 @@ public:
 	TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
 };
 
-TextWithImage::TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_HORIZONTAL, layoutParams) {
+TextWithImage::TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
 	using namespace UI;
 	SetSpacing(8.0f);
 	if (!layoutParams) {
@@ -32,7 +32,7 @@ public:
 	CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
 };
 
-CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_HORIZONTAL, layoutParams) {
+CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
 	using namespace UI;
 	SetSpacing(8.0f);
 	if (!layoutParams) {
@@ -49,7 +49,14 @@ CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLay
 }
 
 UploadScreen::UploadScreen(const Path &targetFolder) : targetFolder_(targetFolder) {
-	net::GetLocalIP4List(localIPs_);
+	std::vector<std::string> ips;
+	net::GetLocalIP4List(ips);
+	localIPs_.clear();
+	for (const auto &ip : ips) {
+		if (!ip.empty() && !startsWith(ip, "127.") && !startsWith(ip, "169.254.")) {
+			localIPs_.push_back(ip);
+		}
+	}
 	WebServerSetUploadPath(targetFolder);
 	StartWebServer(WebServerFlags::FILE_UPLOAD);
 }

--- a/UWP/UI_UWP/UI_UWP.vcxproj
+++ b/UWP/UI_UWP/UI_UWP.vcxproj
@@ -113,6 +113,7 @@
     <ClInclude Include="..\..\UI\InstallZipScreen.h" />
     <ClInclude Include="..\..\UI\JitCompareScreen.h" />
     <ClInclude Include="..\..\UI\JoystickHistoryView.h" />
+    <ClInclude Include="..\..\UI\MiscViews.h" />
     <ClInclude Include="..\..\UI\SystemInfoScreen.h" />
     <ClInclude Include="..\..\UI\TabbedDialogScreen.h" />
     <ClInclude Include="..\..\UI\RetroAchievementScreens.h" />
@@ -165,6 +166,7 @@
     <ClCompile Include="..\..\UI\InstallZipScreen.cpp" />
     <ClCompile Include="..\..\UI\JitCompareScreen.cpp" />
     <ClCompile Include="..\..\UI\JoystickHistoryView.cpp" />
+    <ClCompile Include="..\..\UI\MiscViews.cpp" />
     <ClCompile Include="..\..\UI\SystemInfoScreen.cpp" />
     <ClCompile Include="..\..\UI\TabbedDialogScreen.cpp" />
     <ClCompile Include="..\..\UI\RetroAchievementScreens.cpp" />

--- a/UWP/UI_UWP/UI_UWP.vcxproj.filters
+++ b/UWP/UI_UWP/UI_UWP.vcxproj.filters
@@ -127,6 +127,9 @@
     <ClCompile Include="..\..\UI\UploadScreen.cpp">
       <Filter>Screens</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\UI\MiscViews.cpp">
+      <Filter>Screens</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -253,6 +256,9 @@
       <Filter>Screens</Filter>
     </ClInclude>
     <ClInclude Include="..\..\UI\UploadScreen.h">
+      <Filter>Screens</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UI\MiscViews.h">
       <Filter>Screens</Filter>
     </ClInclude>
   </ItemGroup>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -912,6 +912,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/UI/MemStickScreen.cpp \
   $(SRC)/UI/IAPScreen.cpp \
   $(SRC)/UI/MiscScreens.cpp \
+  $(SRC)/UI/MiscViews.cpp \
   $(SRC)/UI/RemoteISOScreen.cpp \
   $(SRC)/UI/ReportScreen.cpp \
   $(SRC)/UI/PauseScreen.cpp \

--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -43,8 +43,6 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
-	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
@@ -53,8 +51,6 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>GCSupportsGameMode</key>
-	<true/>
-	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -196,6 +196,9 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	self.glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 	[self.view addSubview:self.glView];
 
+	self.view.insetsLayoutMarginsFromSafeArea = NO;
+	self.view.clipsToBounds = YES;
+
 	// Put context current for initial GL setup
 	[EAGLContext setCurrentContext:self.glContext];
 
@@ -336,9 +339,6 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	INFO_LOG(Log::System, "shutdown GL");
 
 	g_Config.Save("shutdown GL");
-
-	_dbg_assert_(sharedViewController != nil);
-	sharedViewController = nil;
 
 	_dbg_assert_(graphicsContext);
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -196,8 +196,8 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	self.glView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 	[self.view addSubview:self.glView];
 
-	self.view.insetsLayoutMarginsFromSafeArea = NO;
-	self.view.clipsToBounds = YES;
+	// self.view.insetsLayoutMarginsFromSafeArea = NO;
+	// self.view.clipsToBounds = YES;
 
 	// Put context current for initial GL setup
 	[EAGLContext setCurrentContext:self.glContext];

--- a/ios/ViewControllerCommon.mm
+++ b/ios/ViewControllerCommon.mm
@@ -300,25 +300,32 @@ extern float g_safeInsetRight;
 extern float g_safeInsetTop;
 extern float g_safeInsetBottom;
 
-static float BoostInset(float inset) {
-	if (inset > 0.0f) {
-		// If there's some inset, add a few pixels extra. Really needed on iPhone 12, at least.
-		inset += 4.0f;
-	}
-	return inset;
-}
-
 - (void)viewSafeAreaInsetsDidChange {
 	[super viewSafeAreaInsetsDidChange];
-	// we use 0.0f instead of safeAreaInsets.bottom because the bottom overlay isn't disturbing (for now)
-	g_safeInsetLeft = BoostInset(self.view.safeAreaInsets.left);
-	g_safeInsetRight = BoostInset(self.view.safeAreaInsets.right);
-	g_safeInsetTop = BoostInset(self.view.safeAreaInsets.top);
 
-	// TODO: In portrait mode, should probably use safeAreaInsets.bottom.
-	// However, in landscape mode, it's not really needed.
-	// g_safeInsetBottom = BoostInset(self.view.safeAreaInsets.bottom);
-	g_safeInsetBottom = 0.0f;
+	// Converts points to pixels.
+	CGFloat scale = UIScreen.mainScreen.scale;
+
+	float xInsetSum = self.view.safeAreaInsets.left + self.view.safeAreaInsets.right;
+	float yInsetSum = self.view.safeAreaInsets.top + self.view.safeAreaInsets.bottom;
+
+	// Only use the larger set of insets. The other set, we'll handle through layouts.
+	// Also, we'll treat the bottom inset differently: We'll add some space at the end of everything
+	// that scrolls so that when you're not at the bottom, we use the full vertical area,
+	// just looks better.
+	if (xInsetSum > yInsetSum) {
+		// Landscape mode insets are larger, use those.
+		g_safeInsetLeft = self.view.safeAreaInsets.left * scale;
+		g_safeInsetRight = self.view.safeAreaInsets.right * scale;
+		g_safeInsetTop = 0.0f;
+		g_safeInsetBottom = 0.0f;
+	} else {
+		// Portrait mode insets are larger, use those.
+		g_safeInsetLeft = 0.0f;
+		g_safeInsetRight = 0.0f;
+		g_safeInsetTop = self.view.safeAreaInsets.top * scale;
+		g_safeInsetBottom = self.view.safeAreaInsets.bottom * scale;
+	}
 }
 
 - (void)shareText:(NSString *)text {

--- a/ios/ViewControllerCommon.mm
+++ b/ios/ViewControllerCommon.mm
@@ -40,6 +40,12 @@
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillTerminate:) name:UIApplicationWillTerminateNotification object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(controllerDidConnect:) name:GCControllerDidConnectNotification object:nil];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(controllerDidDisconnect:) name:GCControllerDidDisconnectNotification object:nil];
+
+		// Observe orientation changes
+		[[NSNotificationCenter defaultCenter] addObserver:self
+												selector:@selector(onOrientationChanged)
+												name:UIDeviceOrientationDidChangeNotification
+												object:nil];
 	}
 	self.accelerometerQueue = [[NSOperationQueue alloc] init];
 	self.accelerometerQueue.name = @"AccelerometerQueue";
@@ -395,5 +401,38 @@ static float BoostInset(float inset) {
 }
 
 #endif
+#pragma mark - Status Bar Control
+
+// iOS calls this to determine whether to hide the status bar
+- (BOOL)prefersStatusBarHidden {
+	UIInterfaceOrientation orientation;
+
+	if (@available(iOS 13.0, *)) {
+		UIWindowScene *scene = self.view.window.windowScene;
+		if (scene != nil) {
+			orientation = scene.interfaceOrientation;
+		} else {
+			orientation = UIApplication.sharedApplication.statusBarOrientation;
+		}
+	} else {
+		orientation = UIApplication.sharedApplication.statusBarOrientation;
+	}
+
+	BOOL isLandscape = UIInterfaceOrientationIsLandscape(orientation);
+
+	bool userWantsStatusBar = true; // g_Config.bShowStatusBar;
+	// return isLandscape || !userWantsStatusBar;
+	return false;
+}
+
+// Optional: choose light/dark text for the status bar
+- (UIStatusBarStyle)preferredStatusBarStyle {
+	return UIStatusBarStyleLightContent;
+}
+
+// This should also be called when the user preference changes.
+- (void)onOrientationChanged {
+	[self setNeedsStatusBarAppearanceUpdate];
+}
 
 @end

--- a/ios/ViewControllerCommon.mm
+++ b/ios/ViewControllerCommon.mm
@@ -309,18 +309,16 @@ static float BoostInset(float inset) {
 }
 
 - (void)viewSafeAreaInsetsDidChange {
-	if (@available(iOS 11.0, *)) {
-		[super viewSafeAreaInsetsDidChange];
-		// we use 0.0f instead of safeAreaInsets.bottom because the bottom overlay isn't disturbing (for now)
-		g_safeInsetLeft = BoostInset(self.view.safeAreaInsets.left);
-		g_safeInsetRight = BoostInset(self.view.safeAreaInsets.right);
-		g_safeInsetTop = BoostInset(self.view.safeAreaInsets.top);
+	[super viewSafeAreaInsetsDidChange];
+	// we use 0.0f instead of safeAreaInsets.bottom because the bottom overlay isn't disturbing (for now)
+	g_safeInsetLeft = BoostInset(self.view.safeAreaInsets.left);
+	g_safeInsetRight = BoostInset(self.view.safeAreaInsets.right);
+	g_safeInsetTop = BoostInset(self.view.safeAreaInsets.top);
 
-		// TODO: In portrait mode, should probably use safeAreaInsets.bottom.
-		// However, in landscape mode, it's not really needed.
-		// g_safeInsetBottom = BoostInset(self.view.safeAreaInsets.bottom);
-		g_safeInsetBottom = 0.0f;
-	}
+	// TODO: In portrait mode, should probably use safeAreaInsets.bottom.
+	// However, in landscape mode, it's not really needed.
+	// g_safeInsetBottom = BoostInset(self.view.safeAreaInsets.bottom);
+	g_safeInsetBottom = 0.0f;
 }
 
 - (void)shareText:(NSString *)text {

--- a/ios/ViewControllerMetal.mm
+++ b/ios/ViewControllerMetal.mm
@@ -347,8 +347,8 @@ void VulkanRenderLoop(IOSVulkanContext *graphicsContext, CAMetalLayer *metalLaye
 	UIScreen* screen = [(AppDelegate*)[UIApplication sharedApplication].delegate screen];
 	self.view.frame = [screen bounds];
 	self.view.multipleTouchEnabled = YES;
-	self.view.insetsLayoutMarginsFromSafeArea = NO;
-	self.view.clipsToBounds = YES;
+	// self.view.insetsLayoutMarginsFromSafeArea = NO;
+	// self.view.clipsToBounds = YES;
 
 	graphicsContext = new IOSVulkanContext();
 

--- a/ios/ViewControllerMetal.mm
+++ b/ios/ViewControllerMetal.mm
@@ -347,6 +347,9 @@ void VulkanRenderLoop(IOSVulkanContext *graphicsContext, CAMetalLayer *metalLaye
 	UIScreen* screen = [(AppDelegate*)[UIApplication sharedApplication].delegate screen];
 	self.view.frame = [screen bounds];
 	self.view.multipleTouchEnabled = YES;
+	self.view.insetsLayoutMarginsFromSafeArea = NO;
+	self.view.clipsToBounds = YES;
+
 	graphicsContext = new IOSVulkanContext();
 
 	[[DisplayManager shared] updateResolution:[UIScreen mainScreen]];

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -36,6 +36,7 @@
 #include "Common/StringUtils.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/Thread/ThreadUtil.h"
+#include "Common/System/Display.h"
 #include "Core/Config.h"
 #include "Common/Log.h"
 #include "Common/Log/LogManager.h"
@@ -343,13 +344,13 @@ float System_GetPropertyFloat(SystemProperty prop) {
 	case SYSPROP_DISPLAY_REFRESH_RATE:
 		return 60.f;
 	case SYSPROP_DISPLAY_SAFE_INSET_LEFT:
-		return g_safeInsetLeft;
+		return g_safeInsetLeft * g_display.dpi_scale_x;
 	case SYSPROP_DISPLAY_SAFE_INSET_RIGHT:
-		return g_safeInsetRight;
+		return g_safeInsetRight * g_display.dpi_scale_x;
 	case SYSPROP_DISPLAY_SAFE_INSET_TOP:
-		return g_safeInsetTop;
+		return g_safeInsetTop * g_display.dpi_scale_y;
 	case SYSPROP_DISPLAY_SAFE_INSET_BOTTOM:
-		return g_safeInsetBottom;
+		return g_safeInsetBottom * g_display.dpi_scale_y;
 	default:
 		return -1;
 	}


### PR DESCRIPTION
In iOS portrait mode, show the clock / wifi / battery indicators as usual (not in landscape mode though of course, won't fit).

Adjust a bunch of margins and stuff to make things nicer.

Scrollviews add a bit of extra space if needed at the bottom, to make it easier to hit the lowest items on a touchscreen.