### PR TITLE
fix GCC warning

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -935,7 +935,7 @@ void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, std::string_view nam
 				}
 			}, path);
 		} else {
-			free(path);
+			delete[] path;
 		}
 		return;
 	}


### PR DESCRIPTION
```
C:/src/ppsspp/Core/System.cpp: In function 'void DumpFileIfEnabled(const u8*, u32, std::string_view, DumpFileType)': C:/src/ppsspp/Core/System.cpp:938:29: warning: 'void free(void*)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
  938 |                         free(path);
      |                         ~~~~^~~~~~
C:/src/ppsspp/Core/System.cpp:924:67: note: returned from 'void* operator new [](std::size_t)'
  924 |                 char *path = new char[strlen(fullPath.c_str()) + 1];
      |
```