### PR TITLE
Fix pgd_offset

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2588,6 +2588,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 		f->pgdInfo = pgd_open(kirk, pgd_header, 2, key_ptr);
 		if (!f->pgdInfo) {
 			f->npdrm = false;
+			f->pgd_offset = 0;  // Reset PGD offset so file can be read as regular file
 			pspFileSystem.SeekFile(f->handle, (s32)0, FILEMOVE_BEGIN);
 			if (memcmp(pgd_header, pgd_magic, 4) == 0) {
 				// File is PGD file, but key mismatch


### PR DESCRIPTION
By miniMax AI while debuging scemp4 .When PGD decryption failed for .edat files, the pgd_offset variable was not being reset to 0. This caused subsequent file reads to access the wrong file position.