### PR TITLE
Ability to adjust the number of savestate slots and some savestate QOL features

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -263,6 +263,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("DumpAudio", SETTING(g_Config, bDumpAudio), false, CfgFlag::DEFAULT),
 	ConfigSetting("SaveLoadResetsAVdumping", SETTING(g_Config, bSaveLoadResetsAVdumping), false, CfgFlag::DEFAULT),
 	ConfigSetting("StateSlot", SETTING(g_Config, iCurrentStateSlot), 0, CfgFlag::PER_GAME),
+	ConfigSetting("NumSaveStateSlots", SETTING(g_Config, iNumSaveStateSlots), 10, CfgFlag::DEFAULT),
 	ConfigSetting("EnableStateUndo", SETTING(g_Config, bEnableStateUndo), &DefaultEnableStateUndo, CfgFlag::PER_GAME),
 	ConfigSetting("StateLoadUndoGame", SETTING(g_Config, sStateLoadUndoGame), "NA", CfgFlag::DEFAULT),
 	ConfigSetting("StateUndoLastSaveGame", SETTING(g_Config, sStateUndoLastSaveGame), "NA", CfgFlag::DEFAULT),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -243,7 +243,6 @@ static const ConfigSetting generalSettings[] = {
 
 	ConfigSetting("DisableHTTPS", SETTING(g_Config, bDisableHTTPS), false, CfgFlag::DONT_SAVE),
 	ConfigSetting("AutoLoadSaveState", SETTING(g_Config, iAutoLoadSaveState), 0, CfgFlag::PER_GAME),
-	ConfigSetting("SaveStateSlotAmount", SETTING(g_Config, iSaveStateSlotAmount), 5, CfgFlag::DEFAULT),
 	ConfigSetting("EnableCheats", SETTING(g_Config, bEnableCheats), false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("EnablePlugins", SETTING(g_Config, bEnablePlugins), true, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("CwCheatRefreshRate", SETTING(g_Config, iCwCheatRefreshIntervalMs), 77, CfgFlag::PER_GAME),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -244,6 +244,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("DisableHTTPS", SETTING(g_Config, bDisableHTTPS), false, CfgFlag::DONT_SAVE),
 	ConfigSetting("AutoLoadSaveState", SETTING(g_Config, iAutoLoadSaveState), 0, CfgFlag::PER_GAME),
 	ConfigSetting("SaveStateSlotAmount", SETTING(g_Config, iSaveStateSlotAmount), 5, CfgFlag::DEFAULT),
+	ConfigSetting("SaveStateSlotAutoLoadSlot", SETTING(g_Config, iSaveStateAutoLoadSlot), 1, CfgFlag::PER_GAME),
 	ConfigSetting("EnableCheats", SETTING(g_Config, bEnableCheats), false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("EnablePlugins", SETTING(g_Config, bEnablePlugins), true, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("CwCheatRefreshRate", SETTING(g_Config, iCwCheatRefreshIntervalMs), 77, CfgFlag::PER_GAME),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -263,7 +263,6 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("DumpAudio", SETTING(g_Config, bDumpAudio), false, CfgFlag::DEFAULT),
 	ConfigSetting("SaveLoadResetsAVdumping", SETTING(g_Config, bSaveLoadResetsAVdumping), false, CfgFlag::DEFAULT),
 	ConfigSetting("StateSlot", SETTING(g_Config, iCurrentStateSlot), 0, CfgFlag::PER_GAME),
-	ConfigSetting("NumSaveStateSlots", SETTING(g_Config, iNumSaveStateSlots), 10, CfgFlag::DEFAULT),
 	ConfigSetting("EnableStateUndo", SETTING(g_Config, bEnableStateUndo), &DefaultEnableStateUndo, CfgFlag::PER_GAME),
 	ConfigSetting("StateLoadUndoGame", SETTING(g_Config, sStateLoadUndoGame), "NA", CfgFlag::DEFAULT),
 	ConfigSetting("StateUndoLastSaveGame", SETTING(g_Config, sStateUndoLastSaveGame), "NA", CfgFlag::DEFAULT),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -243,6 +243,7 @@ static const ConfigSetting generalSettings[] = {
 
 	ConfigSetting("DisableHTTPS", SETTING(g_Config, bDisableHTTPS), false, CfgFlag::DONT_SAVE),
 	ConfigSetting("AutoLoadSaveState", SETTING(g_Config, iAutoLoadSaveState), 0, CfgFlag::PER_GAME),
+	ConfigSetting("SaveStateSlotAmount", SETTING(g_Config, iSaveStateSlotAmount), 5, CfgFlag::DEFAULT),
 	ConfigSetting("EnableCheats", SETTING(g_Config, bEnableCheats), false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("EnablePlugins", SETTING(g_Config, bEnablePlugins), true, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("CwCheatRefreshRate", SETTING(g_Config, iCwCheatRefreshIntervalMs), 77, CfgFlag::PER_GAME),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -243,6 +243,7 @@ static const ConfigSetting generalSettings[] = {
 
 	ConfigSetting("DisableHTTPS", SETTING(g_Config, bDisableHTTPS), false, CfgFlag::DONT_SAVE),
 	ConfigSetting("AutoLoadSaveState", SETTING(g_Config, iAutoLoadSaveState), 0, CfgFlag::PER_GAME),
+	ConfigSetting("ShowSetAutoLoadButton", SETTING(g_Config, bShowSetAutoLoadButton), false, CfgFlag::DEFAULT),
 	ConfigSetting("SaveStateSlotAmount", SETTING(g_Config, iSaveStateSlotAmount), 5, CfgFlag::DEFAULT),
 	ConfigSetting("SaveStateSlotAutoLoadSlot", SETTING(g_Config, iSaveStateAutoLoadSlot), 1, CfgFlag::PER_GAME),
 	ConfigSetting("EnableCheats", SETTING(g_Config, bEnableCheats), false, CfgFlag::PER_GAME | CfgFlag::REPORT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -325,8 +325,9 @@ public:
 	std::string sStateLoadUndoGame;
 	std::string sStateUndoLastSaveGame;
 	int iStateUndoLastSaveSlot;
-	int iAutoLoadSaveState; // 0 = off, 1 = oldest, 2 = newest, >2 = slot number + 3
+	int iAutoLoadSaveState; // 0 = off, 1 = oldest, 2 = newest, 3 = Savestate slot selection
 	int iSaveStateSlotAmount; 
+	int iSaveStateAutoLoadSlot;
 	bool bEnableCheats;
 	bool bReloadCheats;
 	bool bEnablePlugins;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -326,7 +326,6 @@ public:
 	std::string sStateUndoLastSaveGame;
 	int iStateUndoLastSaveSlot;
 	int iAutoLoadSaveState; // 0 = off, 1 = oldest, 2 = newest, >2 = slot number + 3
-	int iSaveStateSlotAmount; 
 	bool bEnableCheats;
 	bool bReloadCheats;
 	bool bEnablePlugins;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -326,6 +326,7 @@ public:
 	std::string sStateUndoLastSaveGame;
 	int iStateUndoLastSaveSlot;
 	int iAutoLoadSaveState; // 0 = off, 1 = oldest, 2 = newest, 3 = Savestate slot selection
+	bool bShowSetAutoLoadButton;
 	int iSaveStateSlotAmount; 
 	int iSaveStateAutoLoadSlot;
 	bool bEnableCheats;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -319,6 +319,8 @@ public:
 	int iAnalogFpsLimit;
 	int iMaxRecent;
 	int iCurrentStateSlot;
+	// Number of savestate slots shown in the pause menu (1..SaveState::NUM_SLOTS).
+	int iNumSaveStateSlots = 10;
 	int iRewindSnapshotInterval;
 	bool bUISound;
 	bool bEnableStateUndo;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -319,8 +319,6 @@ public:
 	int iAnalogFpsLimit;
 	int iMaxRecent;
 	int iCurrentStateSlot;
-	// Number of savestate slots shown in the pause menu (1..SaveState::NUM_SLOTS).
-	int iNumSaveStateSlots = 10;
 	int iRewindSnapshotInterval;
 	bool bUISound;
 	bool bEnableStateUndo;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -326,6 +326,7 @@ public:
 	std::string sStateUndoLastSaveGame;
 	int iStateUndoLastSaveSlot;
 	int iAutoLoadSaveState; // 0 = off, 1 = oldest, 2 = newest, >2 = slot number + 3
+	int iSaveStateSlotAmount; 
 	bool bEnableCheats;
 	bool bReloadCheats;
 	bool bEnablePlugins;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -554,12 +554,12 @@ double g_lastSaveTime = -1.0;
 
 	void PrevSlot()
 	{
-		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot - 1 + g_Config.iSaveStateSlotAmount) % g_Config.iSaveStateSlotAmount;
+		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot - 1 + NUM_SLOTS) % NUM_SLOTS;
 	}
 
 	void NextSlot()
 	{
-		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % g_Config.iSaveStateSlotAmount;
+		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % NUM_SLOTS;
 	}
 
 	static void DeleteIfExists(const Path &fn) {
@@ -807,7 +807,7 @@ double g_lastSaveTime = -1.0;
 	int GetNewestSlot(const Path &gameFilename) {
 		int newestSlot = -1;
 		tm newestDate = {0};
-		for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
+		for (int i = 0; i < NUM_SLOTS; i++) {
 			Path fn = GenerateSaveSlotFilename(gameFilename, i, STATE_EXTENSION);
 			if (File::Exists(fn)) {
 				tm time;
@@ -824,7 +824,7 @@ double g_lastSaveTime = -1.0;
 	int GetOldestSlot(const Path &gameFilename) {
 		int oldestSlot = -1;
 		tm oldestDate = {0};
-		for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
+		for (int i = 0; i < NUM_SLOTS; i++) {
 			Path fn = GenerateSaveSlotFilename(gameFilename, i, STATE_EXTENSION);
 			if (File::Exists(fn)) {
 				tm time;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -554,12 +554,12 @@ double g_lastSaveTime = -1.0;
 
 	void PrevSlot()
 	{
-		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot - 1 + NUM_SLOTS) % NUM_SLOTS;
+		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot - 1 + g_Config.iSaveStateSlotAmount) % g_Config.iSaveStateSlotAmount;
 	}
 
 	void NextSlot()
 	{
-		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % NUM_SLOTS;
+		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % g_Config.iSaveStateSlotAmount;
 	}
 
 	static void DeleteIfExists(const Path &fn) {
@@ -807,7 +807,7 @@ double g_lastSaveTime = -1.0;
 	int GetNewestSlot(const Path &gameFilename) {
 		int newestSlot = -1;
 		tm newestDate = {0};
-		for (int i = 0; i < NUM_SLOTS; i++) {
+		for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
 			Path fn = GenerateSaveSlotFilename(gameFilename, i, STATE_EXTENSION);
 			if (File::Exists(fn)) {
 				tm time;
@@ -824,7 +824,7 @@ double g_lastSaveTime = -1.0;
 	int GetOldestSlot(const Path &gameFilename) {
 		int oldestSlot = -1;
 		tm oldestDate = {0};
-		for (int i = 0; i < NUM_SLOTS; i++) {
+		for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
 			Path fn = GenerateSaveSlotFilename(gameFilename, i, STATE_EXTENSION);
 			if (File::Exists(fn)) {
 				tm time;

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -33,7 +33,6 @@ namespace SaveState {
 	};
 	typedef std::function<void(Status status, std::string_view message)> Callback;
 
-	static const int NUM_SLOTS = 5;
 	static const char * const STATE_EXTENSION = "ppst";
 	static const char * const SCREENSHOT_EXTENSION = "jpg";
 	static const char * const UNDO_STATE_EXTENSION = "undo.ppst";
@@ -44,7 +43,7 @@ namespace SaveState {
 	void Init();
 	void Shutdown();
 
-	// Cycle through the 5 savestate slots
+	// Cycle through the savestate slots
 	void PrevSlot();
 	void NextSlot();
 	void SaveSlot(const Path &gameFilename, int slot, Callback callback);

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -33,7 +33,7 @@ namespace SaveState {
 	};
 	typedef std::function<void(Status status, std::string_view message)> Callback;
 
-	static const int NUM_SLOTS = 50;
+	static const int NUM_SLOTS = 5;
 	static const char * const STATE_EXTENSION = "ppst";
 	static const char * const SCREENSHOT_EXTENSION = "jpg";
 	static const char * const UNDO_STATE_EXTENSION = "undo.ppst";

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -33,6 +33,7 @@ namespace SaveState {
 	};
 	typedef std::function<void(Status status, std::string_view message)> Callback;
 
+	static const int NUM_SLOTS = 5;
 	static const char * const STATE_EXTENSION = "ppst";
 	static const char * const SCREENSHOT_EXTENSION = "jpg";
 	static const char * const UNDO_STATE_EXTENSION = "undo.ppst";
@@ -43,7 +44,7 @@ namespace SaveState {
 	void Init();
 	void Shutdown();
 
-	// Cycle through the savestate slots
+	// Cycle through the 5 savestate slots
 	void PrevSlot();
 	void NextSlot();
 	void SaveSlot(const Path &gameFilename, int slot, Callback callback);

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -33,7 +33,7 @@ namespace SaveState {
 	};
 	typedef std::function<void(Status status, std::string_view message)> Callback;
 
-	static const int NUM_SLOTS = 5;
+	static const int NUM_SLOTS = 50;
 	static const char * const STATE_EXTENSION = "ppst";
 	static const char * const SCREENSHOT_EXTENSION = "jpg";
 	static const char * const UNDO_STATE_EXTENSION = "undo.ppst";

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -2045,8 +2045,8 @@ void EmuScreen::AutoLoadSaveState() {
 	case (int)AutoLoadSaveState::NEWEST: // "Newest Save"
 		autoSlot = SaveState::GetNewestSlot(gamePath_);
 		break;
-	default: // try the specific save state slot specified
-		autoSlot = (SaveState::HasSaveInSlot(gamePath_, g_Config.iAutoLoadSaveState - 3)) ? (g_Config.iAutoLoadSaveState - 3) : -1;
+	default: // "Selected Slot"
+		autoSlot = (SaveState::HasSaveInSlot(gamePath_, g_Config.iSaveStateAutoLoadSlot - 1)) ? (g_Config.iSaveStateAutoLoadSlot - 1) : -1;
 		break;
 	}
 
@@ -2054,7 +2054,7 @@ void EmuScreen::AutoLoadSaveState() {
 		SaveState::LoadSlot(gamePath_, autoSlot, [this, autoSlot](SaveState::Status status, std::string_view message) {
 			AfterSaveStateAction(status, message);
 			auto sy = GetI18NCategory(I18NCat::SYSTEM);
-			std::string msg = std::string(sy->T("Auto Load Savestate")) + ": " + StringFromFormat("%d", autoSlot);
+			std::string msg = std::string(sy->T("Auto Load Savestate")) + ": " + StringFromFormat("%d", autoSlot + 1);
 			g_OSD.Show(OSDType::MESSAGE_SUCCESS, msg);
 			if (status == SaveState::Status::FAILURE) {
 				autoLoadFailed_ = true;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1354,7 +1354,8 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	systemSettings->Add(new ItemHeader(sy->T("Savestates")));
 
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
-	systemSettings->Add(new CheckBox(&g_Config.bShowSetAutoLoadButton, sy->T("Show 'Set Auto Load' button")));
+	systemSettings->Add(new CheckBox(&g_Config.bHideStateWarnings, sy->T("Hide warnings on savestate load")));
+	systemSettings->Add(new CheckBox(&g_Config.bShowSetAutoLoadButton, sy->T("Show 'Set Auto Load' button in pause menu")));
 	static const char* autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Savestate slot selection" };
 	PopupSliderChoice* SavestateSlotAmount = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -998,7 +998,8 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(ms->T("Networking")));
 
-	networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page")))->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
+	Choice *wiki = networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page"), ImageID("I_LINK_OUT")));
+	wiki->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
 
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
 	networkingSettings->Add(new MacAddressChooser(GetRequesterToken(), gamePath_, &g_Config.sMACAddress, n->T("Change Mac Address"), screenManager()));
@@ -1053,7 +1054,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	qc->SetEnabledPtr(&g_Config.bEnableNetworkChat);
 #endif
 
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KEY_CHAR support is added
+#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KeyInputFlags::CHAR support is added
 	PopupTextInputChoice *qc1 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat0, n->T("Quick Chat 1"), "", 32, screenManager()));
 	PopupTextInputChoice *qc2 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat1, n->T("Quick Chat 2"), "", 32, screenManager()));
 	PopupTextInputChoice *qc3 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat2, n->T("Quick Chat 3"), "", 32, screenManager()));
@@ -1202,12 +1203,6 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	static const char *positions[] = { "None", "Bottom Left", "Bottom Center", "Bottom Right", "Top Left", "Top Center", "Top Right", "Center Left", "Center Right" };
 
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iNotificationPos, sy->T("Notification screen position"), positions, -1, ARRAY_SIZE(positions), I18NCat::DIALOG, screenManager()));
-
-	// How many savestate slots to show in the pause menu.
-	// Limit between 1 and SaveState::NUM_SLOTS (configured in core). Default is 10.
-	int maxSlots = SaveState::NUM_SLOTS;
-	PopupSliderChoice *saveSlotsChoice = systemSettings->Add(new PopupSliderChoice(&g_Config.iNumSaveStateSlots, 1, maxSlots, 10, sy->T("Savestate slots in pause menu"), screenManager()));
-	saveSlotsChoice->SetZeroLabel(sy->T("1"));
 
 	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves", "Moving background", "Bouncing icon", "Colored floating symbols" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iBackgroundAnimation, sy->T("UI background animation"), backgroundAnimations, 0, ARRAY_SIZE(backgroundAnimations), I18NCat::SYSTEM, screenManager()));
@@ -1874,10 +1869,10 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	progressView_->SetVisibility(UI::V_GONE);
 }
 
-void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
+void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags) {
 	auto oldView = UI::GetFocusedView();
 	UI::SetFocusedView(addrView_);
-	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KEY_DOWN | flags };
+	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KeyInputFlags::DOWN | flags };
 	addrView_->Key(fakeKey);
 	UI::SetFocusedView(oldView);
 }
@@ -1885,12 +1880,12 @@ void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
 void HostnameSelectScreen::OnNumberClick(UI::EventParams &e) {
 	std::string text = e.v ? e.v->Tag() : "";
 	if (text.length() == 1 && text[0] >= '0' && text[0] <= '9') {
-		SendEditKey((InputKeyCode)text[0], KEY_CHAR);  // ASCII for digits match keycodes.
+		SendEditKey((InputKeyCode)text[0], KeyInputFlags::CHAR);  // ASCII for digits match keycodes.
 	}
 }
 
 void HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
-	SendEditKey((InputKeyCode)'.', KEY_CHAR);
+	SendEditKey((InputKeyCode)'.', KeyInputFlags::CHAR);
 }
 
 void HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1369,6 +1369,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
 	static const char *autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Slot 1", "Slot 2", "Slot 3", "Slot 4", "Slot 5" };
+	systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));
 	if (System_GetPropertyBool(SYSPROP_HAS_KEYBOARD))
 		systemSettings->Add(new CheckBox(&g_Config.bBypassOSKWithKeyboard, sy->T("Use system native keyboard")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1351,6 +1351,17 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	rewindInterval->SetFormat(di->T("%d seconds"));
 	rewindInterval->SetZeroLabel(sy->T("Off"));
 
+	systemSettings->Add(new ItemHeader(sy->T("Savestates")));
+
+	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
+	systemSettings->Add(new CheckBox(&g_Config.bShowSetAutoLoadButton, sy->T("Show 'Set Auto Load' button")));
+	static const char* autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Savestate slot selection" };
+	PopupSliderChoice* SavestateSlotAmount = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
+	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));
+	PopupSliderChoice* SavestateSlotAmountAutoload = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateAutoLoadSlot, 1, g_Config.iSaveStateSlotAmount, 1, sy->T("Savestate Auto Load slot"), screenManager()));
+	// Enable on value 3: "Savestate slot selection"
+	SavestateSlotAmountAutoload->SetEnabled(g_Config.iAutoLoadSaveState == 3);
+
 	systemSettings->Add(new ItemHeader(sy->T("General")));
 
 	PopupSliderChoice *exitConfirmation = systemSettings->Add(new PopupSliderChoice(&g_Config.iAskForExitConfirmationAfterSeconds, 0, 1200, 60, sy->T("Ask for exit confirmation after seconds"), screenManager(), "s"));
@@ -1367,14 +1378,6 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	}
 
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
-
-	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
-	static const char* autoLoadSaveStateChoices[] = {"Off", "Oldest Save", "Newest Save", "Savestate slot selection"};
-	PopupSliderChoice *SavestateSlotAmount = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
-	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));
-	PopupSliderChoice *SavestateSlotAmountAutoload = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateAutoLoadSlot, 1, g_Config.iSaveStateSlotAmount, 1, sy->T("Savestate Auto Load slot"), screenManager()));
-	// Enable on value 3: "Savestate slot selection"
-	SavestateSlotAmountAutoload->SetEnabled(g_Config.iAutoLoadSaveState == 3);
 
 	if (System_GetPropertyBool(SYSPROP_HAS_KEYBOARD))
 		systemSettings->Add(new CheckBox(&g_Config.bBypassOSKWithKeyboard, sy->T("Use system native keyboard")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -998,8 +998,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(ms->T("Networking")));
 
-	Choice *wiki = networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page"), ImageID("I_LINK_OUT")));
-	wiki->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
+	networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page")))->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
 
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
 	networkingSettings->Add(new MacAddressChooser(GetRequesterToken(), gamePath_, &g_Config.sMACAddress, n->T("Change Mac Address"), screenManager()));
@@ -1054,7 +1053,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	qc->SetEnabledPtr(&g_Config.bEnableNetworkChat);
 #endif
 
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KeyInputFlags::CHAR support is added
+#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KEY_CHAR support is added
 	PopupTextInputChoice *qc1 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat0, n->T("Quick Chat 1"), "", 32, screenManager()));
 	PopupTextInputChoice *qc2 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat1, n->T("Quick Chat 2"), "", 32, screenManager()));
 	PopupTextInputChoice *qc3 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat2, n->T("Quick Chat 3"), "", 32, screenManager()));
