### PR TITLE
Convert the pause/menu button to a normal customizable touch screen button

### DIFF
--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -114,7 +114,7 @@ public:
 	void SetBounds(const Bounds &b) { bounds_ = b; }
 	const Bounds &GetBounds() const { return bounds_; }
 	Bounds GetLayoutBounds(bool ignoreBottomInset = false) const;
-	Draw::DrawContext *GetDrawContext() { return draw_; }
+	Draw::DrawContext *GetDrawContext() const { return draw_; }
 	const UI::Theme &GetTheme() const {
 		return *theme;
 	}

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -829,19 +829,6 @@ static bool DefaultShowTouchControls() {
 	}
 }
 
-static bool DefaultShowPauseButton() {
-	switch (System_GetPropertyInt(SYSPROP_DEVICE_TYPE)) {
-	case DEVICE_TYPE_MOBILE:
-	case DEVICE_TYPE_DESKTOP:
-		return true;
-	case DEVICE_TYPE_VR:
-	case DEVICE_TYPE_TV:
-		return false;
-	default:
-		return false;
-	}
-}
-
 static const float defaultControlScale = 1.15f;
 static const ConfigTouchPos defaultTouchPosShow = { -1.0f, -1.0f, defaultControlScale, true };
 static const ConfigTouchPos defaultTouchPosHide = { -1.0f, -1.0f, defaultControlScale, false };
