### PR TITLE
Fix #19398 , provide native window from sdl2 to eglCreateWindowSurface

### DIFF
--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -112,7 +112,7 @@ static int8_t EGL_Open(SDL_Window *window) {
 #if SDL_VERSION_ATLEAST(2, 0, 2) && defined(SDL_VIDEO_DRIVER_WAYLAND)
 		case SDL_SYSWM_WAYLAND:
 			g_Display = (EGLNativeDisplayType)sysInfo.info.wl.display;
-			g_Window = (EGLNativeWindowType)sysInfo.info.wl.shell_surface;
+			g_Window = (EGLNativeWindowType)sysInfo.info.wl.egl_window;
 			break;
 #endif
 #if SDL_VERSION_ATLEAST(2, 0, 5) && defined(SDL_VIDEO_DRIVER_VIVANTE)


### PR DESCRIPTION
#19398

This **should** be correct going by [SDL2 headers](https://github.com/libsdl-org/SDL/blob/3eba0b6f8a21392f47b1b53a476e7633048de9b1/include/SDL_syswm.h#L298), since egl_window is labeled as native egl window, [and that's what eglCreateWindowSurface wants](https://registry.khronos.org/EGL/sdk/docs/man/html/eglCreateWindowSurface.xhtml)

This change allows PPSSPPSDL to create a window on my aarch64 wayland setup, but it created a transparent window, still trying to figure out whether it's a sdl2-compat/SDL3/libhybris/Phosh issue

<img width="2246" height="1080" alt="19700101_01h12m16s_grim" src="https://github.com/user-attachments/assets/876fffbd-7026-4bbc-be28-f37f68f000f9" />

@KianTechHub can you give this a test?

Edit: the change works correctly on my desktop, so the transparency is likely an issue outside of PPSSPP
<img width="1902" height="1133" alt="image" src="https://github.com/user-attachments/assets/fe57458d-7fcf-4f16-b0e0-1ba7d0820635" />