@@ -1368,6 +1367,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
+	systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
 	static const char *autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Slot 1", "Slot 2", "Slot 3", "Slot 4", "Slot 5" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));
 	if (System_GetPropertyBool(SYSPROP_HAS_KEYBOARD))
@@ -1869,10 +1869,10 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	progressView_->SetVisibility(UI::V_GONE);
 }
 
-void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags) {
+void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
 	auto oldView = UI::GetFocusedView();
 	UI::SetFocusedView(addrView_);
-	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KeyInputFlags::DOWN | flags };
+	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KEY_DOWN | flags };
 	addrView_->Key(fakeKey);
 	UI::SetFocusedView(oldView);
 }
@@ -1880,12 +1880,12 @@ void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags
 void HostnameSelectScreen::OnNumberClick(UI::EventParams &e) {
 	std::string text = e.v ? e.v->Tag() : "";
 	if (text.length() == 1 && text[0] >= '0' && text[0] <= '9') {
-		SendEditKey((InputKeyCode)text[0], KeyInputFlags::CHAR);  // ASCII for digits match keycodes.
+		SendEditKey((InputKeyCode)text[0], KEY_CHAR);  // ASCII for digits match keycodes.
 	}
 }
 
 void HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
-	SendEditKey((InputKeyCode)'.', KeyInputFlags::CHAR);
+	SendEditKey((InputKeyCode)'.', KEY_CHAR);
 }
 
 void HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1367,10 +1367,15 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	}
 
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
+
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
-	static const char *autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Slot 1", "Slot 2", "Slot 3", "Slot 4", "Slot 5" };
-	systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
+	static const char* autoLoadSaveStateChoices[] = {"Off", "Oldest Save", "Newest Save", "Savestate slot selection"};
+	PopupSliderChoice *SavestateSlotAmount = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));
+	PopupSliderChoice *SavestateSlotAmountAutoload = systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateAutoLoadSlot, 1, g_Config.iSaveStateSlotAmount, 1, sy->T("Savestate Auto Load slot"), screenManager()));
+	// Enable on value 3: "Savestate slot selection"
+	SavestateSlotAmountAutoload->SetEnabled(g_Config.iAutoLoadSaveState == 3);
+
 	if (System_GetPropertyBool(SYSPROP_HAS_KEYBOARD))
 		systemSettings->Add(new CheckBox(&g_Config.bBypassOSKWithKeyboard, sy->T("Use system native keyboard")));
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -998,8 +998,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(ms->T("Networking")));
 
