### PR TITLE
Update the Android gradle plugin to version 9, upgrade rcheevos

### DIFF
--- a/Common/Net/Resolve.h
+++ b/Common/Net/Resolve.h
@@ -18,7 +18,7 @@ enum class DNSType {
 	IPV6 = 2,
 };
 
-bool HostPortExists(const std::string& host, int port, int timeout_ms);
+bool HostPortExists(const std::string &host, int port, int timeout_ms);
 
 bool DNSResolve(const std::string &host, const std::string &service, addrinfo **res, std::string &error, DNSType type = DNSType::ANY);
 void DNSResolveFree(addrinfo *res);

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -250,7 +250,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 			return false;
 		}
 		strm.next_in = (Bytef *)data.data();
-		strm.avail_in = data.size();
+		strm.avail_in = (u32)data.size();
 		strm.next_out = out_data;
 		strm.avail_out = out_size;
 		int flush = Z_NO_FLUSH;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -24,17 +24,14 @@
 #include "Common/GraphicsContext.h"
 #include "Common/System/OSD.h"
 #include "Common/VR/PPSSPPVR.h"
+#include "Common/StringUtils.h"
 
 #include "Core/Config.h"
-#include "Core/Debugger/Breakpoints.h"
-#include "Core/MemMapHelpers.h"
 #include "Core/Reporting.h"
 #include "Core/Core.h"
 #include "Core/ELF/ParamSFO.h"
 
 #include "GPU/GPUState.h"
-#include "GPU/ge_constants.h"
-#include "GPU/GeDisasm.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 #include "GPU/GLES/ShaderManagerGLES.h"
 #include "GPU/GLES/GPU_GLES.h"
@@ -114,7 +111,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	}
 
 	if (g_Config.bHardwareTessellation) {
-		// Disable hardware tessellation if device is unsupported.
+		// Log information that we disable hardware tessellation if device is unsupported.
 		if (!drawEngine_.SupportsHWTessellation()) {
 			ERROR_LOG(Log::G3D, "Hardware Tessellation is unsupported, falling back to software tessellation");
 		}
@@ -211,10 +208,8 @@ void GPU_GLES::BuildReportingInfo() {
 		glExtensions = render->GetGLString(GL_EXTENSIONS);
 	}
 
-	char temp[16384];
-	snprintf(temp, sizeof(temp), "%s (%s %s), %s (extensions: %s)", glVersion.c_str(), glVendor.c_str(), glRenderer.c_str(), glSlVersion.c_str(), glExtensions.c_str());
 	reportingPrimaryInfo_ = glVendor;
-	reportingFullInfo_ = temp;
+	reportingFullInfo_ = StringFromFormat("%s (%s %s), %s (extensions: %s)", glVersion.c_str(), glVendor.c_str(), glRenderer.c_str(), glSlVersion.c_str(), glExtensions.c_str());
 
 	Reporting::UpdateConfig();
 }

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -24,6 +24,7 @@
 #include "Common/TimeUtil.h"
 #include "Common/File/FileUtil.h"
 #include "Common/GraphicsContext.h"
+#include "Common/StringUtils.h"
 
 #include "Core/Config.h"
 #include "Core/Reporting.h"
@@ -384,10 +385,8 @@ void GPU_Vulkan::BuildReportingInfo() {
 		featureNames = featureNames.substr(2);
 	}
 
-	char temp[16384];
-	snprintf(temp, sizeof(temp), "v%08x driver v%08x (%s), vendorID=%d, deviceID=%d (features: %s)", props.apiVersion, props.driverVersion, props.deviceName, props.vendorID, props.deviceID, featureNames.c_str());
 	reportingPrimaryInfo_ = props.deviceName;