@@ -865,6 +852,8 @@ void TouchControlConfig::ResetLayout() {
 	reset(&touchRKey);
 	reset(&touchAnalogStick);
 	reset(&touchRightAnalogStick);
+	reset(&touchPauseKey);
+
 	for (int i = 0; i < CUSTOM_BUTTON_COUNT; i++) {
 		reset(&touchCustom[i]);
 	}
@@ -875,6 +864,18 @@ void TouchControlConfig::ResetLayout() {
 bool TouchControlConfig::ResetToDefault(std::string_view blockName) {
 	static const TouchControlConfig defaults = TouchControlConfig();
 	*this = defaults;
+
+	switch (System_GetPropertyInt(SYSPROP_DEVICE_TYPE)) {
+	case DEVICE_TYPE_MOBILE:
+	case DEVICE_TYPE_DESKTOP:
+		touchPauseKey.show = true;
+		break;
+	case DEVICE_TYPE_VR:
+	case DEVICE_TYPE_TV:
+		touchPauseKey.show = false;
+		break;
+	}
+
 	return true;
 }
 
@@ -918,6 +919,7 @@ static const ConfigSetting touchControlSettings[] = {
 	ConfigSetting("UnthrottleKeyX", "UnthrottleKeyY", "UnthrottleKeyScale", "ShowTouchUnthrottle", SETTING(g_Config.touchControlsLandscape, touchFastForwardKey), defaultTouchPosShow, CfgFlag::PER_GAME),
 	ConfigSetting("LKeyX", "LKeyY", "LKeyScale", "ShowTouchLTrigger", SETTING(g_Config.touchControlsLandscape, touchLKey), defaultTouchPosShow, CfgFlag::PER_GAME),
 	ConfigSetting("RKeyX", "RKeyY", "RKeyScale", "ShowTouchRTrigger", SETTING(g_Config.touchControlsLandscape, touchRKey), defaultTouchPosShow, CfgFlag::PER_GAME),
+	ConfigSetting("PauseKeyX", "PauseKeyY", "PauseKeyScale", "ShowTouchPause", SETTING(g_Config.touchControlsLandscape, touchPauseKey), defaultTouchPosShow, CfgFlag::PER_GAME),
 	ConfigSetting("AnalogStickX", "AnalogStickY", "AnalogStickScale", "ShowAnalogStick", SETTING(g_Config.touchControlsLandscape, touchAnalogStick), defaultTouchPosShow, CfgFlag::PER_GAME),
 	ConfigSetting("RightAnalogStickX", "RightAnalogStickY", "RightAnalogStickScale", "ShowRightAnalogStick", SETTING(g_Config.touchControlsLandscape, touchRightAnalogStick), defaultTouchPosHide, CfgFlag::PER_GAME),
 
@@ -929,9 +931,6 @@ static const ConfigSetting touchControlSettings[] = {
 static const ConfigSetting controlSettings[] = {
 	ConfigSetting("HapticFeedback", SETTING(g_Config, bHapticFeedback), false, CfgFlag::PER_GAME),
 	
-	// A win32 user seeing touch controls is likely using PPSSPP on a tablet. There it makes
-	// sense to default this to on.
-	ConfigSetting("ShowTouchPause", SETTING(g_Config, bShowTouchPause), &DefaultShowPauseButton, CfgFlag::DEFAULT),
 #if defined(USING_WIN_UI)
 	ConfigSetting("IgnoreWindowsKey", SETTING(g_Config, bIgnoreWindowsKey), false, CfgFlag::PER_GAME),
 #endif

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -120,6 +120,7 @@ struct TouchControlConfig : public ConfigBlock {
 	ConfigTouchPos touchRKey;
 	ConfigTouchPos touchAnalogStick;
 	ConfigTouchPos touchRightAnalogStick;
+	ConfigTouchPos touchPauseKey;
 
 	enum { CUSTOM_BUTTON_COUNT = 20 };
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1262,10 +1262,7 @@ void EmuScreen::CreateViews() {
 	const Bounds &bounds = screenManager()->getUIContext()->GetLayoutBounds();
 	InitPadLayout(&touch, deviceOrientation, bounds.w, bounds.h);
 
-	// Devices without a back button like iOS need an on-screen touch back button.
-	bool showPauseButton = !System_GetPropertyBool(SYSPROP_HAS_BACK_BUTTON) || g_Config.bShowTouchPause;
-
-	root_ = CreatePadLayout(touch, bounds.w, bounds.h, &pauseTrigger_, showPauseButton, &controlMapper_);
+	root_ = CreatePadLayout(touch, bounds.w, bounds.h, &pauseTrigger_, &controlMapper_);
 	if (g_Config.bShowDeveloperMenu) {
 		root_->Add(new Button(dev->T("DevMenu")))->OnClick.Handle(this, &EmuScreen::OnDevTools);
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -899,18 +899,7 @@ void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings)
 			controlsSettings->Add(new CheckBox(&g_Config.bHapticFeedback, co->T("HapticFeedback", "Haptic Feedback (vibration)")));
 		}
 
-		// On non iOS systems, offer to let the user see this button.
-		// Some Windows touch devices don't have a back button or other button to call up the menu.
-		if (System_GetPropertyBool(SYSPROP_HAS_BACK_BUTTON)) {
-			CheckBox *enablePauseBtn = controlsSettings->Add(new CheckBox(&g_Config.bShowTouchPause, co->T("Show Touch Pause Menu Button")));
-
-			// Don't allow the user to disable it once in-game, so they can't lock themselves out of the menu.
-			if (!PSP_IsInited()) {
-				enablePauseBtn->SetEnabledPtr(&g_Config.bShowTouchControls);
-			} else {
-				enablePauseBtn->SetEnabled(false);
-			}
-		}
+		// The pause button is now a regular on-screen button.
 
 		CheckBox *disableDiags = controlsSettings->Add(new CheckBox(&g_Config.bDisableDpadDiagonals, co->T("Disable D-Pad diagonals (4-way touch)")));
 		disableDiags->SetEnabledPtr(&g_Config.bShowTouchControls);

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -142,7 +142,7 @@ bool MultiTouchButton::Touch(const TouchInput &input) {
 }
 
 void MultiTouchButton::Draw(UIContext &dc) {
-	float opacity = g_gamepadOpacity;
+	float opacity = std::max(g_gamepadOpacity, minimumAlpha_);
 	if (opacity <= 0.0f)
 		return;
 
@@ -757,13 +757,30 @@ void InitPadLayout(TouchControlConfig *config, DeviceOrientation orientation, fl
 	const float scale = globalScale;
 	const int halfW = xres / 2;
 
-	auto initTouchPos = [=](ConfigTouchPos *touch, float x, float y) {
+	auto initTouchPos = [=](ConfigTouchPos *touch, float x, float y, float extraScale = 1.0f) {
 		if (touch->x == -1.0f || touch->y == -1.0f) {
 			touch->x = x / xres;
 			touch->y = std::max(y, 20.0f * globalScale) / yres;
-			touch->scale = scale;
+			touch->scale = scale * extraScale;
 		}
 	};
+
+	// Pause button. Has some special handling, it MUST be visible on some platforms.
+	float Pause_button_center_X = halfW;
+	float Pause_button_center_Y = 28.0f;
+
+	if (!System_GetPropertyBool(SYSPROP_HAS_BACK_BUTTON)) {
+		// Make really sure the pause button will be visible. Setting to -1 ensures reinit.
+		if (config->touchPauseKey.x < 0.0f || config->touchPauseKey.x > 1.0f) {
+			config->touchPauseKey.x = -1;
+		}
+		if (config->touchPauseKey.y < 0.0f || config->touchPauseKey.y > 1.0f) {
+			config->touchPauseKey.y = -1;
+		}
+		config->touchPauseKey.show = true;
+	}
+
+	initTouchPos(&config->touchPauseKey, Pause_button_center_X, Pause_button_center_Y, 0.8f);
 
 	// PSP buttons (triangle, circle, square, cross)---------------------
 	// space between the PSP buttons (triangle, circle, square and cross)
@@ -878,7 +895,7 @@ void InitPadLayout(TouchControlConfig *config, DeviceOrientation orientation, fl
 	}
 }
 
-UI::ViewGroup *CreatePadLayout(const TouchControlConfig &config, float xres, float yres, bool *pause, bool showPauseButton, ControlMapper *controlMapper) {
+UI::ViewGroup *CreatePadLayout(const TouchControlConfig &config, float xres, float yres, bool *pause, ControlMapper *controlMapper) {
 	using namespace UI;
 
 	AnchorLayout *root = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
@@ -939,8 +956,12 @@ UI::ViewGroup *CreatePadLayout(const TouchControlConfig &config, float xres, flo
 		return nullptr;
 	};
 
-	if (showPauseButton) {
-		root->Add(new BoolButton(pause, "Pause button", roundImage, ImageID("I_ROUND"), ImageID("I_HAMBURGER"), 1.0f, new AnchorLayoutParams(halfW, 28, NONE, NONE, Centering::Both)));
+	if (config.touchPauseKey.show) {
+		auto button = addBoolButton(pause, "Pause button", roundImage, ImageID("I_ROUND"), ImageID("I_HAMBURGER"), config.touchPauseKey);
+		if (button) {
+			// The user is not allowed to hide this completely on some platforms - it must be findable.
+			button->SetMinimumAlpha(0.1f);
+		}
 	}
 
 	// touchActionButtonCenter.show will always be true, since that's the default.

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -940,7 +940,7 @@ UI::ViewGroup *CreatePadLayout(const TouchControlConfig &config, float xres, flo
 	};
 
 	if (showPauseButton) {
-		root->Add(new BoolButton(pause, "Pause button", roundImage, ImageID("I_ROUND"), ImageID("I_HAMBURGER"), 1.0f, new AnchorLayoutParams(halfW, 20, NONE, NONE, Centering::Both)));
+		root->Add(new BoolButton(pause, "Pause button", roundImage, ImageID("I_ROUND"), ImageID("I_HAMBURGER"), 1.0f, new AnchorLayoutParams(halfW, 28, NONE, NONE, Centering::Both)));
 	}
 
 	// touchActionButtonCenter.show will always be true, since that's the default.

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -55,6 +55,7 @@ public:
 	MultiTouchButton *SetAngle(float angle, float bgAngle) { angle_ = angle; bgAngle_ = bgAngle; return this; }
 
 	bool CanGlide() const;
+	void SetMinimumAlpha(float minAlpha) { minimumAlpha_ = minAlpha; }
 
 protected:
 	uint32_t pointerDownMask_ = 0;
@@ -67,6 +68,7 @@ private:
 	float bgAngle_ = 0.0f;
 	float angle_ = 0.0f;
 	bool flipImageH_ = false;
+	float minimumAlpha_ = 0.0f;
 };
 
 class BoolButton : public MultiTouchButton {
@@ -159,7 +161,7 @@ struct TouchControlConfig;
 
 // Initializes the layout from Config. if a default layout does not exist, it sets up default values
 void InitPadLayout(TouchControlConfig *config, DeviceOrientation orientation, float xres, float yres, float globalScale = 1.15f);
-UI::ViewGroup *CreatePadLayout(const TouchControlConfig &config, float xres, float yres, bool *pause, bool showPauseButton, ControlMapper *controlMapper);
+UI::ViewGroup *CreatePadLayout(const TouchControlConfig &config, float xres, float yres, bool *pause, ControlMapper *controlMapper);
 
 const int D_pad_Radius = 50;
 const int baseActionButtonSpacing = 60;

--- a/UI/MiscViews.h
+++ b/UI/MiscViews.h
@@ -70,9 +70,9 @@ public:
 	std::string DescribeText() const override { return ""; }
 
 private:
+	GameInfoTex *GetTex(std::shared_ptr<GameInfo> info) const;
+
 	Path gamePath_;
 	GameInfoFlags image_;
 	float scale_ = 1.0f;
-	int textureWidth_ = 0;
-	int textureHeight_ = 0;
 };

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -486,6 +486,7 @@ void ControlLayoutView::CreateViews() {
 	}
 
 	ImageID rectImage = g_Config.iTouchButtonStyle ? ImageID("I_RECT_LINE") : ImageID("I_RECT");
+	ImageID roundImage = g_Config.iTouchButtonStyle ? ImageID("I_ROUND_LINE") : ImageID("I_ROUND");
 	ImageID shoulderImage = g_Config.iTouchButtonStyle ? ImageID("I_SHOULDER_LINE") : ImageID("I_SHOULDER");
 	ImageID stickImage = g_Config.iTouchButtonStyle ? ImageID("I_STICK_LINE") : ImageID("I_STICK");
 	ImageID stickBg = g_Config.iTouchButtonStyle ? ImageID("I_STICK_BG_LINE") : ImageID("I_STICK_BG");
@@ -502,6 +503,8 @@ void ControlLayoutView::CreateViews() {
 	if (touch.touchDpad.show) {
 		controls_.push_back(new PSPDPadButtons(touch.touchDpad, "D-pad", touch.fDpadSpacing, bounds));
 	}
+
+	addDragDropButton(touch.touchPauseKey, "Pause button", roundImage, ImageID("I_HAMBURGER"));
 
 	addDragDropButton(touch.touchSelectKey, "Select button", rectImage, ImageID("I_SELECT"));
 	addDragDropButton(touch.touchStartKey, "Start button", rectImage, ImageID("I_START"));

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -135,6 +135,13 @@ void TouchControlVisibilityScreen::CreateVisibilityTab(UI::LinearLayout *vert) {
 		} else {
 			choice = new CheckBoxChoice(mc->T(toggle.key), checkbox, new LinearLayoutParams(1.0f));
 		}
+
+		// Cannot hide the back button if the system doesn't have a built-in one.
+		if (toggle.key == "Pause" && !System_GetPropertyBool(SYSPROP_HAS_BACK_BUTTON)) {
+			checkbox->SetEnabled(false);
+			choice->SetEnabled(false);
+		}
+
 		choice->SetCentered(true);
 		row->Add(choice);
 		grid->Add(row);

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -99,7 +99,8 @@ void TouchControlVisibilityScreen::CreateVisibilityTab(UI::LinearLayout *vert) {
 	toggles_.push_back({ "Right Analog Stick", &touch.touchRightAnalogStick.show, ImageID::invalid(), [=](EventParams &e) {
 		screenManager()->push(new RightAnalogMappingScreen(gamePath_));
 	}});
-	toggles_.push_back({ "Fast-forward", &touch.touchFastForwardKey.show, ImageID::invalid(), nullptr });
+	toggles_.push_back({ "Fast-forward", &touch.touchFastForwardKey.show, ImageID::invalid(), nullptr});
+	toggles_.push_back({ "Pause", &touch.touchPauseKey.show, ImageID("I_HAMBURGER"), nullptr});
 
 	for (int i = 0; i < TouchControlConfig::CUSTOM_BUTTON_COUNT; i++) {
 		char temp[256];
@@ -116,6 +117,7 @@ void TouchControlVisibilityScreen::CreateVisibilityTab(UI::LinearLayout *vert) {
 
 		CheckBox *checkbox = new CheckBox(toggle.show, "", "", new LinearLayoutParams(50, WRAP_CONTENT));
 		row->Add(checkbox);
+
 		Choice *choice;
 		if (toggle.handle) {
 			// Handle custom button strings differently, and hackily. But will extend to arbitrary button counts.

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -589,7 +589,7 @@ Setting Background = ‎إعدادات الخلفية
 Time Played: %1h %2m %3s = %1س %2د %3ث : وقت اللعب
 Uncompressed = تم فك الضغط
 USA = ‎أمريكا
-Use UI background = ‎إستخدم خلفية الواجهة
+Use background as UI background = ‎إستخدم خلفية الواجهة
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -170,7 +170,6 @@ Screen Rotation = ‎تدوير الشاشة
 Sensitivity (scale) = الحساسية(مقياس)
 Sensitivity = ‎الحساسية
 Shape = شكل
-Show Touch Pause Menu Button = ‎أظهر زر قائمة التوقف المؤقت
 Sticky D-Pad (easier sweeping movements) =  مثبة D-Pad (حركات سحب اسهل)
 Swipe = سحب
 Swipe sensitivity = حساسية السحب

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -162,7 +162,6 @@ Screen Rotation = Ekran dönüşü
 Sensitivity (scale) = Həssaslıq (ölçək)
 Sensitivity = Həssaslıq
 Shape = Forma
-Show Touch Pause Menu Button = Ara seçməsini göstər
 Sticky D-Pad (easier sweeping movements) = Yapışqan D-Pad (asan sürükləmə hərəkətləri)
 Swipe = Sürüşdürmə
 Swipe sensitivity = Sürüşdürmə həssaslığı

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -585,7 +585,7 @@ Setting Background = Arxafon quruluşu
 Time Played: %1h %2m %3s = Oynanış vaxtı: %1h %2m %3s
 Uncompressed = Sıxışdırılmamış
 USA = ABŞ
-Use UI background = AY arxafonunu işlət
+Use background as UI background = AY arxafonunu işlət
 
 [Graphics]
 % of the void = % boşluq

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -161,7 +161,6 @@ Screen Rotation = Паварот экрана
 Sensitivity = Адчувальнасць
 Sensitivity (scale) = Адчувальнасць (шкала)
 Shape = Форма
-Show Touch Pause Menu Button = Паказаць кнопку меню паўзы
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Свайп
 Swipe sensitivity = Адчувальнасць свайпаў

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -581,7 +581,7 @@ Setting Background = Налада фону
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Несціснуты
 USA = ЗША
-Use UI background = Выкарыстоўваць фон інтэрфейсу
+Use background as UI background = Выкарыстоўваць фон інтэрфейсу
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -162,7 +162,6 @@ Screen Rotation = Въртене на екрана
 Sensitivity (scale) = Чувствителност (скала)
 Sensitivity = Чувствителност
 Shape = Форма
-Show Touch Pause Menu Button = Покажи бутон „Пауза“
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -581,7 +581,7 @@ Setting Background = Задаване на фон
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Некомпресирано
 USA = САЩ
-Use UI background = Използване на фона на интерфейса
+Use background as UI background = Използване на фона на интерфейса
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotació de pantalla
 Sensitivity (scale) = Sensibilitat (escala)
 Sensitivity = Sensibilitat
 Shape = Forma
-Show Touch Pause Menu Button = Mostrar botó del menú
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Lliscar cap a
 Swipe sensitivity = Sensibilitat de lliscament

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -581,7 +581,7 @@ Setting Background = Imatge de fons
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = EEUU
-Use UI background = Utilitzar imatge de fons de l'interfície d'usuari
+Use background as UI background = Utilitzar imatge de fons de l'interfície d'usuari
 
 [Graphics]
 % of the void = % de buit

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -162,7 +162,6 @@ Screen Rotation = Otočení obrazovky
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Citlivost
 Shape = Shape
-Show Touch Pause Menu Button = Zobrazit tlačítko Nabídky při pozastavení
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Brug UI baggrund
+Use background as UI background = Brug UI baggrund
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -162,7 +162,6 @@ Screen Rotation = Skærm rotation
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Følsomhed
 Shape = Shape
-Show Touch Pause Menu Button = Vis pause menu knap
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -571,7 +571,7 @@ Setting Background = Einstellungshintergrund
 Time Played: %1h %2m %3s = Gespielte Zeit: %1std %2m %3s
 Uncompressed = Unkomprimiert
 USA = USA
-Use UI background = UI-Hintergrund benutzen
+Use background as UI background = UI-Hintergrund benutzen
 
 [Graphics]
 % of the void = % vom Leerbereich

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -161,7 +161,6 @@ Screen Rotation = Bildschirmausrichtung
 Sensitivity (scale) = Empfindlichkeit (Skala)
 Sensitivity = Empfindlichkeit
 Shape = Form
-Show Touch Pause Menu Button = Pausenmenü-Schaltfläche anzeigen
 Sticky D-Pad (easier sweeping movements) = Haftendes Steuerkreuz (einfachere Wischbewegungen)
 Swipe = Wischen
 Swipe sensitivity = Wischempfindlichkeit

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -162,7 +162,6 @@ Screen Rotation = Screen rotation
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivity
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -605,7 +605,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -185,7 +185,6 @@ Screen Rotation = Screen rotation
 Sensitivity = Sensitivity
 Sensitivity (scale) = Sensitivity (scale)
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -582,7 +582,7 @@ Setting Background = Configurar fondo
 Time Played: %1h %2m %3s = Tiempo jugado: %1h %2m %3s
 Uncompressed = Sin comprimir
 USA = América
-Use UI background = Establecer imagen como fondo
+Use background as UI background = Establecer imagen como fondo
 
 [Graphics]
 % of the void = % de vacío

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -163,7 +163,6 @@ Screen Rotation = Rotación de pantalla
 Sensitivity = Sensibilidad
 Sensitivity (scale) = Sensibilidad (escala)
 Shape = Forma
-Show Touch Pause Menu Button = Mostrar botón de menú de pausa
 Sticky D-Pad (easier sweeping movements) = D-Pad direccional fijo (movimientos de barrido más fáciles)
 Swipe = Deslizar
 Swipe sensitivity = Sensibilidad de deslizado

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotación de pantalla
 Sensitivity (scale) = Sensibilidad (escala)
 Sensitivity = Sensibilidad
 Shape = Forma
-Show Touch Pause Menu Button = Mostrar botón del menú
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (movimientos de barrido más fáciles)
 Swipe = Deslizar hacia
 Swipe sensitivity = Sensibilidad del deslizado

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -581,7 +581,7 @@ Setting Background = Configurar fondo
 Time Played: %1h %2m %3s = Tiempo Jugado: %1h %2m %3s
 Uncompressed = Sin comprimir
 USA = América
-Use UI background = Usar fondo como interfaz
+Use background as UI background = Usar fondo como interfaz
 
 [Graphics]
 % of the void = % del vacío

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -581,7 +581,7 @@ Setting Background = تنظیمات پس زمینا
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = آمریکا
-Use UI background = استفاده به عنوان پس زمینه؟
+Use background as UI background = استفاده به عنوان پس زمینه؟
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -162,7 +162,6 @@ Screen Rotation = ‎چرخش صفحه
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = ‎حساسیت
 Shape = شکل
-Show Touch Pause Menu Button = نمایش دکمهٔ توقف بازی
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = حساسیت
 Swipe sensitivity = حساسیت کشیدن

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -581,7 +581,7 @@ Setting Background = Taustakuvan asetus
 ime Played: %1h %2m %3s = Pelattu aika: %1t %2m %3s
 Uncompressed = Pakkauksen purku tehty
 USA = USA
-Use UI background = Käytä käyttöliittymän taustakuvaa
+Use background as UI background = Käytä käyttöliittymän taustakuvaa
 
 [Graphics]
 % of the void = % tyhjästä tilasta

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -162,7 +162,6 @@ Screen Rotation = Näytön kierto
 Sensitivity (scale) = Herkkyys (skaala)
 Sensitivity = Herkkyys
 Shape = Muoto
-Show Touch Pause Menu Button = Näytä kosketusnäytöllä taukovalikon näppäin
 Sticky D-Pad (easier sweeping movements) = Tahmea ristiohjain (helpommat pyyhkäisyliikkeet)
 Swipe = Pyyhkäise
 Swipe sensitivity = Pyyhkäisyn herkkyys

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -581,7 +581,7 @@ Setting Background = Paramétrage du fond d'écran
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Utiliser le fond d'écran
+Use background as UI background = Utiliser le fond d'écran
 
 [Graphics]
 % of the void = % de l'espace vide

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotation de l'écran
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensibilité
 Shape = Shape
-Show Touch Pause Menu Button = Afficher le bouton Pause tactile
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotación de pantalla
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensibilidade
 Shape = Shape
-Show Touch Pause Menu Button = Mostrar botón de menú
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -162,7 +162,6 @@ Screen Rotation = Περιστροφή οθόνης
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Ευαισθησία
 Shape = Shape
-Show Touch Pause Menu Button = Εμφάνιση απτικού κουμπιού μενού παύσης
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -581,7 +581,7 @@ Setting Background = Ρύθμιση φόντου
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = ΗΠΑ
-Use UI background = Χρήση φόντου UI
+Use background as UI background = Χρήση φόντου UI
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -162,7 +162,6 @@ Screen Rotation = Screen rotation
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivity
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -578,7 +578,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -162,7 +162,6 @@ Screen Rotation = Screen rotation
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivity
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -581,7 +581,7 @@ Setting Background = Postavljanje pozadine
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = SAD
-Use UI background = Koristi UI pozadinu
+Use background as UI background = Koristi UI pozadinu
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotacija ekrana
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Osjetljivost
 Shape = Shape
-Show Touch Pause Menu Button = Prikaži tipku za izbornik pauze
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -162,7 +162,6 @@ Screen Rotation = Képernyő elforgatása
 Sensitivity (scale) = Érzékenység (skála)
 Sensitivity = Érzékenység
 Shape = Alak
-Show Touch Pause Menu Button = Szünet gomb megjelenítése
 Sticky D-Pad (easier sweeping movements) = Tapadós D-Pad (könnyebb seprő mozdulatok)
 Swipe = Csúsztatás
 Swipe sensitivity = Csúsztatás érzékenysége

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -581,7 +581,7 @@ Setting Background = Háttér beállítása
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Tömörítetlen
 USA = USA
-Use UI background = Beállítás háttérként
+Use background as UI background = Beállítás háttérként
 
 [Graphics]
 % of the void = %-a az üres térnek

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotasi layar
 Sensitivity (scale) = Sensitivitas (skala)
 Sensitivity = Sensitivitas
 Shape = Bentuk
-Show Touch Pause Menu Button = Tampilkan tombol menu jeda
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Geser
 Swipe sensitivity = Geser sensitivitas

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -581,7 +581,7 @@ Setting Background = Atur latar belakang
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Tidak terkompresi
 USA = Amerika Serikat
-Use UI background = Gunakan latar belakang UI
+Use background as UI background = Gunakan latar belakang UI
 
 [Graphics]
 % of the void = % dari ruang kosong

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -161,7 +161,6 @@ Screen Rotation = Rotazione Schermo
 Sensitivity (scale) = Sensibilità (scala)
 Sensitivity = Sensibilità
 Shape = Forma
-Show Touch Pause Menu Button = Mostra Tasto Menu di Pausa
 Sticky D-Pad (easier sweeping movements) = D-Pad appiccicoso (movimenti di spazzamento più semplici)
 Swipe = Scorrimento
 Swipe sensitivity = Sensibilità Scorrimento

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -581,7 +581,7 @@ Setting Background = Imposta sfondo
 Time Played: %1h %2m %3s = Tempo di gioco: %1h %2m %3s
 Uncompressed = Non compresso
 USA = USA
-Use UI background = Usa sfondo interfaccia
+Use background as UI background = Usa sfondo interfaccia
 
 [Graphics]
 % of the void = % di spazio vuoto

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -162,7 +162,6 @@ Screen Rotation = 画面の向き
 Sensitivity (scale) = 反応感度 (比率)
 Sensitivity = 感度
 Shape = ボタンの形
-Show Touch Pause Menu Button = 一時停止ボタンを表示する
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad（スイープ動作がしやすくなる）
 Swipe = スワイプ
 Swipe sensitivity = スワイプの感度

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -581,7 +581,7 @@ Setting Background = 背景を設定
 Time Played: %1h %2m %3s = プレイ時間: %1時間 %2分 %3秒
 Uncompressed = 非圧縮
 USA = 米国
-Use UI background = UIの背景を使う
+Use background as UI background = UIの背景を使う
 
 [Graphics]
 % of the void = ボイドの%

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotasi layar
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitiv
 Shape = Shape
-Show Touch Pause Menu Button = Deleng tombol menu ngaso
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -161,7 +161,6 @@ Screen Rotation = 화면 회전
 Sensitivity = 감도
 Sensitivity (scale) = 감도 (스케일)
 Shape = 모양
-Show Touch Pause Menu Button = 일시중지 메뉴 버튼 표시
 Sticky D-Pad (easier sweeping movements) = 스티커형 십자 패드(더 쉬운 밀기 동작)
 Swipe = 밀기
 Swipe sensitivity = 밀기 감도

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -581,7 +581,7 @@ Setting Background = 배경 설정
 Time Played: %1h %2m %3s = 플레이 시간: %1시간 %2분 %3초
 Uncompressed = 비압축
 USA = 미국
-Use UI background = UI 배경 사용
+Use background as UI background = UI 배경 사용
 
 [Graphics]
 % of the void = 공백의 %

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -174,7 +174,6 @@ Screen Rotation = Screen rotation
 Sensitivity = Sensitivity
 Sensitivity (scale) = Sensitivity (scale)
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -595,7 +595,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = دا UI بەکارهێنانی لە باکگراوند
+Use background as UI background = دا UI بەکارهێنانی لە باکگراوند
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = ໃຊ້ເປັນພາບພື້ນຫຼັງ
+Use background as UI background = ໃຊ້ເປັນພາບພື້ນຫຼັງ
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -162,7 +162,6 @@ Screen Rotation = ການໝຸນໜ້າຈໍ
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = ຄວາມໄວຕໍ່ການຕອບສະໜອງ
 Shape = Shape
-Show Touch Pause Menu Button = ສະແດງປຸ່ມຢຸດສຳລັບເຂົ້າເມນູ
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -162,7 +162,6 @@ Screen Rotation = Ekramo pasukimas
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivacija
 Shape = Shape
-Show Touch Pause Menu Button = Rodyti liečiamą pauzės meniu mygtuką
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -162,7 +162,6 @@ Screen Rotation = Screen rotation
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivity
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -162,7 +162,6 @@ Screen Rotation = Schermrotatie
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Gevoeligheid
 Shape = Shape
-Show Touch Pause Menu Button = Pauzemenutoets weergeven
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -581,7 +581,7 @@ Setting Background = Achtergrondinstelling
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = VS
-Use UI background = UI-achtergrond gebruiken
+Use background as UI background = UI-achtergrond gebruiken
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -162,7 +162,6 @@ Screen Rotation = Screen rotation
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivity
 Shape = Shape
-Show Touch Pause Menu Button = Show pause menu button
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -581,7 +581,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -161,7 +161,6 @@ Screen Rotation = Obrót ekranu
 Sensitivity (scale) = Czułość (dostosuj)
 Sensitivity = Czułość
 Shape = Kształt
-Show Touch Pause Menu Button = Pokaż dotykowy przycisk Menu Pauzy
 Sticky D-Pad (easier sweeping movements) = Lepki D-Pad (łatwiejsze ruchy rozległe)
 Swipe = Przesunięcie palcem
 Swipe sensitivity = Czułość przesunięcia

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -583,7 +583,7 @@ Setting Background = Ustawianie tła
 Time Played: %1h %2m %3s = Czas gry: %1h %2m %3s
 Uncompressed = Nieskompresowane
 USA = USA
-Use UI background = Użyj tego tła
+Use background as UI background = Użyj tego tła
 
 [Graphics]
 % of the void = % pustej przestrzeni

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -604,7 +604,7 @@ Setting Background = Configurando o cenário de fundo
 Time Played: %1h %2m %3s = Tempo Jogado: %1h %2m %3s
 Uncompressed = Descomprimido
 USA = EUA
-Use UI background = Usar cenário de fundo da interface do usuário
+Use background as UI background = Usar cenário de fundo da interface do usuário
 
 [Graphics]
 % of the void = % do vazio

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -185,7 +185,6 @@ Screen Rotation = Rotação da tela
 Sensitivity = Sensibilidade
 Sensitivity (scale) = Sensibilidade (escala)
 Shape = Forma
-Show Touch Pause Menu Button = Mostrar o botão do menu da pausa
 Sticky D-Pad (easier sweeping movements) = Direcional pegajoso (movimentos abrangentes mais fáceis)
 Swipe = Deslizar
 Swipe sensitivity = Sensibilidade do deslizar

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -185,7 +185,6 @@ Screen Rotation = Rotação do ecrã
 Sensitivity = Sensibilidade
 Sensitivity (scale) = Sensibilidade (escala)
 Shape = Forma
-Show Touch Pause Menu Button = Mostrar o botão do menu de pausa
 Sticky D-Pad (easier sweeping movements) = D-Pad pegajoso (para deslizar de forma mais fácil)
 Swipe = Deslizar
 Swipe sensitivity = Sensibilidade do deslizamento

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -605,7 +605,7 @@ Setting Background = Definindo o cenário de fundo
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = EUA
-Use UI background = Usar cenário de fundo da interface do usuário.
+Use background as UI background = Usar cenário de fundo da interface do usuário.
 
 [Graphics]
 % of the void = % do vazio

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotație ecran
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivitate
 Shape = Shape
-Show Touch Pause Menu Button = Arată buton meniu pauză
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -582,7 +582,7 @@ Setting Background = Setting background
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Use UI background
+Use background as UI background = Use background as UI background
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -162,7 +162,6 @@ Screen Rotation = Ориентация экрана
 Sensitivity (scale) = Чувствительность (шкала)
 Sensitivity = Чувствительность
 Shape = Форма
-Show Touch Pause Menu Button = Показывать кнопку паузы
 Sticky D-Pad (easier sweeping movements) = Прилипающий D-Pad (облегчённые масштабные движения)
 Swipe = Свайпы
 Swipe sensitivity = Чувствительность свайпов

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -581,7 +581,7 @@ Setting Background = Установка фона
 Time Played: %1h %2m %3s = Проведено в игре: %1ч %2м %3с
 Uncompressed = Несжато
 USA = США
-Use UI background = Использовать фон интерфейса
+Use background as UI background = Использовать фон интерфейса
 
 [Graphics]
 % of the void = % пустоты

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -162,7 +162,6 @@ Screen Rotation = Skärmrotation
 Sensitivity (scale) = Känslighet (skala)
 Sensitivity = Känslighet
 Shape = Form
-Show Touch Pause Menu Button = Visa touch-knapp för paus
 Sticky D-Pad (easier sweeping movements) = Klistriga riktningsknappar (enklare svepningsrörelser)
 Swipe = Svepning
 Swipe sensitivity = Känslighet för svepning

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -582,7 +582,7 @@ Setting Background = Sätter UI-bakgrund
 Time Played: %1h %2m %3s = Spelad tid: %1h %2m %3s
 Uncompressed = Okomprimerat
 USA = USA
-Use UI background = Använd UI-bakgrund
+Use background as UI background = Använd UI-bakgrund
 
 [Graphics]
 % of the void = % av tomrummet

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -582,7 +582,7 @@ Setting Background = Background sa Setting
 Time Played: %1h %2m %3s = Oras ng paglalaro: %1h %2m %3s
 Uncompressed = Di Compressed
 USA = USA
-Use UI background = Gamitin ang UI background mula sa laro
+Use background as UI background = Gamitin ang UI background mula sa laro
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -162,7 +162,6 @@ Screen Rotation = Rotasyon ng screen
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Sensitivity
 Shape = Hugis
-Show Touch Pause Menu Button = Ipakita ang pause menu button
 Sticky D-Pad (easier sweeping movements) = Madikit na D-Pad (madaling pagpalit ng paggalaw)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -597,7 +597,7 @@ Setting Background = การตั้งค่าพื้นหลัง
 Time Played: %1h %2m %3s = เวลาที่เล่น: %1ชั่วโมง %2นาที %3วินาที
 Uncompressed = ไม่ได้ถูกบีบอัด
 USA = USA (โซนอเมริกา)
-Use UI background = ใช้เป็นภาพพื้นหลัง
+Use background as UI background = ใช้เป็นภาพพื้นหลัง
 
 [Graphics]
 % of the void = % ของช่องว่าง

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -162,7 +162,6 @@ Screen Rotation = การหมุนหน้าจอ
 Sensitivity = ความไวต่อการตอบสนอง
 Sensitivity (scale) = ความไวการตอบสนอง
 Shape = กรอบปุ่ม
-Show Touch Pause Menu Button = แสดงปุ่มหยุดสำหรับเข้าหน้าเมนู
 Sticky D-Pad (easier sweeping movements) = ปุมลูกศรแบบหนืด (การกดกวาดปุ่มทำได้ง่ายขึ้น)
 Swipe = ปัดหน้าจอ
 Swipe sensitivity = ความแรงที่ใช้ปัดหน้าจอ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -583,7 +583,7 @@ Setting Background = Arkaplan ayarlanıyor
 Time Played: %1h %2m %3s = Oynanan Süre: %1s %2d %3s
 Uncompressed = Sıkıştırılmamış
 USA = ABD
-Use UI background = Arayüz Arkaplanında Kullan
+Use background as UI background = Arayüz Arkaplanında Kullan
 
 [Graphics]
 % of the void = % boşluk

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -162,7 +162,6 @@ Screen Rotation = Ekran Döndürme
 Sensitivity (scale) = Hassasiyet (ölçek)
 Sensitivity = Hassasiyet
 Shape = Şekil
-Show Touch Pause Menu Button = Dokunmatik Duraklatma Menü Düğmesini Göster
 Sticky D-Pad (easier sweeping movements) = Yapışkan D-Pad (daha kolay sürükleme hareketleri)
 Swipe = Kaydır
 Swipe sensitivity = Kaydırma Hassasiyeti

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -581,7 +581,7 @@ Setting Background = Налаштування фону
 Time Played: %1h %2m %3s = Час гри: %1г %2х %3с
 Uncompressed = Без стиснення
 USA = США
-Use UI background = Використати фон інтерфейсу
+Use background as UI background = Використати фон інтерфейсу
 
 [Graphics]
 % of the void = % з пустого

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -162,7 +162,6 @@ Screen Rotation = Орієнтація екрану
 Sensitivity (scale) = Чутливість (масштаб)
 Sensitivity = Чутливість
 Shape = Форма
-Show Touch Pause Menu Button = Показувати кнопку меню
 Sticky D-Pad (easier sweeping movements) = Липкий D-Pad (легші розмашисті рухи)
 Swipe = Проведення
 Swipe sensitivity = Чутливість проведення

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -162,7 +162,6 @@ Screen Rotation = Xoay màn hình
 Sensitivity (scale) = Sensitivity (scale)
 Sensitivity = Độ nhạy
 Shape = Shape
-Show Touch Pause Menu Button = Hiện phím dừng
 Sticky D-Pad (easier sweeping movements) = Sticky D-Pad (easier sweeping movements)
 Swipe = Swipe
 Swipe sensitivity = Swipe sensitivity

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -581,7 +581,7 @@ Setting Background = Cài đặt nền
 Time Played: %1h %2m %3s = Time Played: %1h %2m %3s
 Uncompressed = Uncompressed
 USA = USA
-Use UI background = Sử dụng nền UI
+Use background as UI background = Sử dụng nền UI
 
 [Graphics]
 % of the void = % of the void

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -581,7 +581,7 @@ Setting Background = 设置壁纸中
 Time Played: %1h %2m %3s = 游玩时间：%1小时 %2分 %3秒
 Uncompressed = 已解压
 USA = 美国
-Use UI background = 将游戏封面设为壁纸
+Use background as UI background = 将游戏封面设为壁纸
 
 [Graphics]
 % of the void = %的边框

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -162,7 +162,6 @@ Screen Rotation = 屏幕旋转
 Sensitivity (scale) = 灵敏度(倍率)
 Sensitivity = 灵敏度
 Shape = 按键形状
-Show Touch Pause Menu Button = 显示暂停键
 Sticky D-Pad (easier sweeping movements) = 方向键自由滑动
 Swipe = 滑动手势
 Swipe sensitivity = 滑动灵敏度

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -161,7 +161,6 @@ Screen Rotation = 螢幕旋轉
 Sensitivity = 敏感度
 Sensitivity (scale) = 敏感度 (比例)
 Shape = 圖形
-Show Touch Pause Menu Button = 顯示暫停選單按鈕
 Sticky D-Pad (easier sweeping movements) = 黏性方向鍵 (更易掃動)
 Swipe = 滑動
 Swipe sensitivity = 滑動敏感度

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -581,7 +581,7 @@ Setting Background = 設定背景
 Time Played: %1h %2m %3s = 已遊玩時間：%1小時 %2分鐘 %3秒
 Uncompressed = 已解壓縮
 USA = 美國
-Use UI background = 使用 UI 背景
+Use background as UI background = 使用 UI 背景
 
 [Graphics]
 % of the void = % 的無效區


### PR DESCRIPTION
Still enforcing its presence on iOS, of course, since there's no other sure-fire way to get back to the menu.

Fixes #14500

Also some other assorted tweaks.