### PR TITLE
Add android fallback when Nintendo Switch Left Joycon keyCode event is 0

### DIFF
--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -137,12 +137,24 @@ public class InputDeviceState {
 	public boolean onKeyDown(KeyEvent event) {
 		int keyCode = event.getKeyCode();
 		boolean repeat = event.getRepeatCount() > 0;
+
+		if (isInvalidKeyCode(keyCode) && isEventSentByNintendoSwitchLeftJoyCon(event)) {
+			keyCode = remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(event.getScanCode());
+			// need to pass false for the repeat flag, otherwise pressing two adjacent dpad buttons simultaneously to move diagonally does not work.
+			return NativeApp.keyDown(deviceId, keyCode, false); 
+		}
+
 		return NativeApp.keyDown(deviceId, keyCode, repeat);
 	}
 
 	// This is called from dispatchKeyEvent.
 	public boolean onKeyUp(KeyEvent event) {
 		int keyCode = event.getKeyCode();
+
+		if (isInvalidKeyCode(keyCode) && isEventSentByNintendoSwitchLeftJoyCon(event)) {
+			keyCode = remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(event.getScanCode());
+		}
+
 		return NativeApp.keyUp(deviceId, keyCode);
 	}
 
@@ -165,5 +177,28 @@ public class InputDeviceState {
 		}
 		NativeApp.joystickAxis(deviceId, mAxisIds, mValues, count);
 		return true;
+	}
+
+	private boolean isInvalidKeyCode(int keyCode) {
+		return keyCode == 0;
+	}
+
+	private boolean isEventSentByNintendoSwitchLeftJoyCon(KeyEvent event) {
+		return event.getDevice().getName().contains("Nintendo Switch Left Joy-Con");
+	}
+
+	private int remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(int scanCode) {
+		switch (scanCode) {
+			case 544:
+				return KeyEvent.KEYCODE_DPAD_UP;
+			case 545:
+				return KeyEvent.KEYCODE_DPAD_DOWN;
+			case 546:
+				return KeyEvent.KEYCODE_DPAD_LEFT;
+			case 547:
+				return KeyEvent.KEYCODE_DPAD_RIGHT;
+			default:
+				return 0;
+		}
 	}
 }


### PR DESCRIPTION
Nothing Phone 2A devices aren’t fully compatible with Nintendo Switch (1) Joycons: the OS does not correctly recognise the left dpad input. This appears to be an OS-level issue in Nothing OS and likely affects all Nothing phones. Since resolving it at the OS level would require root access, it’s more practical to handle the fix directly in the app.

To debug the issue, I first wrote a small app that logs all Left Joycon dpad inputs, and got the following:
- Up: keyCode=0 | scanCode=544
- Left: keyCode=0 | scanCode=546
- Down: keyCode=0 | scanCode=545
- Right: keyCode=0 | scanCode=547

As you can see, keyCode is always 0. Therefore, I had to use the scanCode to identify the pressed button. There was also an issue with pressing two dpad buttons simultaneously, which I explain in more detail in the risks section below.


## Tests

I've tested on a Nothing Phone 2A using the following games:
- Ape Academy
- Daxter
- Assassin’s Creed: Bloodlines
- Jungle Party
- Kingdom Hearts: Birth by Sleep

Also tested on a Samsung Galaxy A12 to confirm no regressions on devices that are fully compatible with Joycons.

## Risks
- This fix assumes that all Nintendo Switch (1) Left Joycons use the same scancodes. I verified this with two different Left Joycons, but cannot guarantee it holds universally.

- When pressing a second dpad button while another is already held, the repeat count for the second input does not start at 0. This causes the game to miss the input, preventing diagonal movement in titles that rely on dpad movement.
The fix implemented here forces the repeat flag to always be false. This resolves the issue in all tested games. So far, I haven’t observed any negative side effects, but there may be edge cases I haven’t encountered.
