### PR TITLE
Fix buffer overflow in kirk

### DIFF
--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -476,7 +476,8 @@ int sceSdCipherUpdate(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
 		return -1025;
 	}
 	int i = 0;
-	u8 kirkData[20+2048];
+	u8 kirkData[37 + 2048] = {0};
+	u8* kirkDataPtr = kirkData + 20;
 	if ((u32)alignedLen >= (u32)2048)
 	{
 		for(i = 0; alignedLen >= 2048; i += 2048)

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -416,7 +416,7 @@ int sceSdCipherInit(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, cons
 	}
 	else if (uknw == 1)
 	{
-		u8 kirkHeader[37];
+		u8 kirkHeader[37+2048];
 		u8* kirkData = kirkHeader+20;
 		int res = sub_17A8(&g_kirk, kirkHeader);
 		if (res)

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -416,7 +416,7 @@ int sceSdCipherInit(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, cons
 	}
 	else if (uknw == 1)
 	{
-		u8 kirkHeader[37+2048];
+		u8 kirkHeader[37+2048] = {0};
 		u8* kirkData = kirkHeader+20;
 		int res = sub_17A8(&g_kirk, kirkHeader);
 		if (res)


### PR DESCRIPTION
By minimax AI,https://agent.minimax.io/share/333400393080967?chat_type=1 
1. u8 kirkHeader[37]; - 37 bytes allocated
2. u8* kirkData = kirkHeader+20; - kirkData points to offset 20 in kirkHeader 
3. u8 kirkData[20+2048] in line 479; - but this suggests kirkData should have 2068 bytes There's a memory layout mismatch!
#13781 still not fix (because I have apply other changed) , saving issue of other games not test.