-	Choice *wiki = networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page"), ImageID("I_LINK_OUT")));
-	wiki->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
+	networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page")))->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
 
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
 	networkingSettings->Add(new MacAddressChooser(GetRequesterToken(), gamePath_, &g_Config.sMACAddress, n->T("Change Mac Address"), screenManager()));
@@ -1054,7 +1053,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	qc->SetEnabledPtr(&g_Config.bEnableNetworkChat);
 #endif
 
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KeyInputFlags::CHAR support is added
+#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KEY_CHAR support is added
 	PopupTextInputChoice *qc1 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat0, n->T("Quick Chat 1"), "", 32, screenManager()));
 	PopupTextInputChoice *qc2 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat1, n->T("Quick Chat 2"), "", 32, screenManager()));
 	PopupTextInputChoice *qc3 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat2, n->T("Quick Chat 3"), "", 32, screenManager()));
@@ -1203,6 +1202,12 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	static const char *positions[] = { "None", "Bottom Left", "Bottom Center", "Bottom Right", "Top Left", "Top Center", "Top Right", "Center Left", "Center Right" };
 
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iNotificationPos, sy->T("Notification screen position"), positions, -1, ARRAY_SIZE(positions), I18NCat::DIALOG, screenManager()));
+
+	// How many savestate slots to show in the pause menu.
+	// Limit between 1 and SaveState::NUM_SLOTS (configured in core). Default is 10.
+	int maxSlots = SaveState::NUM_SLOTS;
+	PopupSliderChoice *saveSlotsChoice = systemSettings->Add(new PopupSliderChoice(&g_Config.iNumSaveStateSlots, 1, maxSlots, 10, sy->T("Savestate slots in pause menu"), screenManager()));
+	saveSlotsChoice->SetZeroLabel(sy->T("1"));
 
 	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves", "Moving background", "Bouncing icon", "Colored floating symbols" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iBackgroundAnimation, sy->T("UI background animation"), backgroundAnimations, 0, ARRAY_SIZE(backgroundAnimations), I18NCat::SYSTEM, screenManager()));
