### PR TITLE
Fix control defaults

### DIFF
--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -71,6 +71,10 @@ bool WordWrapper::IsShy(uint32_t c) {
 std::string WordWrapper::Wrapped() {
 	if (out_.empty()) {
 		Wrap();
+		// Hack: Remove trailing line breaks.
+		if (!out_.empty() && out_.back() == '\n') {
+			out_.pop_back();
+		}
 	}
 	return out_;
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -849,24 +849,25 @@ static const ConfigTouchPos defaultTouchPosHide = { -1.0f, -1.0f, defaultControl
 
 void TouchControlConfig::ResetLayout() {
 	// reset puts the settings in a state so they'll then get properly reinitialized in InitPadLayout.
-	auto reset = [](ConfigTouchPos &pos) {
-		pos.x = defaultTouchPosShow.x;
-		pos.y = defaultTouchPosShow.y;
-		pos.scale = defaultTouchPosShow.scale;
+	// Intentionally don't modify 'show' here, this is only done in ResetToDefault.
+	auto reset = [](ConfigTouchPos *pos) {
+		pos->x = defaultTouchPosShow.x;
+		pos->y = defaultTouchPosShow.y;
+		pos->scale = defaultTouchPosShow.scale;
 	};
-	reset(touchActionButtonCenter);
+	reset(&touchActionButtonCenter);
 	fActionButtonSpacing = 1.0f;
-	reset(touchDpad);
+	reset(&touchDpad);
 	fDpadSpacing = 1.0f;
-	reset(touchStartKey);
-	reset(touchSelectKey);
-	reset(touchFastForwardKey);
-	reset(touchLKey);
-	reset(touchRKey);
-	reset(touchAnalogStick);
-	reset(touchRightAnalogStick);
+	reset(&touchStartKey);
+	reset(&touchSelectKey);
+	reset(&touchFastForwardKey);
+	reset(&touchLKey);
+	reset(&touchRKey);
+	reset(&touchAnalogStick);
+	reset(&touchRightAnalogStick);
 	for (int i = 0; i < CUSTOM_BUTTON_COUNT; i++) {
-		reset(touchCustom[i]);
+		reset(&touchCustom[i]);
 	}
 	fLeftStickHeadScale = 1.0f;
 	fRightStickHeadScale = 1.0f;
@@ -1255,7 +1256,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	IniFile iniFile;
 	if (!iniFile.Load(iniFilename_)) {
-		ERROR_LOG(Log::Loader, "Failed to read '%s'. Setting config to default.", iniFilename_.c_str());
+		WARN_LOG(Log::Loader, "Failed to read '%s'. Setting main config to default.", iniFilename_.c_str());
 		// Continue anyway to initialize the config.
 	}
 
@@ -1820,7 +1821,7 @@ void Config::UnloadGameConfig() {
 void Config::LoadStandardControllerIni() {
 	IniFile controllerIniFile;
 	if (!controllerIniFile.Load(controllerIniFilename_)) {
-		ERROR_LOG(Log::Loader, "Failed to read %s. Setting controller config to default.", controllerIniFilename_.c_str());
+		WARN_LOG(Log::Loader, "Failed to read '%s'. Setting controller config to default.", controllerIniFilename_.c_str());
 		KeyMap::RestoreDefault();
 	} else {
 		// Continue anyway to initialize the config. It will just restore the defaults.

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -97,15 +97,22 @@ struct DisplayLayoutConfig : public ConfigBlock {
 };
 
 struct TouchControlConfig : public ConfigBlock {
-	//space between PSP buttons
-	//the PSP button's center (triangle, circle, square, cross)
+	constexpr TouchControlConfig() {
+		// Hide all extras and custom buttons by default.
+		touchRightAnalogStick.show = false;
+		for (size_t i = 0; i < CUSTOM_BUTTON_COUNT; i++) {
+			touchCustom[i].show = false;
+		}
+	}
+	// the PSP button's center (triangle, circle, square, cross)
 	ConfigTouchPos touchActionButtonCenter;
-	float fActionButtonSpacing = 0.0f;
-	//radius of the D-pad (PSP cross)
-	// int iDpadRadius;
-	//the D-pad (PSP cross) position
+	// space between those PSP buttons
+	float fActionButtonSpacing = 1.0f;
+	// the D-pad (PSP cross) position
 	ConfigTouchPos touchDpad;
-	float fDpadSpacing = 0.0f;
+	// And its spacing.
+	float fDpadSpacing = 1.0f;
+
 	ConfigTouchPos touchStartKey;
 	ConfigTouchPos touchSelectKey;
 	ConfigTouchPos touchFastForwardKey;

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -54,7 +54,7 @@
             android:name=".PpssppActivity"
             android:configChanges="locale|keyboard|keyboardHidden|navigation|uiMode"
             android:theme="@style/ppsspp_style"
-			android:launchMode="singleTop"
+			android:launchMode="singleInstance"
             android:exported="true">
             <!-- android:screenOrientation="landscape" -->
             <intent-filter>


### PR DESCRIPTION
Fixes #20993 properly finally, I think. Sorry for the wait.

Also, changes Android launch mode. Shouldn't notice any difference, but this should prevent the unfortunate problem where in some circumstances two instances could be launched, immediately hanging or crashing.