### PR TITLE
fix proAdhocServer multiinstance bug

### DIFF
--- a/Common/Net/Resolve.h
+++ b/Common/Net/Resolve.h
@@ -18,6 +18,8 @@ enum class DNSType {
 	IPV6 = 2,
 };
 
+bool HostPortExists(const std::string& host, int port, int timeout_ms);
+
 bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error, DNSType type = DNSType::ANY);
 void DNSResolveFree(addrinfo *res);
 bool GetLocalIP4List(std::vector<std::string>& IP4s);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1011,7 +1011,7 @@ static const ConfigSetting controlSettings[] = {
 static const ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", SETTING(g_Config, bEnableWlan), false, CfgFlag::PER_GAME),
 	ConfigSetting("EnableAdhocServer", SETTING(g_Config, bEnableAdhocServer), false, CfgFlag::PER_GAME),
-	ConfigSetting("proAdhocServer", SETTING(g_Config, proAdhocServer), "socom.cc", CfgFlag::PER_GAME),
+	ConfigSetting("proAdhocServer", SETTING(g_Config, sProAdhocServer), "socom.cc", CfgFlag::PER_GAME),
 	ConfigSetting("proAdhocServerList", SETTING(g_Config, proAdhocServerList), &defaultProAdhocServerList, CfgFlag::DEFAULT),
 	ConfigSetting("PortOffset", SETTING(g_Config, iPortOffset), 10000, CfgFlag::PER_GAME),
 	ConfigSetting("PrimaryDNSServer", SETTING(g_Config, sInfrastructureDNSServer), "67.222.156.250", CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -538,7 +538,7 @@ public:
 
 	// Networking
 	bool bEnableAdhocServer;
-	std::string proAdhocServer;
+	std::string sProAdhocServer;
 	std::vector<std::string> proAdhocServerList;
 	std::string sInfrastructureDNSServer;
 	std::string sInfrastructureUsername;  // Username used for Infrastructure play. Different restrictions.

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1353,9 +1353,9 @@ int friendFinder() {
 	addrinfo* resolved = nullptr;
 	std::string err;
 	g_adhocServerIP.in.sin_addr.s_addr = INADDR_NONE;
-	if (g_Config.bEnableWlan && !net::DNSResolve(g_Config.proAdhocServer, "", &resolved, err)) {
-		ERROR_LOG(Log::sceNet, "DNS Error Resolving %s\n", g_Config.proAdhocServer.c_str());
-		g_OSD.Show(OSDType::MESSAGE_ERROR, std::string(n->T("DNS Error Resolving")) + g_Config.proAdhocServer);
+	if (g_Config.bEnableWlan && !net::DNSResolve(g_Config.sProAdhocServer, "", &resolved, err)) {
+		ERROR_LOG(Log::sceNet, "DNS Error Resolving %s\n", g_Config.sProAdhocServer.c_str());
+		g_OSD.Show(OSDType::MESSAGE_ERROR, std::string(n->T("DNS Error Resolving")) + g_Config.sProAdhocServer);
 	}
 	if (resolved) {
 		for (auto ptr = resolved; ptr != NULL; ptr = ptr->ai_next) {
@@ -2238,7 +2238,7 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 			sleep_ms(10, "pro-adhoc-socket-poll");
 		}
 		if (!done) {
-			ERROR_LOG(Log::sceNet, "Socket error (%i) when connecting to AdhocServer [%s/%s:%u]", errorcode, g_Config.proAdhocServer.c_str(), ip2str(g_adhocServerIP.in.sin_addr).c_str(), ntohs(g_adhocServerIP.in.sin_port));
+			ERROR_LOG(Log::sceNet, "Socket error (%i) when connecting to AdhocServer [%s/%s:%u]", errorcode, g_Config.sProAdhocServer.c_str(), ip2str(g_adhocServerIP.in.sin_addr).c_str(), ntohs(g_adhocServerIP.in.sin_port));
 			g_OSD.Show(OSDType::MESSAGE_ERROR, std::string(n->T("Failed to connect to Adhoc Server")) + " (" + std::string(n->T("Error")) + ": " + std::to_string(errorcode) + ")");
 			return iResult;
 		}

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -36,9 +36,11 @@
 
 #include "Common/File/FileUtil.h"
 #include "Common/TimeUtil.h"
+#include "Common/Net/Resolve.h"
 #include "Core/Util/PortManager.h"
 #include "Core/Instance.h"
 #include "Core/Core.h"
+#include "Core/Config.h"
 #include "Core/HLE/proAdhocServer.h"
 
 #ifdef _WIN32
@@ -344,6 +346,8 @@ static const db_productid default_productids[] = {
 	{ "ULES01432", "Full Metal Alchemist - Brotherhood" },
 	{ "ULUS10490", "GTA Chinatown Wars" },
 	{ "ULUS10160", "GTA Vice City Stories" },
+	{ "ULUS10041", "GTA Liberty City Stories" },
+	{ "ULES00151", "GTA Liberty City Stories" },
 	{ "ULUS10210", "Ghost Rider" },
 	{ "ULJS00237", "God Eater" },
 	{ "NPJH50832", "God Eater 2" },
@@ -462,6 +466,7 @@ static const db_productid default_productids[] = {
 	{ "ULJM05151", "Yu-Gi-Oh! GX Tag Force" },
 	{ "ULJM05373", "Yu-Gi-Oh! GX Tag Force 3" },
 	{ "NPUG80086", "flOw" },
+	// TODO? GTA 10160,beta,10041,00151
 };
 
 // Function Prototypes
@@ -1660,7 +1665,13 @@ int proAdhocServerThread(int port) // (int argc, char * argv[])
 	// Result
 	int result = 0;
 
-	INFO_LOG(Log::sceNet, "AdhocServer: Begin of AdhocServer Thread");
+	if (net::HostPortExists(g_Config.sProAdhocServer, SERVER_PORT, 200)) {
+		INFO_LOG(Log::sceNet, "AdhocServer: Skiped starting because the server is already available");
+		return 0;
+	}
+	else {
+		INFO_LOG(Log::sceNet, "AdhocServer: Begin of AdhocServer Thread");
+	}
 
 	// Create Signal Receiver for CTRL + C
 	//signal(SIGINT, interrupt);
@@ -1815,11 +1826,6 @@ int create_listen_socket(uint16_t port)
 		local.sin_family = AF_INET;
 		local.sin_addr.s_addr = INADDR_ANY;
 		local.sin_port = htons(port);
-
-		// Should only bind to specific IP for the 2nd or more instance of PPSSPP to prevent communication interference issue when sharing the same port. (ie. Capcom Classics Collection Remixed)
-		if (PPSSPP_ID > 1) {
-			local.sin_addr = g_localhostIP.in.sin_addr;
-		}
 
 		// Bind Local Address to Socket
 		int bindresult = bind(fd, (struct sockaddr *)&local, sizeof(local));

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -1666,7 +1666,7 @@ int proAdhocServerThread(int port) // (int argc, char * argv[])
 	int result = 0;
 
 	if (net::HostPortExists(g_Config.sProAdhocServer, SERVER_PORT, 200)) {
-		INFO_LOG(Log::sceNet, "AdhocServer: Skiped starting because the server is already available");
+		INFO_LOG(Log::sceNet, "AdhocServer: Skipped starting because the server is already available");
 		return 0;
 	}
 	else {

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -521,7 +521,7 @@ void InitLocalhostIP() {
 	g_localhostIP.in.sin_addr.s_addr = htonl(localIP);
 	g_localhostIP.in.sin_port = 0;
 
-	std::string serverStr(StripSpaces(g_Config.proAdhocServer));
+	std::string serverStr(StripSpaces(g_Config.sProAdhocServer));
 	isLocalServer = (!strcasecmp(serverStr.c_str(), "localhost") || serverStr.find("127.") == 0);
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1015,8 +1015,8 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(n->T("AdHoc server")));
 	networkingSettings->Add(new CheckBox(&g_Config.bEnableAdhocServer, n->T("Enable built-in PRO Adhoc Server", "Enable built-in PRO Adhoc Server")));
-	networkingSettings->Add(new ChoiceWithValueDisplay(&g_Config.proAdhocServer, n->T("Change proAdhocServer Address"), I18NCat::NONE))->OnClick.Add([=](UI::EventParams &) {
-		screenManager()->push(new HostnameSelectScreen(&g_Config.proAdhocServer, &g_Config.proAdhocServerList, n->T("proAdhocServer Address:")));
+	networkingSettings->Add(new ChoiceWithValueDisplay(&g_Config.sProAdhocServer, n->T("Change proAdhocServer Address"), I18NCat::NONE))->OnClick.Add([=](UI::EventParams &) {
+		screenManager()->push(new HostnameSelectScreen(&g_Config.sProAdhocServer, &g_Config.proAdhocServerList, n->T("proAdhocServer Address:")));
 	});
 	networkingSettings->Add(new SettingHint(n->T("Change proAdhocServer address hint")));
 	networkingSettings->Add(new ItemHeader(n->T("UPnP (port-forwarding)")));

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1026,7 +1026,7 @@ static void check_variables(CoreParameter &coreParam)
    char key[64] = {0};
    var.key = key;
    g_Config.sMACAddress = "";
-   g_Config.proAdhocServer = "";
+   g_Config.sProAdhocServer = "";
    for (int i = 0; i < 12; i++)
    {
       snprintf(key, sizeof(key), "ppsspp_change_mac_address%02d", i + 1);
@@ -1060,13 +1060,13 @@ static void check_variables(CoreParameter &coreParam)
 
    if (changeProAdhocServer == "IP address")
    {
-      g_Config.proAdhocServer = "";
+      g_Config.sProAdhocServer = "";
       bool leadingZero = true;
       for (int i = 0; i < 12; i++)
       {
          if (i && i % 3 == 0)
          {
-            g_Config.proAdhocServer += '.';
+            g_Config.sProAdhocServer += '.';
             leadingZero = true;
          }
 
@@ -1075,11 +1075,11 @@ static void check_variables(CoreParameter &coreParam)
             leadingZero = false; // We are either non-zero or the last digit of a byte
 
          if (! leadingZero)
-            g_Config.proAdhocServer += static_cast<char>('0' + addressPt);
+            g_Config.sProAdhocServer += static_cast<char>('0' + addressPt);
       }
    }
    else
-      g_Config.proAdhocServer = changeProAdhocServer;
+      g_Config.sProAdhocServer = changeProAdhocServer;
 
    g_Config.bTexHardwareScaling = g_Config.sTextureShaderName != "Off";
 


### PR DESCRIPTION
Fix multi-instance proAdhoc server, problem: if you open the first instance (server), the second (slave)...N, close the first, then all subsequent instances will not be able to start a valid server. To start proServer, you need to close all instances (reset PPSSPP_ID). Solution: check host availability at startup + no useless hanging thread in nonhosting instances.