@@ -1869,10 +1874,10 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	progressView_->SetVisibility(UI::V_GONE);
 }
 
-void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags) {
+void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
 	auto oldView = UI::GetFocusedView();
 	UI::SetFocusedView(addrView_);
-	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KeyInputFlags::DOWN | flags };
+	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KEY_DOWN | flags };
 	addrView_->Key(fakeKey);
 	UI::SetFocusedView(oldView);
 }
@@ -1880,12 +1885,12 @@ void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags
 void HostnameSelectScreen::OnNumberClick(UI::EventParams &e) {
 	std::string text = e.v ? e.v->Tag() : "";
 	if (text.length() == 1 && text[0] >= '0' && text[0] <= '9') {
-		SendEditKey((InputKeyCode)text[0], KeyInputFlags::CHAR);  // ASCII for digits match keycodes.
+		SendEditKey((InputKeyCode)text[0], KEY_CHAR);  // ASCII for digits match keycodes.
 	}
 }
 
 void HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
-	SendEditKey((InputKeyCode)'.', KeyInputFlags::CHAR);
+	SendEditKey((InputKeyCode)'.', KEY_CHAR);
 }
 
 void HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -998,7 +998,8 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(ms->T("Networking")));
 
-	networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page")))->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
+	Choice *wiki = networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page"), ImageID("I_LINK_OUT")));
+	wiki->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
 
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
 	networkingSettings->Add(new MacAddressChooser(GetRequesterToken(), gamePath_, &g_Config.sMACAddress, n->T("Change Mac Address"), screenManager()));
