### PR TITLE
Achievements: support rc_client_set_host

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -377,6 +377,7 @@ static const ConfigSetting achievementSettings[] = {
 	// from the ini if manually entered (useful when testing various builds on Android).
 	ConfigSetting("AchievementsToken", SETTING(g_Config, sAchievementsToken), "", CfgFlag::DONT_SAVE),
 	ConfigSetting("AchievementsUserName", SETTING(g_Config, sAchievementsUserName), "", CfgFlag::DEFAULT),
+	ConfigSetting("AchievementsHost", SETTING(g_Config, sAchievementsHost), "", CfgFlag::DEFAULT),
 
 	// Customizations
 	ConfigSetting("AchievementsSoundEffects", SETTING(g_Config, bAchievementsSoundEffects), true, CfgFlag::DEFAULT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -642,6 +642,7 @@ public:
 	// Still, we may wanna store it more securely than in PPSSPP.ini, especially on Android.
 	std::string sAchievementsUserName;
 	std::string sAchievementsToken;  // Not saved, to be used if you want to manually make your RA login persistent. See Native_SaveSecret for the normal case.
+	std::string sAchievementsHost;  // Optional custom host for debugging against alternate RA servers.
 
 	// Various directories. Autoconfigured, not read from ini.
 	Path currentDirectory;  // The directory selected in the game browsing window.

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -622,7 +622,10 @@ void Initialize() {
 
 	// Provide a logging function to simplify debugging
 	rc_client_enable_logging(g_rcClient, RC_CLIENT_LOG_LEVEL_VERBOSE, log_message_callback);
-	if (!System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS)) {
+	if (!g_Config.sAchievementsHost.empty()) {
+		// Custom host, only useful for debugging against non-prod RA environments.
+		rc_client_set_host(g_rcClient, g_Config.sAchievementsHost.c_str());
+	} else if (!System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS)) {
 		// Disable SSL if not supported by our platform implementation.
 		rc_client_set_host(g_rcClient, "http://retroachievements.org");
 	}


### PR DESCRIPTION
Related: https://github.com/PCSX2/pcsx2/pull/13550

This PR adds support for a `AchievementsHost` INI setting in the `Achievements` scope, eg:
```
[Achievements]
AchievementsHost = http://localhost:64000
```

When a value for `AchievementsHost` is given, `rc_client_set_host()` is called during achievement client initialization.

Rationale: I am trying to test some changes we made in rcheevos v12 on my local server instance, namely, running multiple achievement sets for one game simultaneously (multiset).

**How to test this PR**
When no `AchievementsHost` value is given, you should see normal behavior (RA integration hitting prod @ https://retroachievements.org).
Setting `AchievementsHost = https://stage.retroachievements.org` should hit our staging environment.