### PR TITLE
Rework listing of savestates - a single scan operation instead of lots of File::Exists and GetFileInfo calls.

### DIFF
--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -18,6 +18,7 @@ struct FileInfo {
 	bool isWritable = false;
 	uint64_t size = 0;
 
+
 	uint64_t atime = 0;
 	uint64_t mtime = 0;
 	uint64_t ctime = 0;

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -74,7 +74,7 @@ namespace SaveState {
 	int GetOldestSlot(std::string_view gamePrefix);
 	
 	std::string GetSlotDateAsString(std::string_view gamePrefix, int slot);
-	Path GenerateSaveSlotFilename(std::string_view gamePrefix, int slot, const char *extension);
+	Path GenerateSaveSlotPath(std::string_view gamePrefix, int slot, const char *extension);
 
 	std::string GetTitle(const Path &filename);
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -362,15 +362,13 @@ void EmuScreen::bootComplete() {
 
 	if (g_paramSFO.IsValid()) {
 		g_Discord.SetPresenceGame(SanitizeString(g_paramSFO.GetValueString("TITLE"), StringRestriction::NoLineBreaksOrSpecials));
-	} else {
-		g_Discord.SetPresenceGame(sc->T("Untitled PSP game"));
-	}
-
-	if (g_paramSFO.IsValid()) {
 		std::string gameTitle = SanitizeString(g_paramSFO.GetValueString("TITLE"), StringRestriction::NoLineBreaksOrSpecials, 0, 32);
 		std::string id = g_paramSFO.GetValueString("DISC_ID");
 		extraAssertInfoStr_ = id + " " + gameTitle;
 		SetExtraAssertInfo(extraAssertInfoStr_.c_str());
+		SaveState::Rescan(SaveState::GetGamePrefix(g_paramSFO));
+	} else {
+		g_Discord.SetPresenceGame(sc->T("Untitled PSP game"));
 	}
 
 	UpdateUIState(UISTATE_INGAME);
@@ -1485,7 +1483,7 @@ void EmuScreen::update() {
 
 			Path fn;
 			if (SaveState::HasSaveInSlot(gamePrefix, currentSlot)) {
-				fn = SaveState::GenerateSaveSlotFilename(gamePrefix, currentSlot, SaveState::SCREENSHOT_EXTENSION);
+				fn = SaveState::GenerateSaveSlotPath(gamePrefix, currentSlot, SaveState::SCREENSHOT_EXTENSION);
 			}
 
 			saveStatePreview_->SetFilename(fn);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -229,7 +229,7 @@ private:
 SaveSlotView::SaveSlotView(std::string_view saveStatePrefix, int slot, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams), slot_(slot), saveStatePrefix_(saveStatePrefix) {
 	using namespace UI;
 
-	screenshotFilename_ = SaveState::GenerateSaveSlotFilename(saveStatePrefix_, slot, SaveState::SCREENSHOT_EXTENSION);
+	screenshotFilename_ = SaveState::GenerateSaveSlotPath(saveStatePrefix_, slot, SaveState::SCREENSHOT_EXTENSION);
 
 	std::string number = StringFromFormat("%d", slot + 1);
 	Add(new Spacer(5));
@@ -344,6 +344,7 @@ GamePauseScreen::GamePauseScreen(const Path &filename, bool bootPending)
 	std::string assertStr = "PauseScreen: " + filename.GetFilename();
 	SetExtraAssertInfo(assertStr.c_str());
 	saveStatePrefix_ = SaveState::GetGamePrefix(g_paramSFO);
+	SaveState::Rescan(saveStatePrefix_);
 }
 
 GamePauseScreen::~GamePauseScreen() {


### PR DESCRIPTION
Needed to improve scalability on Android for when we increase the number of states, we don't want bringing up the pause screen to be stuttery even on very low-end.