### PR TITLE
Implement a unicode-char keyboard input event on Android.

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1271,6 +1271,18 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyUp(JNIEnv *, jclass, jin
 	return NativeKey(keyInput);
 }
 
+extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyChar(JNIEnv *, jclass, jint deviceId, jint unicodeChar) {
+	if (!renderer_inited) {
+		return false; // could probably return true here too..
+	}
+
+	KeyInput keyInput;
+	keyInput.deviceId = (InputDeviceID)deviceId;
+	keyInput.unicodeChar = unicodeChar;
+	keyInput.flags = KeyInputFlags::CHAR;
+	return NativeKey(keyInput);
+}
+
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 		JNIEnv *env, jclass, jint deviceId, jintArray axisIds, jfloatArray values, jint count) {
 	if (!renderer_inited)

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -51,6 +51,7 @@ public class NativeApp {
 
 	public static native boolean keyDown(int deviceId, int key, boolean isRepeat);
 	public static native boolean keyUp(int deviceId, int key);
+	public static native boolean keyChar(int deviceId, int unicodeChar);
 
 	public static native void joystickAxis(int deviceId, int []axis, float []value, int count);
 

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -1151,14 +1151,25 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 		if (!passThrough) {
 			switch (event.getAction()) {
 				case KeyEvent.ACTION_DOWN:
-					Log.i(TAG, "KeyEvent Down");
+				{
+					int unicode = event.getUnicodeChar();
+					if (unicode != 0 && !Character.isISOControl(unicode)) {
+						char c = (char) unicode;
+						Log.i(TAG, "Key char event " + unicode);
+						// Handle alphanumeric character
+						NativeApp.keyChar(NativeApp.DEVICE_ID_KEYBOARD, (int)c);
+						return true;
+					}
+
+					// Log.i(TAG, "KeyEvent Down");
 					if (state.onKeyDown(event)) {
 						return true;
 					}
 					break;
+				}
 
 				case KeyEvent.ACTION_UP:
-					Log.i(TAG, "KeyEvent Up");
+					// Log.i(TAG, "KeyEvent Up");
 					if (state.onKeyUp(event)) {
 						return true;
 					}


### PR DESCRIPTION
This fixes the ImDebugger when trying to use it with a bluetooth keyboard, and also fixes other types of text input from bluetooth keybaords on Android.

However, the ImDebugger is currently very crash-prone on Android since it crashes on layout changes. This will be fixed separately.

Fixes part of #19741 