### PR TITLE
Update DNS for EA games

### DIFF
--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -17,10 +17,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspuefa07.ea.com": "ablondel.ddns.net"
+				"pspuefa07.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -41,10 +41,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspfifa07.ea.com": "ablondel.ddns.net"
+				"pspfifa07.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -67,10 +67,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspfifa08.ea.com": "ablondel.ddns.net"
+				"pspfifa08.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -94,10 +94,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspfifa09.ea.com": "ablondel.ddns.net"
+				"pspfifa09.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -123,10 +123,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspfifa10.ea.com": "ablondel.ddns.net"
+				"pspfifa10.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -151,10 +151,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspuefa06.ea.com": "ablondel.ddns.net"
+				"pspuefa06.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -171,10 +171,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspworldcup10.ea.com": "ablondel.ddns.net"
+				"pspworldcup10.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -194,10 +194,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspkok06.ea.com": "ablondel.ddns.net"
+				"pspkok06.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -214,10 +214,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspmadden07.ea.com": "ablondel.ddns.net"
+				"pspmadden07.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -233,10 +233,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspmadden08.ea.com": "ablondel.ddns.net"
+				"pspmadden08.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -253,10 +253,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspmadden09.ea.com": "ablondel.ddns.net"
+				"pspmadden09.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -274,10 +274,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspmadden10.ea.com": "ablondel.ddns.net"
+				"pspmadden10.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -294,7 +294,7 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "81.49.107.142",
-			"dyn_dns": "ablondel.ddns.net",
+			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspmoh07.ea.com": "81.49.107.142",
 				"tos.ea.com": "81.49.107.142"
@@ -324,11 +324,11 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspmoh08.ea.com": "ablondel.ddns.net",
-				"tos.ea.com": "ablondel.ddns.net"
+				"pspmoh08.ea.com": "eahub.eu",
+				"tos.ea.com": "eahub.eu"
 			},
 			"score": 1,
 			"known_working_ids": [
@@ -350,10 +350,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnba06.ea.com": "ablondel.ddns.net"
+				"pspnba06.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -369,10 +369,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnba07.ea.com": "ablondel.ddns.net"
+				"pspnba07.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -388,10 +388,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnba08.ea.com": "ablondel.ddns.net"
+				"pspnba08.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -407,10 +407,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspncaa07.ea.com": "ablondel.ddns.net"
+				"pspncaa07.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -426,10 +426,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnfs06.ea.com": "ablondel.ddns.net"
+				"pspnfs06.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -447,10 +447,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnfs07.ea.com": "ablondel.ddns.net"
+				"pspnfs07.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -468,10 +468,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnfs08.ea.com": "ablondel.ddns.net"
+				"pspnfs08.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -489,10 +489,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnfs09.ea.com": "ablondel.ddns.net"
+				"pspnfs09.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -509,10 +509,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"pspnhl07.ea.com": "ablondel.ddns.net"
+				"pspnhl07.ea.com": "eahub.eu"
 			},
 			"score": 4,
 			"known_working_ids": [
@@ -529,10 +529,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"psptw07.ea.com": "ablondel.ddns.net"
+				"psptw07.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -550,10 +550,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"psptw08.ea.com": "ablondel.ddns.net"
+				"psptw08.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -571,10 +571,10 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "ablondel.ddns.net",
-			"dyn_dns": "ablondel.ddns.net",
+			"dns": "eahub.eu",
+			"dyn_dns": "eahub.eu",
 			"domains": {
-				"psptw10.ea.com": "ablondel.ddns.net"
+				"psptw10.ea.com": "eahub.eu"
 			},
 			"score": 5,
 			"known_working_ids": [


### PR DESCRIPTION
_The server is now hosted on a VPS (static IP - 51.254.141.170), and a domain name has been registered (eahub.eu)_