### PR TITLE
Add DepthRangeHack compatibility setting for multiple FromSoftware ti…

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -136,7 +136,7 @@ ULJM08069 = true
 NPJH50625 = true
 
 [DepthRangeHack]
-# Phantasy Star Portable 2 and Infinity both use viewport depth outside [0, 1].
+# Phantasy Star Portable 2 and Infinity as well as some FromSoftware titles both use viewport depth outside [0, 1].
 # This gets clamped in our current implementation, but attempts to fix it run into
 # Other bugs, so we've restored this hack for now.
 # Phantasy Star Portable
@@ -163,6 +163,40 @@ ULJM91018 = true
 NPJH90062 = true
 # Phantasy Star Portable Infinity Demo
 NPJH90157 = true  # Infinity demo
+# Armored Core 3 Portable
+NPEH00045 = true
+NPUH10023 = true
+NPUH90059 = true
+UCAS40268 = true
+ULJM05492 = true
+ULKS46210 = true
+# Armored Core: Last Raven Portable
+NPEH00046 = true
+NPUH10024 = true
+NPUH90083 = true
+UCAS40302 = true
+UCKS45148 = true
+ULJM05611 = true
+# Armored Core: Silent Line Portable
+NPEH00047 = true
+NPJH90075 = true
+NPUH10025 = true
+NPUH90068 = true
+UCAS40289 = true
+ULJM05552 = true
+# MonHun Nikki
+NPJH50294 = true
+ULAS42285 = true
+ULJM05710 = true
+ULJM05881 = true
+ULJM08039 = true
+# SSX on Tour
+NPHH00081 = true
+ULES00192 = true
+ULJM05063 = true
+ULJM05389 = true
+ULKS46038 = true
+ULUS10042 = true
 
 [ClearToRAM]
 # SOCOM Navy Seals games require this. See issue #8973.


### PR DESCRIPTION
Adds multiple FromSoftware titles to DepthRangeHack under compat.ini

This change fixes the games being overly dark when alpha effects are present on Mali GPUs using the OpenGL backend. I think ideally we wouldn't want that hack to be needed to begin with, but I'm not sure how to go about a solution to that.

This resolves #11430 and #10726 for me