### PR TITLE
Try to fix android  Memory Stick Not Inserted issue

### DIFF
--- a/Core/HW/MemoryStick.cpp
+++ b/Core/HW/MemoryStick.cpp
@@ -35,8 +35,10 @@
 #include "Common/Thread/Promise.h"
 
 // MS and FatMS states.
-static MemStickState memStickState;
-static MemStickFatState memStickFatState;
+// Initialize to INSERTED state by default to avoid race conditions on Android
+// where the save dialog might check state before MemoryStick_Init() is called.
+static MemStickState memStickState = PSP_MEMORYSTICK_STATE_INSERTED;
+static MemStickFatState memStickFatState = PSP_FAT_MEMORYSTICK_STATE_ASSIGNED;
 static bool memStickNeedsAssign = false;
 static uint64_t memStickInsertedAt = 0;
 static uint64_t memstickInitialFree = 0;


### PR DESCRIPTION
By minimax AI
https://agent.minimax.io/share/332637994229989?chat_type=1
Related to #13781
Not tested because I cannot build android version
Static variables declared without explicit initialization
static MemStickState memStickState;
static MemStickFatState memStickFatState;
3.
Impact:
In C++, static variables of enum types are zero-initialized
memStickState initialized to 0
memStickFatState initialized to 0
4.
Enum Values:
PSP_MEMORYSTICK_STATE_INSERTED = 1
PSP_MEMORYSTICK_STATE_NOT_INSERTED = 2
PSP_FAT_MEMORYSTICK_STATE_UNASSIGNED = 0
PSP_FAT_MEMORYSTICK_STATE_ASSIGNED = 1
5.
Race Condition:
On Android, save dialog initialization may occur before __IoInit() → MemoryStick_Init() execution
When PSPSaveDialog.cpp line 1182 checks:
cpp
if (MemoryStick_State() != PSP_MEMORYSTICK_STATE_INSERTED) {
    result = SCE_UTILITY_SAVEDATA_ERROR_RW_NO_MEMSTICK;
}
With uninitialized state (0), the condition evaluates as: 0 != 1 → TRUE
Error triggered incorrectly