-	reportingFullInfo_ = temp;
+	reportingFullInfo_ = StringFromFormat("v%08x driver v%08x (%s), vendorID=%d, deviceID=%d (features: %s)", props.apiVersion, props.driverVersion, props.deviceName, props.vendorID, props.deviceID, featureNames.c_str());
 
 	Reporting::UpdateConfig();
 }

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1000,8 +1000,10 @@ namespace MainWindow {
 			if (rc_client_raintegration_activate_menu_item(Achievements::GetClient(), LOWORD(wParam))) {
 				break;
 			}
+			MessageBox(hWnd, L"Unhandled menu item. Did you unload RAIntegration?", L"Sorry", 0);
+#else
+			MessageBox(hWnd, L"Unhandled menu item. Please report a bug.", L"Sorry", 0);
 #endif
-			MessageBox(hWnd, L"Unhandled menu item", L"Sorry", 0);
 			break;
 		}
 	}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream
 
 plugins {
 	id("com.android.application")
-	id("org.jetbrains.kotlin.android")
 	id("com.google.protobuf")
 }
 
@@ -149,6 +148,8 @@ android {
 			isMinifyEnabled = false
 			if (project.hasProperty("RELEASE_STORE_FILE")) {
 				signingConfig = signingConfigs.getByName("release")
+			} else {
+				println("WARNING: RELEASE_STORE_FILE is missing. Release builds will be unusable.")
 			}
 		}
 	}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -117,7 +117,7 @@ android {
 		applicationId = "org.ppsspp.ppsspp"
 		// Access the git version info via the extension
 		if (gitVersionName != "unknown") {
-			println("Overriding Android Version Name, Code: $gitVersionName $gitVersionCode")
+			println("INFO: Overriding Android Version Name, Code: $gitVersionName $gitVersionCode")
 			versionName = gitVersionName
 			versionCode = gitVersionCode
 		} else {
@@ -164,24 +164,24 @@ android {
 	sourceSets {
 		getByName("main") {
 			manifest.srcFile("AndroidManifest.xml")
-			res.setSrcDirs(listOf("res"))
-			java.setSrcDirs(listOf("src"))
-			aidl.setSrcDirs(listOf("src"))
-			resources.setSrcDirs(listOf("src"))
-			assets.setSrcDirs(listOf("../assets"))
+			res.directories.add("res")
+			java.directories.add("src")
+			aidl.directories.add("src")
+			resources.directories.add("src")
+			assets.directories.add("../assets")
 		}
 		create("normal") {
-			res.setSrcDirs(listOf("normal/res"))
+			res.directories.add("normal/res")
 		}
 		create("gold") {
-			res.setSrcDirs(listOf("gold/res"))
+			res.directories.add("gold/res")
 		}
 		create("vr") {
-			res.setSrcDirs(listOf("normal/res"))
+			res.directories.add("normal/res")
 			manifest.srcFile("VRManifest.xml")
 		}
 		create("legacy") {
-			res.setSrcDirs(listOf("legacy/res"))
+			res.directories.add("legacy/res")
 		}
 	}
 	productFlavors {
@@ -286,8 +286,9 @@ androidComponents {
 	}
 }
 
+/*
 afterEvaluate {
 	android.sourceSets.getByName("main").assets.srcDirs.forEach {
 		println(it)
 	}
-}
+}*/

--- a/android/src/org/ppsspp/ppsspp/LocationHelper.java
+++ b/android/src/org/ppsspp/ppsspp/LocationHelper.java
@@ -37,6 +37,7 @@ class LocationHelper implements LocationListener {
 		mLocationEnable = false;
 	}
 
+	@SuppressWarnings("deprecation")
 	void startLocationUpdates() {
 		Log.d(TAG, "startLocationUpdates");
 		if (!mLocationEnable) {
@@ -89,6 +90,7 @@ class LocationHelper implements LocationListener {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	void stopLocationUpdates() {
 		Log.d(TAG, "stopLocationUpdates");
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -160,6 +162,7 @@ class LocationHelper implements LocationListener {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	private void onGpsStatus(int event) {
 		switch (event) {
 			case GpsStatus.GPS_EVENT_STARTED:
@@ -169,6 +172,7 @@ class LocationHelper implements LocationListener {
 			case GpsStatus.GPS_EVENT_SATELLITE_STATUS: {
 				try {
 					GpsStatus gpsStatus = mLocationManager.getGpsStatus(null);
+					if (gpsStatus == null) return;
 					Iterable<GpsSatellite> satellites = gpsStatus.getSatellites();
 
 					short index = 0;
@@ -197,10 +201,18 @@ class LocationHelper implements LocationListener {
 			return;
 		}
 		if (!tokens[GPGGA_HDOP_INDEX].isEmpty()) {
-			mHdop = Float.valueOf(tokens[GPGGA_HDOP_INDEX]);
+			try {
+				mHdop = Float.parseFloat(tokens[GPGGA_HDOP_INDEX]);
+			} catch (NumberFormatException e) {
+				// Ignore
+			}
 		}
 		if (!tokens[GPGGA_ALTITUDE_INDEX].isEmpty()) {
-			mAltitudeAboveSeaLevel = Float.valueOf(tokens[GPGGA_ALTITUDE_INDEX]);
+			try {
+				mAltitudeAboveSeaLevel = Float.parseFloat(tokens[GPGGA_ALTITUDE_INDEX]);
+			} catch (NumberFormatException e) {
+				// Ignore
+			}
 		}
 	}
 }

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -1364,7 +1364,7 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 							int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
 							String picturePath = cursor.getString(columnIndex);
 							cursor.close();
-							Log.i(TAG, "Selected picture path: " + selectedImage);
+							Log.i(TAG, "Selected picture path: " + picturePath);
 							NativeApp.sendRequestResult(requestId, true, picturePath, 0);
 						}
 					}
@@ -1629,11 +1629,11 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 			InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
 			// No idea what the point of the ApplicationWindowToken is or if it
 			// matters where we get it from...
-			inputMethodManager.toggleSoftInputFromWindow(surfView.getApplicationWindowToken(), InputMethodManager.SHOW_FORCED, 0);
+			inputMethodManager.showSoftInput(surfView, InputMethodManager.SHOW_IMPLICIT);
 			return true;
 		} else if (command.equals("hideKeyboard") && surfView != null) {
 			InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-			inputMethodManager.toggleSoftInputFromWindow(surfView.getApplicationWindowToken(), InputMethodManager.SHOW_FORCED, 0);
+			inputMethodManager.hideSoftInputFromWindow(surfView.getWindowToken(), 0);
 			return true;
 		} else if (command.equals("inputbox")) {
 			String title = "Input";
@@ -1845,6 +1845,7 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 	@Override
 	public void onNewIntent(Intent intent) {
 		super.onNewIntent(intent);
+		setIntent(intent);
 		String value = parseIntent(intent);
 		if (value != null) {
 			// TODO: Actually send a command to the native code to launch the new game.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
 	id("com.android.application") version "8.13.2" apply false
 	id("org.jetbrains.kotlin.android") version "2.2.21" apply false
-	id("com.gladed.androidgitversion") version "0.4.14" apply false
 	id("com.google.protobuf") version "0.9.5" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
 	id("com.android.application") version "9.0.0" apply false
-	id("org.jetbrains.kotlin.android") version "2.2.21" apply false
-	id("com.google.protobuf") version "0.9.5" apply false
+	id("com.google.protobuf") version "0.9.6" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-	id("com.android.application") version "8.13.2" apply false
+	id("com.android.application") version "9.0.0" apply false
 	id("org.jetbrains.kotlin.android") version "2.2.21" apply false
 	id("com.google.protobuf") version "0.9.5" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,4 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
 android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,13 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 # This suppression is only needed for the legacy build.
 android.ndk.suppressMinSdkVersionError=21
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,4 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 # This suppression is only needed for the legacy build.
 android.ndk.suppressMinSdkVersionError=21
-android.defaults.buildfeatures.resvalues=true
-android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
-android.uniquePackageNames=false
-android.dependency.useConstraints=true
-android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
 android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Prepare the Gradle setup to be as close as possible to Gradle 10-compatible, it's a major change coming this summer. Currently the final step (newDsl=true) is blocked by https://github.com/google/protobuf-gradle-plugin/issues/787 .

Update rcheevos to a new version with some bugfixes.

Remove usage of the `com.gladed.androidgitversion` plugin, replace with some kotlin code directly in the build.gradle.kts.

Update some Android library dependencies.

Some minor code cleanups.