### PR TITLE
Fix libretro builds for iOS and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1676,7 +1676,7 @@ if(ANDROID)
 	endif()
 endif()
 
-if (IOS)
+if (IOS AND NOT LIBRETRO)
 	set(nativeExtra ${nativeExtra} ${NativeAppSource})
 endif()
 

--- a/libretro/LibretroD3D11Context.h
+++ b/libretro/LibretroD3D11Context.h
@@ -6,7 +6,7 @@
 
 class LibretroD3D11Context : public LibretroHWRenderContext {
 public:
-   LibretroD3D11Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_DIRECT3D, 11) {}
+   LibretroD3D11Context() : LibretroHWRenderContext(RETRO_HW_CONTEXT_D3D11, 11) {}
    bool Init() override;
 
    void SwapBuffers() override;

--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -133,7 +133,7 @@ LibretroGraphicsContext *LibretroGraphicsContext::CreateGraphicsContext() {
 #endif
 
 #ifdef _WIN32
-	if (preferred == RETRO_HW_CONTEXT_DUMMY || preferred == RETRO_HW_CONTEXT_DIRECT3D) {
+	if (preferred == RETRO_HW_CONTEXT_DUMMY || preferred == RETRO_HW_CONTEXT_D3D11) {
 		ctx = new LibretroD3D11Context();
 
 		if (ctx->Init()) {


### PR DESCRIPTION
The iOS and Windows libretro builds have been broken since #21092.

On iOS, libretro builds are broken because CMake currently includes the files from `NativeAppSource` in iOS libretro builds but not in any other libretro builds. These files are not required by any of the libretro builds and do not build anymore in libretro builds after #21092, so I removed them from the iOS libretro builds.

On Windows, libretro builds are broken because of missing Direct3D-related header files in libretro-common. I have added the missing header files to libretro-common in libretro/libretro-common#224 and updated the libretro-common submodule.