@@ -1053,7 +1054,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	qc->SetEnabledPtr(&g_Config.bEnableNetworkChat);
 #endif
 
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KEY_CHAR support is added
+#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KeyInputFlags::CHAR support is added
 	PopupTextInputChoice *qc1 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat0, n->T("Quick Chat 1"), "", 32, screenManager()));
 	PopupTextInputChoice *qc2 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat1, n->T("Quick Chat 2"), "", 32, screenManager()));
 	PopupTextInputChoice *qc3 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat2, n->T("Quick Chat 3"), "", 32, screenManager()));
@@ -1367,7 +1368,6 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));
-	systemSettings->Add(new PopupSliderChoice(&g_Config.iSaveStateSlotAmount, 1, 100, 5, sy->T("Savestate slot amount"), screenManager()));
 	static const char *autoLoadSaveStateChoices[] = { "Off", "Oldest Save", "Newest Save", "Slot 1", "Slot 2", "Slot 3", "Slot 4", "Slot 5" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iAutoLoadSaveState, sy->T("Auto Load Savestate"), autoLoadSaveStateChoices, 0, ARRAY_SIZE(autoLoadSaveStateChoices), I18NCat::SYSTEM, screenManager()));
 	if (System_GetPropertyBool(SYSPROP_HAS_KEYBOARD))
