### PR TITLE
Remove constexpr from ConfigSetting constructors

### DIFF
--- a/Core/ConfigSettings.h
+++ b/Core/ConfigSettings.h
@@ -77,102 +77,102 @@ struct ConfigSetting {
 		CustomButtonDefaultCallback customButton;
 	};
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, bool *v, bool def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, bool *v, bool def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_BOOL), flags_(flags), offset_((const char *)v - owner) {
 		cb_.b = nullptr;
 		default_.b = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, int *v, int def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, int *v, int def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_INT), flags_(flags), offset_((const char *)v - owner) {
 		cb_.i = nullptr;
 		default_.i = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, int *v, int def, std::string (*transTo)(int), int (*transFrom)(const std::string &), CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, int *v, int def, std::string (*transTo)(int), int (*transFrom)(const std::string &), CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_INT), flags_(flags), translateTo_(transTo), translateFrom_(transFrom), offset_((const char *)v - owner) {
 		cb_.i = nullptr;
 		default_.i = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, uint32_t *v, uint32_t def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, uint32_t *v, uint32_t def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_UINT32), flags_(flags), offset_((const char *)v - owner) {
 		cb_.u = nullptr;
 		default_.u = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, uint64_t *v, uint64_t def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, uint64_t *v, uint64_t def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_UINT64), flags_(flags), offset_((const char *)v - owner) {
 		cb_.lu = nullptr;
 		default_.lu = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, float *v, float def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, float *v, float def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_FLOAT), flags_(flags), offset_((const char *)v - owner) {
 		cb_.f = nullptr;
 		default_.f = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, std::string *v, const char *def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, std::string *v, const char *def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_STRING), flags_(flags), offset_((const char *)v - owner) {
 		cb_.s = nullptr;
 		default_.s = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, std::vector<std::string> *v, const std::vector<std::string> *def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, std::vector<std::string> *v, const std::vector<std::string> *def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_STRING_VECTOR), flags_(flags), offset_((const char *)v - owner) {
 		default_.v = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, Path *v, const char *def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, Path *v, const char *def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_PATH), flags_(flags), offset_((const char *)v - owner) {
 		cb_.p = nullptr;
 		default_.p = def;
 	}
 
-	constexpr ConfigSetting(const char *iniX, const char *iniY, const char *iniScale, const char *iniShow, const char *owner, ConfigTouchPos *v, ConfigTouchPos def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(const char *iniX, const char *iniY, const char *iniScale, const char *iniShow, const char *owner, ConfigTouchPos *v, ConfigTouchPos def, CfgFlag flags) noexcept
 		: iniKey_(iniX), ini2_(iniY), ini3_(iniScale), ini4_(iniShow), type_(Type::TYPE_TOUCH_POS), flags_(flags), offset_((const char *)v - owner) {
 		cb_.touchPos = nullptr;
 		default_.touchPos = def;
 	}
 
-	constexpr ConfigSetting(const char *iniKey, const char *iniImage, const char *iniShape, const char *iniToggle, const char *iniRepeat, const char *owner, ConfigCustomButton *v, ConfigCustomButton def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(const char *iniKey, const char *iniImage, const char *iniShape, const char *iniToggle, const char *iniRepeat, const char *owner, ConfigCustomButton *v, ConfigCustomButton def, CfgFlag flags) noexcept
 		: iniKey_(iniKey), ini2_(iniImage), ini3_(iniShape), ini4_(iniToggle), ini5_(iniRepeat), type_(Type::TYPE_CUSTOM_BUTTON), flags_(flags), offset_((const char *)v - owner) {
 		cb_.customButton = nullptr;
 		default_.customButton = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, bool *v, BoolDefaultCallback def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, bool *v, BoolDefaultCallback def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_BOOL), flags_(flags), offset_((const char *)v - owner) {
 		cb_.b = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, int *v, IntDefaultCallback def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, int *v, IntDefaultCallback def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_INT), flags_(flags), offset_((const char *)v - owner) {
 		cb_.i = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, int *v, IntDefaultCallback def, std::string(*transTo)(int), int(*transFrom)(const std::string &), CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, int *v, IntDefaultCallback def, std::string(*transTo)(int), int(*transFrom)(const std::string &), CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_INT), flags_(flags), offset_((const char *)v - owner), translateTo_(transTo), translateFrom_(transFrom) {
 		cb_.i = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, uint32_t *v, Uint32DefaultCallback def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, uint32_t *v, Uint32DefaultCallback def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_UINT32), flags_(flags), offset_((const char *)v - owner) {
 		cb_.u = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, float *v, FloatDefaultCallback def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, float *v, FloatDefaultCallback def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_FLOAT), flags_(flags), offset_((const char *)v - owner) {
 		cb_.f = def;
 	}
 
-	constexpr ConfigSetting(std::string_view ini, const char *owner, std::string *v, StringDefaultCallback def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view ini, const char *owner, std::string *v, StringDefaultCallback def, CfgFlag flags) noexcept
 		: iniKey_(ini), type_(Type::TYPE_STRING), flags_(flags), offset_((const char *)v - owner) {
 		cb_.s = def;
 	}
 
-	constexpr ConfigSetting(std::string_view iniX, const char *iniY, const char *iniScale, const char *iniShow, const char *owner, ConfigTouchPos *v, TouchPosDefaultCallback def, CfgFlag flags = CfgFlag::DEFAULT) noexcept
+	ConfigSetting(std::string_view iniX, const char *iniY, const char *iniScale, const char *iniShow, const char *owner, ConfigTouchPos *v, TouchPosDefaultCallback def, CfgFlag flags) noexcept
 		: iniKey_(iniX), ini2_(iniY), ini3_(iniScale), ini4_(iniShow), type_(Type::TYPE_TOUCH_POS), flags_(flags), offset_((const char *)v - owner) {
 		cb_.touchPos = def;
 	}
@@ -193,7 +193,7 @@ struct ConfigSetting {
 	bool SaveSetting() const { return !(flags_ & CfgFlag::DONT_SAVE); }
 	bool Report() const { return flags_ & CfgFlag::REPORT; }
 
-	std::string_view iniKey_ = nullptr;
+	std::string_view iniKey_;
 	const char *ini2_ = nullptr;
 	const char *ini3_ = nullptr;
 	const char *ini4_ = nullptr;


### PR DESCRIPTION
We can't take full advantage of it until we start requiring C++20 anyway.

Also remove the CfgFlags defaults while at it.

Fixes #20938