### PR TITLE
libretro: fix mac build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,12 @@ jobs:
           args: ./b.sh --headless --unittest --fat --no-png --no-sdl2
           id: macos
         - os: macos-latest
+          extra: libretro_mac
+          cc: clang
+          cxx: clang++
+          args: ./b.sh --libretro
+          id: macos-libretro
+        - os: macos-latest
           extra: ios
           cc: clang
           cxx: clang++

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -2039,7 +2039,10 @@ void System_AudioClear() {}
 std::vector<std::string> System_GetCameraDeviceList() { return std::vector<std::string>(); }
 bool System_AudioRecordingIsAvailable() { return false; }
 bool System_AudioRecordingState() { return false; }
-
+#elif PPSSPP_PLATFORM(MAC)
+std::vector<std::string> __mac_getDeviceList() { return std::vector<std::string>(); }
+int __mac_startCapture(int width, int height) { return 0; }
+int __mac_stopCapture() { return 0; }
 #endif
 
 // TODO: To avoid having to define these here, these should probably be turned into system "requests".


### PR DESCRIPTION
673c1e76a9802882376614e941dca852ea67a331 adds a few functions that get called on Mac in Core/HW but the SDL/MacCameraHelper.mm doesn't get included on libretro (correctly) and this leads to linker errors. This is just a quick build fix for now; more proper would be adding actual libretro camera support.

https://git.libretro.com/libretro/ppsspp/-/pipelines/24087