@@ -1869,10 +1869,10 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	progressView_->SetVisibility(UI::V_GONE);
 }
 
-void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
+void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags) {
 	auto oldView = UI::GetFocusedView();
 	UI::SetFocusedView(addrView_);
-	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KEY_DOWN | flags };
+	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KeyInputFlags::DOWN | flags };
 	addrView_->Key(fakeKey);
 	UI::SetFocusedView(oldView);
 }
@@ -1880,12 +1880,12 @@ void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
 void HostnameSelectScreen::OnNumberClick(UI::EventParams &e) {
 	std::string text = e.v ? e.v->Tag() : "";
 	if (text.length() == 1 && text[0] >= '0' && text[0] <= '9') {
-		SendEditKey((InputKeyCode)text[0], KEY_CHAR);  // ASCII for digits match keycodes.
+		SendEditKey((InputKeyCode)text[0], KeyInputFlags::CHAR);  // ASCII for digits match keycodes.
 	}
 }
 
 void HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
-	SendEditKey((InputKeyCode)'.', KEY_CHAR);
+	SendEditKey((InputKeyCode)'.', KeyInputFlags::CHAR);
 }
 
 void HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -998,7 +998,8 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(ms->T("Networking")));
 
-	networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page")))->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
+	Choice *wiki = networkingSettings->Add(new Choice(n->T("Open PPSSPP Multiplayer Wiki Page"), ImageID("I_LINK_OUT")));
+	wiki->OnClick.Handle(this, &GameSettingsScreen::OnAdhocGuides);
 
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableWlan, n->T("Enable networking", "Enable networking/wlan (beta)")));
 	networkingSettings->Add(new MacAddressChooser(GetRequesterToken(), gamePath_, &g_Config.sMACAddress, n->T("Change Mac Address"), screenManager()));
@@ -1053,7 +1054,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	qc->SetEnabledPtr(&g_Config.bEnableNetworkChat);
 #endif
 
-#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KEY_CHAR support is added
+#if !defined(MOBILE_DEVICE) && !defined(USING_QT_UI)  // TODO: Add all platforms where KeyInputFlags::CHAR support is added
 	PopupTextInputChoice *qc1 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat0, n->T("Quick Chat 1"), "", 32, screenManager()));
 	PopupTextInputChoice *qc2 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat1, n->T("Quick Chat 2"), "", 32, screenManager()));
 	PopupTextInputChoice *qc3 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat2, n->T("Quick Chat 3"), "", 32, screenManager()));
@@ -1869,10 +1870,10 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	progressView_->SetVisibility(UI::V_GONE);
 }
 
-void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
+void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, KeyInputFlags flags) {
 	auto oldView = UI::GetFocusedView();
 	UI::SetFocusedView(addrView_);
-	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KEY_DOWN | flags };
+	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KeyInputFlags::DOWN | flags };
 	addrView_->Key(fakeKey);
 	UI::SetFocusedView(oldView);
 }
@@ -1880,12 +1881,12 @@ void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
 void HostnameSelectScreen::OnNumberClick(UI::EventParams &e) {
 	std::string text = e.v ? e.v->Tag() : "";
 	if (text.length() == 1 && text[0] >= '0' && text[0] <= '9') {
-		SendEditKey((InputKeyCode)text[0], KEY_CHAR);  // ASCII for digits match keycodes.
+		SendEditKey((InputKeyCode)text[0], KeyInputFlags::CHAR);  // ASCII for digits match keycodes.
 	}
 }
 
 void HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
