### PR TITLE
Rework the game screen to work better in portrait mode

### DIFF
--- a/Common/Math/geom2d.h
+++ b/Common/Math/geom2d.h
@@ -54,6 +54,10 @@ struct Bounds {
 		return Bounds(x_ - radius, y_ - radius, radius * 2.0f, radius * 2.0f);
 	}
 
+	static Bounds FromCenterWH(float x_, float y_, float w, float h) {
+		return Bounds(x_ - w * 0.5f, y_ - h * 0.5f, w, h);
+	}
+
 	float GetSize(Orientation o) const {
 		return (o == ORIENT_HORIZONTAL) ? w : h;
 	}
@@ -114,6 +118,10 @@ struct Bounds {
 	}
 	Bounds Inset(float left, float top, float right, float bottom) const {
 		return Bounds(x + left, y + top, w - left - right, h - top - bottom);
+	}
+
+	float AspectRatio() const {
+		return w / h;
 	}
 
 	float x;

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -267,6 +267,13 @@ void PopupContextMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	ap->top = sourceView_->GetBounds().y2();
 }
 
+void PopupCallbackScreen::CreatePopupContents(ViewGroup *parent) {
+	createViews_(parent);
+	for (int i = 0; i < parent->GetNumSubviews(); i++) {
+		parent->GetViewByIndex(i)->SetAutoResult(DialogResult::DR_OK);
+	}
+}
+
 std::string ChopTitle(const std::string &title) {
 	size_t pos = title.find('\n');
 	if (pos != title.npos) {

--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -241,7 +241,6 @@ struct ContextMenuItem {
 class PopupContextMenuScreen : public PopupScreen {
 public:
 	PopupContextMenuScreen(const ContextMenuItem *items, size_t itemCount, I18NCat category, UI::View *sourceView);
-	void CreatePopupContents(ViewGroup *parent) override;
 
 	const char *tag() const override { return "ContextMenuPopup"; }
 
@@ -252,11 +251,27 @@ public:
 	UI::Event OnChoice;
 
 private:
+	void CreatePopupContents(ViewGroup *parent) override;
 	const ContextMenuItem *items_;
 	size_t itemCount_;
 	I18NCat category_;
 	UI::View *sourceView_;
 	std::vector<bool> enabled_;
+};
+
+class PopupCallbackScreen : public PopupScreen {
+public:
+	PopupCallbackScreen(std::function<void(UI::ViewGroup *)> createViews, UI::View *sourceView) : PopupScreen(""), createViews_(createViews) {
+		if (sourceView) {
+			SetPopupOrigin(sourceView);
+		}
+	}
+
+	const char *tag() const override { return "ContextMenuPopup"; }
+
+private:
+	void CreatePopupContents(ViewGroup *parent) override;
+	std::function<void(UI::ViewGroup *)> createViews_;
 };
 
 // Reads and writes value to determine the current selection.

--- a/Common/UI/ScrollView.h
+++ b/Common/UI/ScrollView.h
@@ -48,6 +48,7 @@ public:
 
 private:
 	float ChildSize() const;  // in the scrolled direction
+	float ScrollMax() const;
 	float HardClampedScrollPos(float pos) const;
 
 	// TODO: Don't adjust pull_ within this!

--- a/Common/UI/TabHolder.cpp
+++ b/Common/UI/TabHolder.cpp
@@ -8,7 +8,7 @@
 
 namespace UI {
 
-TabHolder::TabHolder(Orientation orientation, float stripSize, TabHolderFlags flags, View *bannerView, LayoutParams *layoutParams)
+TabHolder::TabHolder(Orientation orientation, float stripSize, TabHolderFlags flags, View *bannerView, std::function<void()> contextMenuCallback, LayoutParams *layoutParams)
 	: LinearLayout(Opposite(orientation), layoutParams), tabOrientation_(orientation), flags_(flags) {
 	SetSpacing(0.0f);
 	if (orientation == ORIENT_HORIZONTAL) {
@@ -26,6 +26,13 @@ TabHolder::TabHolder(Orientation orientation, float stripSize, TabHolderFlags fl
 			tabScroll_ = new ScrollView(orientation, new LinearLayoutParams(1.0f));
 			tabScroll_->Add(tabStrip_);
 			container->Add(tabScroll_);
+			if (contextMenuCallback) {
+				Choice *menuChoice = new Choice(ImageID("I_THREE_DOTS"), new LinearLayoutParams(ITEM_HEIGHT, ITEM_HEIGHT));
+				menuChoice->OnClick.Add([contextMenuCallback](EventParams &e) {
+					contextMenuCallback();
+				});
+				container->Add(menuChoice);
+			}
 			Add(container);
 		} else {
 			tabScroll_ = new ScrollView(orientation, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));

--- a/Common/UI/TabHolder.h
+++ b/Common/UI/TabHolder.h
@@ -21,7 +21,7 @@ ENUM_CLASS_BITOPS(TabHolderFlags);
 
 class TabHolder : public LinearLayout {
 public:
-	TabHolder(Orientation orientation, float stripSize, TabHolderFlags flags, View *bannerView, LayoutParams *layoutParams);
+	TabHolder(Orientation orientation, float stripSize, TabHolderFlags flags, View *bannerView, std::function<void()> contextMenuCallback, LayoutParams *layoutParams);
 
 	template <class T>
 	T *AddTab(std::string_view title, ImageID imageId, T *tabContents) {

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -221,6 +221,9 @@ void Clickable::DrawBG(UIContext &dc, const Style &style) {
 void Clickable::ClickInternal() {
 	UI::EventParams e{};
 	e.v = this;
+	if (hasAutoResult_) {
+		e.bubbleResult = autoResult_;
+	}
 	OnClick.Trigger(e);
 };
 

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -463,6 +463,10 @@ public:
 	}
 
 	virtual void Recurse(void (*func)(View *view)) {}
+	virtual void SetAutoResult(DialogResult result) {
+		hasAutoResult_ = true;
+		autoResult_ = result;
+	}
 
 protected:
 	// Inputs to layout
@@ -482,6 +486,8 @@ protected:
 
 	// Whether to use popup colors for styling.
 	bool popupStyle_ = false;
+	bool hasAutoResult_ = false;
+	DialogResult autoResult_ = DR_OK;
 
 private:
 	std::function<bool()> enabledFunc_;
@@ -893,6 +899,9 @@ public:
 	virtual void Toggle();
 	virtual bool Toggled() const;
 
+	// we don't allow these for checkboxes.
+	virtual void SetAutoResult(DialogResult result) {}
+
 protected:
 	void ClickInternal() override;
 
@@ -997,7 +1006,6 @@ private:
 	bool small_ = false;
 	bool big_ = false;
 };
-
 
 class TextView : public InertView {
 public:

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -170,6 +170,8 @@ public:
 		: LayoutParams(w, h, LP_LINEAR), weight(wgt), gravity(grav), margins(mgn), hasMargins_(true) {}
 	LinearLayoutParams(Size w, Size h, const Margins &mgn)
 		: LayoutParams(w, h, LP_LINEAR), weight(0.0f), gravity(Gravity::G_TOPLEFT), margins(mgn), hasMargins_(true) {}
+	LinearLayoutParams(Size w, Size h, Gravity grav, const Margins &mgn)
+		: LayoutParams(w, h, LP_LINEAR), weight(0.0f), gravity(grav), margins(mgn), hasMargins_(true) {}
 	LinearLayoutParams(Size w, Size h, float wgt, const Margins &mgn)
 		: LayoutParams(w, h, LP_LINEAR), weight(wgt), gravity(Gravity::G_TOPLEFT), margins(mgn), hasMargins_(true) {}
 	LinearLayoutParams(const Margins &mgn)

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -532,7 +532,7 @@ void AnalogCalibrationScreen::axis(const AxisInput &axis) {
 
 std::string_view AnalogCalibrationScreen::GetTitle() const {
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
-	return co->T("Analog Settings");
+	return co->T("Calibrate analog stick");
 }
 
 void AnalogCalibrationScreen::CreateSettingsViews(UI::LinearLayout *scrollContents) {

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -480,7 +480,7 @@ void KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 	}
 }
 
-AnalogCalibrationScreen::AnalogCalibrationScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath) {
+AnalogCalibrationScreen::AnalogCalibrationScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath, TwoPaneFlags::Default) {
 	mapper_.SetCallbacks(
 		[](int vkey, bool down) {},
 		[](int vkey, float analogValue) {},
@@ -535,7 +535,7 @@ std::string_view AnalogCalibrationScreen::GetTitle() const {
 	return co->T("Calibrate analog stick");
 }
 
-void AnalogCalibrationScreen::CreateSettingsViews(UI::LinearLayout *scrollContents) {
+void AnalogCalibrationScreen::CreateSettingsViews(UI::ViewGroup *scrollContents) {
 	using namespace UI;
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
 
@@ -551,7 +551,7 @@ void AnalogCalibrationScreen::CreateSettingsViews(UI::LinearLayout *scrollConten
 	scrollContents->Add(new Choice(co->T("Reset to defaults")))->OnClick.Handle(this, &AnalogCalibrationScreen::OnResetToDefaults);
 }
 
-void AnalogCalibrationScreen::CreateContentViews(UI::LinearLayout *parent) {
+void AnalogCalibrationScreen::CreateContentViews(UI::ViewGroup *parent) {
 	using namespace UI;
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
 

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -232,7 +232,7 @@ static const BindingCategory cats[] = {
 	{},  // sentinel
 };
 
-void ControlMappingScreen::CreateExtraButtons(UI::LinearLayout *verticalLayout, int margins) {
+void ControlMappingScreen::CreateExtraButtons(UI::ViewGroup *verticalLayout, int margins) {
 	using namespace UI;
 	auto km = GetI18NCategory(I18NCat::KEYMAPPING);
 	verticalLayout->Add(new Choice(km->T("Clear All")))->OnClick.Add([](UI::EventParams &) {

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -39,7 +39,7 @@ class SingleControlMapper;
 
 class ControlMappingScreen : public UITabbedBaseDialogScreen {
 public:
-	ControlMappingScreen(const Path &gamePath) : UITabbedBaseDialogScreen(gamePath) {
+	ControlMappingScreen(const Path &gamePath) : UITabbedBaseDialogScreen(gamePath, TabDialogFlags::ContextMenuInPortrait) {
 		categoryToggles_[0] = true;
 		categoryToggles_[1] = true;
 		categoryToggles_[2] = true;
@@ -49,7 +49,7 @@ public:
 
 protected:
 	void CreateTabs() override;
-	void CreateExtraButtons(UI::LinearLayout *verticalLayout, int margins) override;
+	void CreateExtraButtons(UI::ViewGroup *verticalLayout, int margins) override;
 	void update() override;
 
 private:

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -137,8 +137,8 @@ public:
 	const char *tag() const override { return "AnalogSetup"; }
 
 protected:
-	void CreateSettingsViews(UI::LinearLayout *parent) override;
-	void CreateContentViews(UI::LinearLayout *parent) override;
+	void CreateSettingsViews(UI::ViewGroup *parent) override;
+	void CreateContentViews(UI::ViewGroup *parent) override;
 
 	std::string_view GetTitle() const override;
 private:

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -301,7 +301,7 @@ void GPUDriverTestScreen::CreateViews() {
 	AnchorLayout *anchor = new AnchorLayout();
 	root_ = anchor;
 
-	tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 30.0f, TabHolderFlags::Default, nullptr, new AnchorLayoutParams(FILL_PARENT, FILL_PARENT, Centering::None));
+	tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 30.0f, TabHolderFlags::Default, nullptr, nullptr, new AnchorLayoutParams(FILL_PARENT, FILL_PARENT, Centering::None));
 	anchor->Add(tabHolder_);
 	tabHolder_->AddTab("Discard", ImageID::invalid(), new LinearLayout(ORIENT_VERTICAL));
 	tabHolder_->AddTab("Shader", ImageID::invalid(), new LinearLayout(ORIENT_VERTICAL));

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -22,8 +22,9 @@
 #include "UI/BaseScreens.h"
 #include "Common/UI/UIScreen.h"
 #include "Common/File/Path.h"
-
 #include "UI/GameInfoCache.h"
+#include "UI/SimpleDialogScreen.h"
+
 
 class NoticeView;
 
@@ -33,7 +34,7 @@ class NoticeView;
 // Uses GameInfoCache heavily to implement the functionality.
 // Should possibly merge this with the PauseScreen.
 
-class GameScreen : public UIBaseDialogScreen {
+class GameScreen : public UITwoPaneBaseDialogScreen {
 public:
 	GameScreen(const Path &gamePath, bool inGame);
 	~GameScreen();
@@ -45,7 +46,10 @@ public:
 	const char *tag() const override { return "Game"; }
 
 protected:
-	void CreateViews() override;
+	void CreateContentViews(UI::LinearLayout *parent) override;
+	void CreateSettingsViews(UI::LinearLayout *parent) override;
+
+	bool SettingsToTheRight() const override { return true; }
 
 private:
 	// Event handlers
@@ -69,4 +73,6 @@ private:
 	GameInfoFlags knownFlags_ = GameInfoFlags::EMPTY;
 
 	bool knownHasCRC_ = false;
+
+	std::shared_ptr<GameInfo> info_;
 };

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -46,10 +46,9 @@ public:
 	const char *tag() const override { return "Game"; }
 
 protected:
-	void CreateContentViews(UI::LinearLayout *parent) override;
-	void CreateSettingsViews(UI::LinearLayout *parent) override;
+	void CreateContentViews(UI::ViewGroup *parent) override;
+	void CreateSettingsViews(UI::ViewGroup *parent) override;
 
-	bool SettingsToTheRight() const override { return true; }
 	std::string_view GetTitle() const override;
 
 private:

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -50,6 +50,7 @@ protected:
 	void CreateSettingsViews(UI::LinearLayout *parent) override;
 
 	bool SettingsToTheRight() const override { return true; }
+	std::string_view GetTitle() const override;
 
 private:
 	// Event handlers
@@ -75,4 +76,5 @@ private:
 	bool knownHasCRC_ = false;
 
 	std::shared_ptr<GameInfo> info_;
+	mutable std::string titleCache_;
 };

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1224,7 +1224,7 @@ void MainScreen::CreateViews() {
 
 	auto mm = GetI18NCategory(I18NCat::MAINMENU);
 
-	tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
+	tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
 	ViewGroup *leftColumn = tabHolder_;
 	tabHolder_->SetTag("MainScreenGames");
 	gameBrowsers_.clear();
@@ -1610,7 +1610,7 @@ void UmdReplaceScreen::CreateViews() {
 
 	const bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
 
-	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0));
+	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0));
 	leftColumn->SetTag("UmdReplace");
 	leftColumn->SetClip(true);
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -515,8 +515,8 @@ void DirButton::Draw(UIContext &dc) {
 	}
 }
 
-GameBrowser::GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams)
-	: LinearLayout(ORIENT_VERTICAL, layoutParams), gridStyle_(gridStyle), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink), screenManager_(screenManager), token_(token) {
+GameBrowser::GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool portrait, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams)
+	: LinearLayout(ORIENT_VERTICAL, layoutParams), gridStyle_(gridStyle), browseFlags_(browseFlags), portrait_(portrait), lastText_(lastText), lastLink_(lastLink), screenManager_(screenManager), token_(token) {
 	using namespace UI;
 	path_.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
 	Path memstickRoot = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT);
@@ -796,7 +796,7 @@ void GameBrowser::Refresh() {
 #else
 			if ((browseFlags_ & BrowseFlags::BROWSE) && System_GetPropertyBool(SYSPROP_HAS_FOLDER_BROWSER)) {
 				// Collapse the button title on very small screens (Retroid Pocket) or portrait mode.
-				std::string_view browseTitle = g_display.pixel_xres <= 550 ? "" : mm->T("Browse");
+				std::string_view browseTitle = (g_display.dp_xres <= 550 || portrait_) ? "" : mm->T("Browse");
 				topBar->Add(new Choice(browseTitle, ImageID("I_FOLDER_OPEN"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::BrowseClick);
 			}
 			if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_TV) {
@@ -1092,8 +1092,10 @@ void MainScreen::CreateRecentTab() {
 	ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollRecentGames->SetTag("MainScreenRecentGames");
 
+	bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
+
 	GameBrowser *tabRecentGames = new GameBrowser(GetRequesterToken(),
-		Path("!RECENT"), BrowseFlags::NONE, &g_Config.bGridView1, screenManager(), "", "",
+		Path("!RECENT"), BrowseFlags::NONE, portrait, &g_Config.bGridView1, screenManager(), "", "",
 		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 
 	scrollRecentGames->Add(tabRecentGames);
@@ -1109,10 +1111,12 @@ GameBrowser *MainScreen::CreateBrowserTab(const Path &path, std::string_view tit
 	using namespace UI;
 	auto mm = GetI18NCategory(I18NCat::MAINMENU);
 
+	const bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
+
 	ScrollView *scrollView = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollView->SetTag(title);  // Re-use title as tag, should be fine.
 
-	GameBrowser *gameBrowser = new GameBrowser(GetRequesterToken(), path, browseFlags, bGridView, screenManager(),
+	GameBrowser *gameBrowser = new GameBrowser(GetRequesterToken(), path, browseFlags, portrait, bGridView, screenManager(),
 		mm->T(howToTitle), howToUri,
 		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 
@@ -1604,6 +1608,8 @@ void UmdReplaceScreen::CreateViews() {
 	auto mm = GetI18NCategory(I18NCat::MAINMENU);
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 
+	const bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
+
 	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0));
 	leftColumn->SetTag("UmdReplace");
 	leftColumn->SetClip(true);
@@ -1617,7 +1623,7 @@ void UmdReplaceScreen::CreateViews() {
 		ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollRecentGames->SetTag("UmdReplaceRecentGames");
 		GameBrowser *tabRecentGames = new GameBrowser(GetRequesterToken(),
-			Path("!RECENT"), BrowseFlags::NONE, &g_Config.bGridView1, screenManager(), "", "",
+			Path("!RECENT"), BrowseFlags::NONE, portrait, &g_Config.bGridView1, screenManager(), "", "",
 			new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 		scrollRecentGames->Add(tabRecentGames);
 		leftColumn->AddTab(mm->T("Recent"), ImageID::invalid(), scrollRecentGames);
@@ -1627,7 +1633,7 @@ void UmdReplaceScreen::CreateViews() {
 	ScrollView *scrollAllGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollAllGames->SetTag("UmdReplaceAllGames");
 
-	GameBrowser *tabAllGames = new GameBrowser(GetRequesterToken(), Path(g_Config.currentDirectory), BrowseFlags::STANDARD, &g_Config.bGridView2, screenManager(),
+	GameBrowser *tabAllGames = new GameBrowser(GetRequesterToken(), Path(g_Config.currentDirectory), BrowseFlags::STANDARD, portrait, &g_Config.bGridView2, screenManager(),
 		mm->T("How to get games"), "https://www.ppsspp.org/getgames.html",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -46,7 +46,7 @@ ENUM_CLASS_BITOPS(BrowseFlags);
 
 class GameBrowser : public UI::LinearLayout {
 public:
-	GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams = nullptr);
+	GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool portrait, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams = nullptr);
 
 	UI::Event OnChoice;
 	UI::Event OnHoldChoice;
@@ -114,7 +114,8 @@ private:
 	float lastScale_ = 1.0f;
 	bool lastLayoutWasGrid_ = true;
 	ScreenManager *screenManager_;
-	int token_;
+	int token_ = -1;
+	bool portrait_ = false;
 };
 
 class RemoteISOBrowseScreen;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -508,7 +508,7 @@ std::string_view CreditsScreen::GetTitle() const {
 	return mm->T("About PPSSPP");
 }
 
-void CreditsScreen::CreateDialogViews(UI::ViewGroup *root) {
+void CreditsScreen::CreateDialogViews(UI::ViewGroup *parent) {
 	using namespace UI;
 
 	ignoreBottomInset_ = false;
@@ -528,13 +528,25 @@ void CreditsScreen::CreateDialogViews(UI::ViewGroup *root) {
 		root_->Add(new ImageView(ImageID("I_ICON"), "", IS_DEFAULT, new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 10, 10, NONE, NONE, false)))->SetScale(1.5f);
 	}*/
 
-	root->Add(new CreditsScroller(new LinearLayoutParams(1.0f)));
+	LinearLayout *left;
+	LinearLayout *right;
+	if (portrait) {
+		parent->Add(new CreditsScroller(new LinearLayoutParams(1.0f)));
 
-	LinearLayout *columns = root->Add(new LinearLayout(ORIENT_HORIZONTAL));
+		LinearLayout *columns = parent->Add(new LinearLayout(ORIENT_HORIZONTAL));
 
-	LinearLayout *left = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT, Margins(10))));
-	LinearLayout *middle = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
-	LinearLayout *right = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT, Margins(10))));
+		left = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT, Margins(10))));
+		columns->Add(new Spacer(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
+		right = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, WRAP_CONTENT, Margins(10))));
+	} else {
+		LinearLayout *columns = parent->Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(1.0f)));
+
+		left = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, FILL_PARENT, Margins(10))));
+		left->Add(new Spacer(0.0f, new LinearLayoutParams(1.0f)));
+		columns->Add(new CreditsScroller(new LinearLayoutParams(WRAP_CONTENT, FILL_PARENT, 1.0f)));
+		right = columns->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(250.0f, FILL_PARENT, Margins(10))));
+		right->Add(new Spacer(0.0f, new LinearLayoutParams(1.0f)));
+	}
 
 	int rightYOffset = 0;
 	if (!System_GetPropertyBool(SYSPROP_APP_GOLD)) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -539,7 +539,12 @@ void CreditsScreen::CreateDialogViews(UI::ViewGroup *root) {
 	int rightYOffset = 0;
 	if (!System_GetPropertyBool(SYSPROP_APP_GOLD)) {
 		ScreenManager *sm = screenManager();
-		left->Add(new Choice(mm->T("Buy PPSSPP Gold")))->OnClick.Add([sm](UI::EventParams) {
+		Choice *gold = new Choice(mm->T("Buy PPSSPP Gold"));
+		gold->SetIcon(ImageID("I_ICON_GOLD"), 0.5f);
+		gold->SetImageScale(0.6f);  // for the left-icon in case of vertical.
+		gold->SetShine(true);
+
+		left->Add(gold)->OnClick.Add([sm](UI::EventParams) {
 			LaunchBuyGold(sm);
 		});
 		rightYOffset = 74;

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -56,7 +56,8 @@ TopBar::TopBar(const UIContext &ctx, bool usePortraitLayout, std::string_view ti
 		e.bubbleResult = DR_BACK;
 	});
 	if (!usePortraitLayout) {
-		backButton_->SetText(dlg->T("Back"));
+		// Not really liking this..
+		// backButton_->SetText(dlg->T("Back"));
 	}
 
 	if (!title.empty()) {

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -42,7 +42,7 @@ CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLay
 	});
 }
 
-TopBar::TopBar(const UIContext &ctx, bool usePortraitLayout, std::string_view title, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
+TopBar::TopBar(const UIContext &ctx, TopBarFlags flags, std::string_view title, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams), flags_(flags) {
 	using namespace UI;
 	SetSpacing(10.0f);
 	if (!layoutParams) {
@@ -55,10 +55,6 @@ TopBar::TopBar(const UIContext &ctx, bool usePortraitLayout, std::string_view ti
 	backButton_ ->OnClick.Add([](UI::EventParams &e) {
 		e.bubbleResult = DR_BACK;
 	});
-	if (!usePortraitLayout) {
-		// Not really liking this..
-		// backButton_->SetText(dlg->T("Back"));
-	}
 
 	if (!title.empty()) {
 		TextView *titleView = Add(new TextView(title, ALIGN_VCENTER | FLAG_WRAP_TEXT, false, new LinearLayoutParams(1.0f, Gravity::G_VCENTER)));
@@ -66,6 +62,13 @@ TopBar::TopBar(const UIContext &ctx, bool usePortraitLayout, std::string_view ti
 		titleView->SetBig(true);
 		// If using HCENTER, to balance the centering, add a spacer on the right.
 		// Add(new Spacer(50.0f));
+	}
+
+	if (flags & TopBarFlags::ContextMenuButton) {
+		Choice *menuButton = Add(new Choice(ImageID("I_THREE_DOTS"), new LinearLayoutParams(ITEM_HEIGHT, ITEM_HEIGHT)));
+		menuButton->OnClick.Add([this](UI::EventParams &e) {
+			this->OnContextMenuClick.Trigger(e);
+		});
 	}
 }
 

--- a/UI/MiscViews.h
+++ b/UI/MiscViews.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Common/Common.h"
 #include "Common/UI/View.h"
 #include "UI/ViewGroup.h"
 
@@ -15,14 +16,24 @@ public:
 	CopyableText(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams = nullptr);
 };
 
+enum class TopBarFlags {
+	Default = 0,
+	Portrait = 1,
+	ContextMenuButton = 2,
+};
+ENUM_CLASS_BITOPS(TopBarFlags);
+
 class TopBar : public UI::LinearLayout {
 public:
 	// The context is needed to get the theme for the background.
-	TopBar(const UIContext &ctx, bool usePortraitLayout, std::string_view title, UI::LayoutParams *layoutParams = nullptr);
+	TopBar(const UIContext &ctx, TopBarFlags flags, std::string_view title, UI::LayoutParams *layoutParams = nullptr);
 	UI::View *GetBackButton() const { return backButton_; }
+
+	UI::Event OnContextMenuClick;
 
 private:
 	UI::Choice *backButton_ = nullptr;
+	TopBarFlags flags_ = TopBarFlags::Default;
 };
 
 class SettingInfoMessage : public UI::LinearLayout {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -596,7 +596,7 @@ void RemoteISOBrowseScreen::CreateViews() {
 
 	using namespace UI;
 
-	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	TabHolder *leftColumn = new TabHolder(ORIENT_HORIZONTAL, 64, TabHolderFlags::Default, nullptr, nullptr, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	tabHolder_ = leftColumn;
 	tabHolder_->SetTag("RemoteGames");
 	gameBrowsers_.clear();

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -592,7 +592,7 @@ void RemoteISOBrowseScreen::CreateViews() {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 	auto ri = GetI18NCategory(I18NCat::REMOTEISO);
 
-	bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
+	const bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
 
 	using namespace UI;
 
@@ -606,7 +606,7 @@ void RemoteISOBrowseScreen::CreateViews() {
 	ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollRecentGames->SetTag("RemoteGamesTab");
 	GameBrowser *tabRemoteGames = new GameBrowser(GetRequesterToken(),
-		Path(url_), BrowseFlags::NAVIGATE, &g_Config.bGridView1, screenManager(), "", "",
+		Path(url_), BrowseFlags::NAVIGATE, portrait, &g_Config.bGridView1, screenManager(), "", "",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	tabRemoteGames->SetHomePath(Path(url_));
 

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -671,7 +671,7 @@ void SavedataScreen::CreateTabs() {
 	});
 }
 
-void SavedataScreen::CreateExtraButtons(UI::LinearLayout *verticalLayout, int margins) {
+void SavedataScreen::CreateExtraButtons(UI::ViewGroup *verticalLayout, int margins) {
 	using namespace UI;
 	if (System_GetPropertyBool(SYSPROP_HAS_TEXT_INPUT_DIALOG)) {
 		auto di = GetI18NCategory(I18NCat::DIALOG);

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -431,26 +431,26 @@ void SavedataBrowser::Update() {
 		int n = gameList_->GetNumSubviews();
 		bool matches = searchFilter_.empty();
 		for (int i = 0; i < n; ++i) {
-			SavedataButton *v = static_cast<SavedataButton *>(gameList_->GetViewByIndex(i));
-
+			View *view = gameList_->GetViewByIndex(i);
 			// Note: might be resetting to empty string.  Can do that right away.
 			if (searchFilter_.empty()) {
-				v->SetVisibility(UI::V_VISIBLE);
+				view->SetVisibility(UI::V_VISIBLE);
 				continue;
 			}
 
-			if (!v->UpdateText()) {
+			SavedataButton *savedataButton = static_cast<SavedataButton *>(view);
+			if (!savedataButton->UpdateText()) {
 				// We'll need to wait until the text is loaded.
 				searchPending_ = true;
-				v->SetVisibility(UI::V_GONE);
+				view->SetVisibility(UI::V_GONE);
 				continue;
 			}
 
-			std::string label = v->DescribeText();
+			std::string label = view->DescribeText();
 			std::transform(label.begin(), label.end(), label.begin(), tolower);
 			bool match = label.find(searchFilter_) != label.npos;
 			matches = matches || match;
-			v->SetVisibility(match ? UI::V_VISIBLE : UI::V_GONE);
+			view->SetVisibility(match ? UI::V_VISIBLE : UI::V_GONE);
 		}
 
 		if (searchingView_) {

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -80,10 +80,10 @@ public:
 
 protected:
 	void CreateTabs() override;
-	void CreateExtraButtons(UI::LinearLayout *verticalLayout, int margins) override;
+	void CreateExtraButtons(UI::ViewGroup *verticalLayout, int margins) override;
 
 	bool ShowSearchControls() const override { return false; }
-
+	
 private:
 	void OnSavedataButtonClick(UI::EventParams &e);
 	void OnSearch(UI::EventParams &e);

--- a/UI/SimpleDialogScreen.cpp
+++ b/UI/SimpleDialogScreen.cpp
@@ -41,7 +41,7 @@ void UITwoPaneBaseDialogScreen::CreateViews() {
 		root->SetSpacing(0);
 		CreateContentViews(root);
 
-		ScrollView *settingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
+		ScrollView *settingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f, Margins(8)));
 		LinearLayout *settingsPane = new LinearLayout(ORIENT_VERTICAL);
 		settingsScroll->Add(settingsPane);
 		CreateSettingsViews(settingsPane);
@@ -52,13 +52,21 @@ void UITwoPaneBaseDialogScreen::CreateViews() {
 		ignoreBottomInset_ = false;
 		LinearLayout *root = new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, FILL_PARENT));
 		// root_->Add(new TopBar(*screenManager()->getUIContext(), portrait, GetTitle(), new LayoutParams(FILL_PARENT, FILL_PARENT)));
-		LinearLayout *settingsPane = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(400.0f, FILL_PARENT));
+		ScrollView *settingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(SettingsWidth(), FILL_PARENT, 0.0f, Margins(8)));
+		LinearLayout *settingsPane = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT));
 		settingsPane->SetSpacing(0);
 		CreateSettingsViews(settingsPane);
 		settingsPane->Add(new BorderView(BORDER_BOTTOM, BorderStyle::HEADER_FG, 2.0f, new LayoutParams(FILL_PARENT, 40.0f)));
 		settingsPane->Add(new Choice(di->T("Back"), ImageID("I_NAVIGATE_BACK")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-		root->Add(settingsPane);
-		CreateContentViews(root);
+		settingsScroll->Add(settingsPane);
+
+		if (SettingsToTheRight()) {
+			CreateContentViews(root);
+			root->Add(settingsScroll);
+		} else {
+			root->Add(settingsScroll);
+			CreateContentViews(root);
+		}
 
 		root_ = root;
 	}

--- a/UI/SimpleDialogScreen.cpp
+++ b/UI/SimpleDialogScreen.cpp
@@ -50,7 +50,14 @@ void UITwoPaneBaseDialogScreen::CreateViews() {
 		root_ = root;
 	} else {
 		ignoreBottomInset_ = false;
-		LinearLayout *root = new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, FILL_PARENT));
+		LinearLayout *root = new LinearLayout(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, FILL_PARENT));
+		std::string title(GetTitle());
+		root->Add(new TopBar(*screenManager()->getUIContext(), portrait, title));
+		root->SetSpacing(0);
+
+		LinearLayout *columns = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0f));
+		root->Add(columns);
+
 		// root_->Add(new TopBar(*screenManager()->getUIContext(), portrait, GetTitle(), new LayoutParams(FILL_PARENT, FILL_PARENT)));
 		ScrollView *settingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(SettingsWidth(), FILL_PARENT, 0.0f, Margins(8)));
 		LinearLayout *settingsPane = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT));
@@ -61,11 +68,11 @@ void UITwoPaneBaseDialogScreen::CreateViews() {
 		settingsScroll->Add(settingsPane);
 
 		if (SettingsToTheRight()) {
-			CreateContentViews(root);
-			root->Add(settingsScroll);
+			CreateContentViews(columns);
+			columns->Add(settingsScroll);
 		} else {
-			root->Add(settingsScroll);
-			CreateContentViews(root);
+			columns->Add(settingsScroll);
+			CreateContentViews(columns);
 		}
 
 		root_ = root;

--- a/UI/SimpleDialogScreen.h
+++ b/UI/SimpleDialogScreen.h
@@ -39,6 +39,9 @@ public:
 	virtual void CreateSettingsViews(UI::LinearLayout *parent) = 0;
 	virtual void CreateContentViews(UI::LinearLayout *parent) = 0;
 	virtual std::string_view GetTitle() const { return ""; }
+	virtual float SettingsWidth() const { return 350.0f; }
+
+	virtual bool SettingsToTheRight() const { return false; }
 
 private:
 	void CreateViews() override;

--- a/UI/SimpleDialogScreen.h
+++ b/UI/SimpleDialogScreen.h
@@ -24,25 +24,31 @@ private:
 	void CreateViews() override;
 };
 
+enum class TwoPaneFlags {
+	Default = 0,
+	SettingsToTheRight = 1,
+	SettingsInContextMenu = 2,
+};
+ENUM_CLASS_BITOPS(TwoPaneFlags);
+
 // A two-pane version of the above, where settings are meant to go in the settings pane,
 // and contents in the content pane. Will generate nice layouts for portrait and landscape.
 // but with a consistent portrait-compatible back button and title.
 // The settings pane is scrollable while the other is not.
 class UITwoPaneBaseDialogScreen : public UIBaseDialogScreen {
 public:
-	UITwoPaneBaseDialogScreen(const Path &gamePath = Path()) : UIBaseDialogScreen(gamePath) {
+	UITwoPaneBaseDialogScreen(const Path &gamePath, TwoPaneFlags flags) : UIBaseDialogScreen(gamePath), flags_(flags) {
 		// We need to check CanScroll before we know whether to ignore
 		// bottom inset. Can't do that here, we do it in CreateViews
 	}
 
 	// Override this, don't override CreateViews. And don't touch root_ directly.
-	virtual void CreateSettingsViews(UI::LinearLayout *parent) = 0;
-	virtual void CreateContentViews(UI::LinearLayout *parent) = 0;
+	virtual void CreateSettingsViews(UI::ViewGroup *parent) = 0;
+	virtual void CreateContentViews(UI::ViewGroup *parent) = 0;
 	virtual std::string_view GetTitle() const { return ""; }
 	virtual float SettingsWidth() const { return 350.0f; }
 
-	virtual bool SettingsToTheRight() const { return false; }
-
 private:
 	void CreateViews() override;
+	TwoPaneFlags flags_ = TwoPaneFlags::Default;
 };

--- a/UI/TabbedDialogScreen.cpp
+++ b/UI/TabbedDialogScreen.cpp
@@ -58,16 +58,26 @@ void UITabbedBaseDialogScreen::CreateViews() {
 		if (flags_ & TabDialogFlags::HorizontalOnlyIcons) {
 			tabHolderFlags |= TabHolderFlags::HorizontalOnlyIcons;
 		}
-		tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 200, tabHolderFlags, filterNotice_, new LinearLayoutParams(1.0f));
+		std::function<void()> contextMenu;
+		if (flags_ & TabDialogFlags::ContextMenuInPortrait) {
+			contextMenu = [this]() {
+				this->screenManager()->push(new PopupCallbackScreen([this](UI::ViewGroup *parent) {
+					CreateExtraButtons(parent, 0);
+				}, nullptr));
+			};
+		}
+		tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 200, tabHolderFlags, filterNotice_, contextMenu, new LinearLayoutParams(1.0f));
 		verticalLayout->Add(tabHolder_);
-		CreateExtraButtons(verticalLayout, 0);
+		if (!(flags_ & TabDialogFlags::ContextMenuInPortrait)) {
+			CreateExtraButtons(verticalLayout, 0);
+		}
 		root_->Add(verticalLayout);
 	} else {
 		TabHolderFlags tabHolderFlags = TabHolderFlags::Default;
 		if (flags_ & TabDialogFlags::VerticalShowIcons) {
 			tabHolderFlags |= TabHolderFlags::VerticalShowIcons;
 		}
-		tabHolder_ = new TabHolder(ORIENT_VERTICAL, 300, tabHolderFlags, filterNotice_, new AnchorLayoutParams(10, 0, 10, 0));
+		tabHolder_ = new TabHolder(ORIENT_VERTICAL, 300, tabHolderFlags, filterNotice_, nullptr, new AnchorLayoutParams(10, 0, 10, 0));
 		CreateExtraButtons(tabHolder_->Container(), 10);
 		tabHolder_->AddBack(this);
 		root_->Add(tabHolder_);

--- a/UI/TabbedDialogScreen.h
+++ b/UI/TabbedDialogScreen.h
@@ -20,6 +20,7 @@ enum class TabDialogFlags {
 	HorizontalOnlyIcons = 1,
 	VerticalShowIcons = 2,
 	AddTitles = 4,
+	ContextMenuInPortrait = 8,
 };
 ENUM_CLASS_BITOPS(TabDialogFlags);
 
@@ -45,9 +46,10 @@ protected:
 	// Load data and define your tabs here.
 	virtual void PreCreateViews() {}
 	virtual void CreateTabs() = 0;
-	virtual void CreateExtraButtons(UI::LinearLayout *verticalLayout, int margins) {}
+	virtual void CreateExtraButtons(UI::ViewGroup *verticalLayout, int margins) {}
 	virtual bool ShowSearchControls() const { return true; }
 	virtual void EnsureTabs();
+	virtual bool UsePopupMenuInPortrait() const { return false; }
 	virtual bool ForceHorizontalTabs() const { return false; }
 
 	int GetCurrentTab() const;

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -83,12 +83,12 @@ std::string_view TiltAnalogSettingsScreen::GetTitle() const {
 	return co->T("Tilt control setup");
 }
 
-void TiltAnalogSettingsScreen::CreateContentViews(UI::LinearLayout *parent) {
+void TiltAnalogSettingsScreen::CreateContentViews(UI::ViewGroup *parent) {
 	using namespace UI;
 	CreateCalibrationView(parent, new LinearLayoutParams(300.0f, 300.0f, 1.0f, Gravity::G_CENTER));
 }
 
-void TiltAnalogSettingsScreen::CreateSettingsViews(UI::LinearLayout *settings) {
+void TiltAnalogSettingsScreen::CreateSettingsViews(UI::ViewGroup *settings) {
 	using namespace UI;
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
 

--- a/UI/TiltAnalogSettingsScreen.h
+++ b/UI/TiltAnalogSettingsScreen.h
@@ -26,10 +26,10 @@ class GamepadView;
 
 class TiltAnalogSettingsScreen : public UITwoPaneBaseDialogScreen {
 public:
-	TiltAnalogSettingsScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath) {}
+	TiltAnalogSettingsScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath, TwoPaneFlags::Default) {}
 
-	void CreateSettingsViews(UI::LinearLayout *parent) override;
-	void CreateContentViews(UI::LinearLayout *parent) override;
+	void CreateSettingsViews(UI::ViewGroup *parent) override;
+	void CreateContentViews(UI::ViewGroup*parent) override;
 	std::string_view GetTitle() const override;
 
 	void update() override;

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -155,7 +155,7 @@ void RightAnalogMappingScreen::CreateViews() {
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 	Choice *back = new Choice(di->T("Back"), ImageID("I_NAVIGATE_BACK"), new AnchorLayoutParams(leftColumnWidth - 10, WRAP_CONTENT, 10, NONE, NONE, 10));
 	root_->Add(back)->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-	TabHolder *tabHolder = new TabHolder(ORIENT_VERTICAL, leftColumnWidth, TabHolderFlags::Default, nullptr, new AnchorLayoutParams(10, 0, 10, 0, Centering::None));
+	TabHolder *tabHolder = new TabHolder(ORIENT_VERTICAL, leftColumnWidth, TabHolderFlags::Default, nullptr, nullptr, new AnchorLayoutParams(10, 0, 10, 0, Centering::None));
 	root_->Add(tabHolder);
 	ScrollView *rightPanel = new ScrollView(ORIENT_VERTICAL);
 	tabHolder->AddTab(co->T("Binds"), ImageID::invalid(), rightPanel);

--- a/UI/UploadScreen.cpp
+++ b/UI/UploadScreen.cpp
@@ -39,7 +39,7 @@ void UploadScreen::CreateDialogViews(UI::ViewGroup *root) {
 	if (prevRunning_) {
 		container->Add(new TextWithImage(ImageID("I_WIFI"), n->T("With a web browser on the same network, go to:")));
 		for (const auto &ip : localIPs_) {
-			std::string url = StringFromFormat("http://%s:%d/upload", ip.c_str(), WebServerPort());
+			std::string url = StringFromFormat("%s:%d/upload", ip.c_str(), WebServerPort());
 			container->Add(new CopyableText(ImageID("I_WEB_BROWSER"), url));
 		}
 	}


### PR DESCRIPTION
Still some cleanup to do (the CRC stuff is looking kinda silly).

Moves most of the buttons to a popup menu to make things look cleaner.

Additionally, now crops instead of stretches game backgrounds in menus. Looks better in portrait mode, although maybe in landscape we should compromise a bit and stretch if the aspect ratio isn't too different... hm.