-	SendEditKey((InputKeyCode)'.', KEY_CHAR);
+	SendEditKey((InputKeyCode)'.', KeyInputFlags::CHAR);
 }
 
 void HostnameSelectScreen::OnDeleteClick(UI::EventParams &e) {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -342,7 +342,7 @@ GamePauseScreen::~GamePauseScreen() {
 }
 
 bool GamePauseScreen::key(const KeyInput &key) {
-	if (!UIScreen::key(key) && (key.flags & KEY_DOWN)) {
+	if (!UIScreen::key(key) && (key.flags & KeyInputFlags::DOWN)) {
 		// Special case to be able to unpause with a bound pause key.
 		// Normally we can't bind keys used in the UI.
 		InputMapping mapping(key.deviceId, key.keyCode);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -362,12 +362,10 @@ bool GamePauseScreen::key(const KeyInput &key) {
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems) {
 	auto pa = GetI18NCategory(I18NCat::PAUSE);
 
-	static const int NUM_SAVESLOTS = 5;
-
 	using namespace UI;
 
 	leftColumnItems->SetSpacing(10.0);
-	for (int i = 0; i < NUM_SAVESLOTS; i++) {
+	for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
 		SaveSlotView *slot = leftColumnItems->Add(new SaveSlotView(gamePath_, i, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Gravity::G_HCENTER, Margins(0,0,0,0))));
 		slot->OnStateLoaded.Handle(this, &GamePauseScreen::OnState);
 		slot->OnStateSaved.Handle(this, &GamePauseScreen::OnState);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -342,7 +342,7 @@ GamePauseScreen::~GamePauseScreen() {
 }
 
 bool GamePauseScreen::key(const KeyInput &key) {
-	if (!UIScreen::key(key) && (key.flags & KEY_DOWN)) {
+	if (!UIScreen::key(key) && (key.flags & KeyInputFlags::DOWN)) {
 		// Special case to be able to unpause with a bound pause key.
 		// Normally we can't bind keys used in the UI.
 		InputMapping mapping(key.deviceId, key.keyCode);
@@ -362,10 +362,12 @@ bool GamePauseScreen::key(const KeyInput &key) {
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems) {
 	auto pa = GetI18NCategory(I18NCat::PAUSE);
 
+	static const int NUM_SAVESLOTS = 5;
+
 	using namespace UI;
 
 	leftColumnItems->SetSpacing(10.0);
-	for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
+	for (int i = 0; i < NUM_SAVESLOTS; i++) {
 		SaveSlotView *slot = leftColumnItems->Add(new SaveSlotView(gamePath_, i, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Gravity::G_HCENTER, Margins(0,0,0,0))));
 		slot->OnStateLoaded.Handle(this, &GamePauseScreen::OnState);
 		slot->OnStateSaved.Handle(this, &GamePauseScreen::OnState);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -192,7 +192,7 @@ void ScreenshotViewScreen::OnSetAutoLoadStateSlot(UI::EventParams& e) {
 	if (!NetworkWarnUserIfOnlineAndCantSavestate()) {
 		g_Config.iCurrentStateSlot = slot_;
 		g_Config.iSaveStateAutoLoadSlot = slot_ + 1;
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_BACK);
 	}
 }
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -266,10 +266,17 @@ SaveSlotView::SaveSlotView(const Path &gameFilename, int slot, UI::LayoutParams 
 	autoloadStateButton_ = buttons->Add(new Button(pa->T("Set Auto Load"), new LinearLayoutParams(0.0, Gravity::G_VCENTER)));
 	autoloadStateButton_->OnClick.Handle(this, &SaveSlotView::OnSetAutoLoadStateSlot);
 
-	if (g_Config.bShowSetAutoLoadButton)
+	if (g_Config.bShowSetAutoLoadButton) {
 		autoloadStateButton_->SetVisibility(UI::V_VISIBLE);
-	else
+		if (g_Config.iSaveStateAutoLoadSlot == slot_ + 1) {
+			autoloadStateButton_->SetEnabled(false);
+		}
+		else {
+			autoloadStateButton_->SetEnabled(true);
+		}
+	} else {
 		autoloadStateButton_->SetVisibility(UI::V_GONE);
+	}
 
 	fv->OnClick.Add([this](UI::EventParams &e) {
 		e.v = this;

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -342,7 +342,7 @@ GamePauseScreen::~GamePauseScreen() {
 }
 
 bool GamePauseScreen::key(const KeyInput &key) {
-	if (!UIScreen::key(key) && (key.flags & KeyInputFlags::DOWN)) {
+	if (!UIScreen::key(key) && (key.flags & KEY_DOWN)) {
 		// Special case to be able to unpause with a bound pause key.
 		// Normally we can't bind keys used in the UI.
 		InputMapping mapping(key.deviceId, key.keyCode);
@@ -362,12 +362,10 @@ bool GamePauseScreen::key(const KeyInput &key) {
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems) {
 	auto pa = GetI18NCategory(I18NCat::PAUSE);
 
-	static const int NUM_SAVESLOTS = 5;
-
 	using namespace UI;
 
 	leftColumnItems->SetSpacing(10.0);
-	for (int i = 0; i < NUM_SAVESLOTS; i++) {
+	for (int i = 0; i < g_Config.iSaveStateSlotAmount; i++) {
 		SaveSlotView *slot = leftColumnItems->Add(new SaveSlotView(gamePath_, i, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Gravity::G_HCENTER, Margins(0,0,0,0))));
 		slot->OnStateLoaded.Handle(this, &GamePauseScreen::OnState);
 		slot->OnStateSaved.Handle(this, &GamePauseScreen::OnState);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -342,7 +342,7 @@ GamePauseScreen::~GamePauseScreen() {
 }
 
 bool GamePauseScreen::key(const KeyInput &key) {
-	if (!UIScreen::key(key) && (key.flags & KEY_DOWN)) {
+	if (!UIScreen::key(key) && (key.flags & KeyInputFlags::DOWN)) {
 		// Special case to be able to unpause with a bound pause key.
 		// Normally we can't bind keys used in the UI.
 		InputMapping mapping(key.deviceId, key.keyCode);
@@ -362,13 +362,12 @@ bool GamePauseScreen::key(const KeyInput &key) {
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems) {
 	auto pa = GetI18NCategory(I18NCat::PAUSE);
 
+	static const int NUM_SAVESLOTS = 5;
+
 	using namespace UI;
 
-	// Number of visual save slots to display in the pause menu. Clamped to valid range.
-	int numSaveSlots = std::max(1, std::min(g_Config.iNumSaveStateSlots, SaveState::NUM_SLOTS));
-
 	leftColumnItems->SetSpacing(10.0);
-	for (int i = 0; i < numSaveSlots; i++) {
+	for (int i = 0; i < NUM_SAVESLOTS; i++) {
 		SaveSlotView *slot = leftColumnItems->Add(new SaveSlotView(gamePath_, i, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Gravity::G_HCENTER, Margins(0,0,0,0))));
 		slot->OnStateLoaded.Handle(this, &GamePauseScreen::OnState);
 		slot->OnStateSaved.Handle(this, &GamePauseScreen::OnState);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -342,7 +342,7 @@ GamePauseScreen::~GamePauseScreen() {
 }
 
 bool GamePauseScreen::key(const KeyInput &key) {
-	if (!UIScreen::key(key) && (key.flags & KeyInputFlags::DOWN)) {
+	if (!UIScreen::key(key) && (key.flags & KEY_DOWN)) {
 		// Special case to be able to unpause with a bound pause key.
 		// Normally we can't bind keys used in the UI.
 		InputMapping mapping(key.deviceId, key.keyCode);
@@ -362,12 +362,13 @@ bool GamePauseScreen::key(const KeyInput &key) {
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems) {
 	auto pa = GetI18NCategory(I18NCat::PAUSE);
 
-	static const int NUM_SAVESLOTS = 5;
-
 	using namespace UI;
 
+	// Number of visual save slots to display in the pause menu. Clamped to valid range.
+	int numSaveSlots = std::max(1, std::min(g_Config.iNumSaveStateSlots, SaveState::NUM_SLOTS));
+
 	leftColumnItems->SetSpacing(10.0);
-	for (int i = 0; i < NUM_SAVESLOTS; i++) {
+	for (int i = 0; i < numSaveSlots; i++) {
 		SaveSlotView *slot = leftColumnItems->Add(new SaveSlotView(gamePath_, i, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Gravity::G_HCENTER, Margins(0,0,0,0))));
 		slot->OnStateLoaded.Handle(this, &GamePauseScreen::OnState);
 		slot->OnStateSaved.Handle(this, &GamePauseScreen::OnState);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1206,6 +1206,7 @@ namespace MainWindow {
 			CheckMenuItem(menu, frameskipping[i], MF_BYCOMMAND | ((i == g_Config.iFrameSkip) ? MF_CHECKED : MF_UNCHECKED));
 		}
 
+		// Obsolete because of adjustable savestate amount?
 		static const int savestateSlot[] = {
 			ID_FILE_SAVESTATE_SLOT_1,
 			ID_FILE_SAVESTATE_SLOT_2,
@@ -1220,9 +1221,11 @@ namespace MainWindow {
 		else if (g_Config.iCurrentStateSlot >= g_Config.iSaveStateSlotAmount)
 			g_Config.iCurrentStateSlot = g_Config.iSaveStateSlotAmount - 1;
 
+
 		for (int i = 0; i < ARRAY_SIZE(savestateSlot); i++) {
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | ((i == g_Config.iCurrentStateSlot) ? MF_CHECKED : MF_UNCHECKED));
-		}
+		} 
+
 
 #if !PPSSPP_API(ANY_GL)
 		EnableMenuItem(menu, ID_DEBUG_GEDEBUGGER, MF_GRAYED);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1217,8 +1217,8 @@ namespace MainWindow {
 		if (g_Config.iCurrentStateSlot < 0)
 			g_Config.iCurrentStateSlot = 0;
 
-		else if (g_Config.iCurrentStateSlot >= SaveState::NUM_SLOTS)
-			g_Config.iCurrentStateSlot = SaveState::NUM_SLOTS - 1;
+		else if (g_Config.iCurrentStateSlot >= g_Config.iSaveStateSlotAmount)
+			g_Config.iCurrentStateSlot = g_Config.iSaveStateSlotAmount - 1;
 
 		for (int i = 0; i < ARRAY_SIZE(savestateSlot); i++) {
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | ((i == g_Config.iCurrentStateSlot) ? MF_CHECKED : MF_UNCHECKED));

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1217,8 +1217,8 @@ namespace MainWindow {
 		if (g_Config.iCurrentStateSlot < 0)
 			g_Config.iCurrentStateSlot = 0;
 
-		else if (g_Config.iCurrentStateSlot >= g_Config.iSaveStateSlotAmount)
-			g_Config.iCurrentStateSlot = g_Config.iSaveStateSlotAmount - 1;
+		else if (g_Config.iCurrentStateSlot >= SaveState::NUM_SLOTS)
+			g_Config.iCurrentStateSlot = SaveState::NUM_SLOTS - 1;
 
 		for (int i = 0; i < ARRAY_SIZE(savestateSlot); i++) {
 			CheckMenuItem(menu, savestateSlot[i], MF_BYCOMMAND | ((i == g_Config.iCurrentStateSlot) ? MF_CHECKED : MF_UNCHECKED));


### PR DESCRIPTION
I'm new to GitHub, so you may ignore the first few accidental commits and pushes. This may be a trivial change / pull request, but this is also one I was hoping to have been implemented already initially due to me being frustrated with the lack of savestate slots (only 5 slots), which is when I took some initiative to modify the emulator code to my wants. These changes may also serve as a foundation for other Quality Of Life updates related to the use of savestates.
Here are the changes summarized:

- (from the pull request title) Ability to adjust the number of savestate slots (from the default 5 slots, up to 100 slots)
- Altered the auto-load logic to account for the adjustable savestate slot amount
- Added some logic in the Pause Menu to easily set the auto-load slot from both the screenshot view and the slot view (the "Set Auto Load" slot view button can be disabled in the settings)
- Append to the date string (in the pause menu's slot view) to show if the selected slot is the auto-load slot (without directly modifying the date string itself)
- Made the savestate settings into a separate section in the system settings instead of being lumped with the general settings section
- Made the previously unused HideStateWarnings config into a checkbox setting for savestate settings

I have yet to change the savestate settings in the menu bar to account for these changes and some other small things, which should not be a problem for now.