### PR TITLE
Fix annoying issue with frameskipping settings, assorted Android cleanups

### DIFF
--- a/Common/Data/Text/I18n.cpp
+++ b/Common/Data/Text/I18n.cpp
@@ -82,7 +82,10 @@ std::string_view I18NCategory::T(std::string_view key, std::string_view def) {
 			// Too early. This is probably in desktop-ui translation.
 			return !def.empty() ? def : key;
 		}
-		INFO_LOG(Log::UI, "Missing translation [%s] %.*s (%.*s)", name_.c_str(), STR_VIEW(key), STR_VIEW(def));
+		if (key != "Font") {
+			// Font is allowed to be missing.
+			INFO_LOG(Log::UI, "Missing translation [%s] %.*s (%.*s)", name_.c_str(), STR_VIEW(key), STR_VIEW(def));
+		}
 
 		std::lock_guard<std::mutex> guard(missedKeyLock_);
 		std::string missedKey(key);
@@ -103,7 +106,9 @@ const char *I18NCategory::T_cstr(const char *key, const char *def) {
 			// Too early. This is probably in desktop-ui translation.
 			return def ? def : key;
 		}
-		INFO_LOG(Log::UI, "Missing translation %s (%s)", key, def);
+		if (key != "Font") {
+			INFO_LOG(Log::UI, "Missing translation %s (%s)", key, def);
+		}
 
 		std::lock_guard<std::mutex> guard(missedKeyLock_);
 		std::string missedKey(key);

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -882,7 +882,7 @@ void AbstractChoiceWithValueDisplay::Draw(UIContext &dc) {
 	} else {
 		Choice::Draw(dc);
 
-		if (text_.empty() && valueText.empty() && !image_.isValid()) {
+		if (iconOnly_) {
 			// In this case we only display the image of the choice. Useful for small buttons spawning a popup.
 			dc.Draw()->DrawImageRotated(ValueImage(), bounds_.centerX(), bounds_.centerY(), imgScale_, imgRot_, style.fgColor, imgFlipH_);
 			return;

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -748,6 +748,9 @@ public:
 	void SetText(std::string_view text) {
 		text_ = text;
 	}
+	void SetIconOnly(bool iconOnly) {
+		iconOnly_ = iconOnly;
+	}
 
 protected:
 	void ClickInternal() override;
@@ -770,6 +773,7 @@ protected:
 	u32 drawTextFlags_ = 0;
 	bool hideTitle_ = false;
 	float shine_ = false;
+	bool iconOnly_ = false;
 
 private:
 	bool selected_ = false;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1224,10 +1224,6 @@ bool Config::LoadAppendedConfig() {
 }
 
 void Config::UpdateAfterSettingAutoFrameSkip() {
-	if (bAutoFrameSkip && iFrameSkip == 0) {
-		iFrameSkip = 1;
-	}
-	
 	if (bAutoFrameSkip && bSkipBufferEffects) {
 		bSkipBufferEffects = false;
 	}

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1029,11 +1029,11 @@ static const ConfigSetting networkSettings[] = {
 	ConfigSetting("ChatButtonPosition", SETTING(g_Config, iChatButtonPosition), (int)ScreenEdgePosition::BOTTOM_LEFT, CfgFlag::PER_GAME),
 	ConfigSetting("ChatScreenPosition", SETTING(g_Config, iChatScreenPosition), (int)ScreenEdgePosition::BOTTOM_LEFT, CfgFlag::PER_GAME),
 	ConfigSetting("EnableQuickChat", SETTING(g_Config, bEnableQuickChat), true, CfgFlag::PER_GAME),
-	ConfigSetting("QuickChat1", SETTING(g_Config, sQuickChat0), "Quick Chat 1", CfgFlag::PER_GAME),
-	ConfigSetting("QuickChat2", SETTING(g_Config, sQuickChat1), "Quick Chat 2", CfgFlag::PER_GAME),
-	ConfigSetting("QuickChat3", SETTING(g_Config, sQuickChat2), "Quick Chat 3", CfgFlag::PER_GAME),
-	ConfigSetting("QuickChat4", SETTING(g_Config, sQuickChat3), "Quick Chat 4", CfgFlag::PER_GAME),
-	ConfigSetting("QuickChat5", SETTING(g_Config, sQuickChat4), "Quick Chat 5", CfgFlag::PER_GAME),
+	ConfigSetting("QuickChat1", SETTING(g_Config, sQuickChat[0]), "Quick Chat 1", CfgFlag::PER_GAME),
+	ConfigSetting("QuickChat2", SETTING(g_Config, sQuickChat[1]), "Quick Chat 2", CfgFlag::PER_GAME),
+	ConfigSetting("QuickChat3", SETTING(g_Config, sQuickChat[2]), "Quick Chat 3", CfgFlag::PER_GAME),
+	ConfigSetting("QuickChat4", SETTING(g_Config, sQuickChat[3]), "Quick Chat 4", CfgFlag::PER_GAME),
+	ConfigSetting("QuickChat5", SETTING(g_Config, sQuickChat[4]), "Quick Chat 5", CfgFlag::PER_GAME),
 };
 
 static const ConfigSetting systemParamSettings[] = {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -561,11 +561,7 @@ public:
 	int iChatScreenPosition;
 
 	bool bEnableQuickChat;
-	std::string sQuickChat0;
-	std::string sQuickChat1;
-	std::string sQuickChat2;
-	std::string sQuickChat3;
-	std::string sQuickChat4;
+	std::string sQuickChat[5];
 
 	int iPSPModel;
 	int iFirmwareVersion;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -221,7 +221,7 @@ int InitContextFromTrackInfo(SceAtracContext *ctx, const TrackInfo *wave, u32 bu
 		return SCE_ERROR_ATRAC_BAD_CODEC_PARAMS;
 	}
 
-	const int numChunks = (endSample >> (0x100b - (ctx->info).codec & 0x1f));
+	const int numChunks = (endSample >> ((0x100b - (ctx->info).codec) & 0x1f));
 
 	if ((numChunks * (u32)(ctx->info).sampleSize < (wave->waveDataSize + dataOff) - dataOff)) {
 		int retval = ComputeAtracStateAndInitSecondBuffer(&ctx->info, readSize, bufferSize);

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1305,6 +1305,7 @@ void sendChat(const std::string &chatString) {
 		std::lock_guard<std::mutex> guard(chatLogLock);
 		auto n = GetI18NCategory(I18NCat::NETWORKING);
 		chatLog.push_back(std::string(n->T("You're in Offline Mode, go to lobby or online hall")));
+		INFO_LOG(Log::sceNet, "Offline. Would have sent: %s", chatString.c_str());
 		chatMessageGeneration++;
 	}
 }

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -156,8 +156,12 @@ void __DisplayVblankEndCallback(SceUID threadID, SceUID prevCallbackId);
 void __DisplayFlip(int cyclesLate);
 static void __DisplaySetFramerate(void);
 
+static bool UseAutoFrameSkip() {
+	return g_Config.bAutoFrameSkip && !g_Config.bSkipBufferEffects;
+}
+
 static bool UseLagSync() {
-	return g_Config.bForceLagSync && !g_Config.bAutoFrameSkip;
+	return g_Config.bForceLagSync && !UseAutoFrameSkip();
 }
 
 static void ScheduleLagSync(int over = 0) {
@@ -402,6 +406,8 @@ static void DoFrameTiming(bool throttle, bool *skipFrame, float scaledTimestep, 
 	PROFILE_THIS_SCOPE("timing");
 	*skipFrame = false;
 
+	const bool autoFrameSkip = UseAutoFrameSkip();
+
 	// Check if the frameskipping code should be enabled. If neither throttling or frameskipping is on,
 	// we have nothing to do here.
 	bool doFrameSkip = g_Config.iFrameSkip != 0;
@@ -424,8 +430,8 @@ static void DoFrameTiming(bool throttle, bool *skipFrame, float scaledTimestep, 
 	}
 
 	// Auto-frameskip automatically if speed limit is set differently than the default.
-	int frameSkipNum = g_Config.iFrameSkip;
-	if (g_Config.bAutoFrameSkip && !g_Config.bSkipBufferEffects) {
+	const int frameSkipNum = g_Config.iFrameSkip;
+	if (autoFrameSkip) {
 		// autoframeskip
 		// Argh, we are falling behind! Let's skip a frame and see if we catch up.
 		if (curFrameTime > nextFrameTime && doFrameSkip) {

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -948,7 +948,7 @@ enum class OperationType {
 				break;
 			}
 			default:
-				ERROR_LOG(Log::SaveState, "Savestate failure: unknown operation type %d", op.type);
+				ERROR_LOG(Log::SaveState, "Savestate failure: unknown operation type %d", (int)op.type);
 				callbackResult = Status::FAILURE;
 				break;
 			}

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -40,11 +40,12 @@ void ChatMenu::CreateContents(UI::ViewGroup *parent) {
 
 	if (g_Config.bEnableQuickChat) {
 		LinearLayout *quickChat = outer->Add(new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT)));
-		quickChat->Add(new Button("1", new LinearLayoutParams(1.0)))->OnClick.Handle(this, &ChatMenu::OnQuickChat1);
-		quickChat->Add(new Button("2", new LinearLayoutParams(1.0)))->OnClick.Handle(this, &ChatMenu::OnQuickChat2);
-		quickChat->Add(new Button("3", new LinearLayoutParams(1.0)))->OnClick.Handle(this, &ChatMenu::OnQuickChat3);
-		quickChat->Add(new Button("4", new LinearLayoutParams(1.0)))->OnClick.Handle(this, &ChatMenu::OnQuickChat4);
-		quickChat->Add(new Button("5", new LinearLayoutParams(1.0)))->OnClick.Handle(this, &ChatMenu::OnQuickChat5);
+		for (int i = 0; i < 5; i++) {
+			std::string name = std::to_string(i + 1);
+			quickChat->Add(new Button(name, new LinearLayoutParams(1.0)))->OnClick.Add([this, i](UI::EventParams &e) {
+				sendChat(g_Config.sQuickChat[i]);
+			});
+		}
 	}
 	chatVert_ = scroll_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	chatVert_->SetSpacing(0);
@@ -125,26 +126,6 @@ void ChatMenu::OnAskForChatMessage(UI::EventParams &e) {
 		popupScreen->SetPopupOrigin(chatButton_);
 		screenManager_->push(popupScreen);
 	}
-}
-
-void ChatMenu::OnQuickChat1(UI::EventParams &e) {
-	sendChat(g_Config.sQuickChat0);
-}
-
-void ChatMenu::OnQuickChat2(UI::EventParams &e) {
-	sendChat(g_Config.sQuickChat1);
-}
-
-void ChatMenu::OnQuickChat3(UI::EventParams &e) {
-	sendChat(g_Config.sQuickChat2);
-}
-
-void ChatMenu::OnQuickChat4(UI::EventParams &e) {
-	sendChat(g_Config.sQuickChat3);
-}
-
-void ChatMenu::OnQuickChat5(UI::EventParams &e) {
-	sendChat(g_Config.sQuickChat4);
 }
 
 void ChatMenu::UpdateChat() {

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -28,11 +28,6 @@ private:
 	void OnAskForChatMessage(UI::EventParams &e);
 
 	void OnSubmitMessage(UI::EventParams &e);
-	void OnQuickChat1(UI::EventParams &e);
-	void OnQuickChat2(UI::EventParams &e);
-	void OnQuickChat3(UI::EventParams &e);
-	void OnQuickChat4(UI::EventParams &e);
-	void OnQuickChat5(UI::EventParams &e);
 
 	UI::TextEdit *chatEdit_ = nullptr;
 	UI::ScrollView *scroll_ = nullptr;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -466,7 +466,11 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Frame Rate Control")));
 	static const char *frameSkip[] = {"Off", "1", "2", "3", "4", "5", "6", "7", "8"};
-	graphicsSettings->Add(new PopupMultiChoice(&g_Config.iFrameSkip, gr->T("Frame Skipping"), frameSkip, 0, ARRAY_SIZE(frameSkip), I18NCat::GRAPHICS, screenManager()));
+	PopupMultiChoice *frameSkipping = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iFrameSkip, gr->T("Frame Skipping"), frameSkip, 0, ARRAY_SIZE(frameSkip), I18NCat::GRAPHICS, screenManager()));
+	frameSkipping->SetEnabledFunc([] {
+		return !g_Config.bAutoFrameSkip;
+	});
+
 	CheckBox *frameSkipAuto = graphicsSettings->Add(new CheckBox(&g_Config.bAutoFrameSkip, gr->T("Auto FrameSkip")));
 	frameSkipAuto->OnClick.Add([](UI::EventParams &e) {
 		g_Config.UpdateAfterSettingAutoFrameSkip();
@@ -1073,7 +1077,7 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	PopupTextInputChoice *qc4 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat[3], n->T("Quick Chat 4"), "", 32, screenManager()));
 	PopupTextInputChoice *qc5 = networkingSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sQuickChat[4], n->T("Quick Chat 5"), "", 32, screenManager()));
 #elif defined(USING_QT_UI)
-]	Choice *qc1 = networkingSettings->Add(new Choice(n->T("Quick Chat 1")));
+	Choice *qc1 = networkingSettings->Add(new Choice(n->T("Quick Chat 1")));
 	Choice *qc2 = networkingSettings->Add(new Choice(n->T("Quick Chat 2")));
 	Choice *qc3 = networkingSettings->Add(new Choice(n->T("Quick Chat 3")));
 	Choice *qc4 = networkingSettings->Add(new Choice(n->T("Quick Chat 4")));

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -76,9 +76,6 @@ private:
 	std::string memstickDisplay_;
 
 	// Global settings handlers
-	void OnAutoFrameskip(UI::EventParams &e);
-	void OnTextureShader(UI::EventParams &e);
-	void OnTextureShaderChange(UI::EventParams &e);
 	void OnChangeQuickChat0(UI::EventParams &e);
 	void OnChangeQuickChat1(UI::EventParams &e);
 	void OnChangeQuickChat2(UI::EventParams &e);

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -59,12 +59,6 @@ private:
 	void CreateVRSettings(UI::ViewGroup *vrSettings);
 
 	std::string gameID_;
-	UI::CheckBox *enableReportsCheckbox_ = nullptr;
-	UI::Choice *layoutEditorChoice_ = nullptr;
-	UI::Choice *displayEditor_ = nullptr;
-	UI::Choice *backgroundChoice_ = nullptr;
-	UI::PopupMultiChoice *resolutionChoice_ = nullptr;
-	UI::CheckBox *frameSkipAuto_ = nullptr;
 #ifdef _WIN32
 	UI::CheckBox *SavePathInMyDocumentChoice = nullptr;
 	UI::CheckBox *SavePathInOtherChoice = nullptr;

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -241,7 +241,10 @@ void AddRotationPicker(ScreenManager *screenManager, UI::ViewGroup *parent, bool
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
 
 	PopupMultiChoice *rot = parent->Add(new PopupMultiChoice(&g_Config.iScreenRotation, text ? co->T("Screen Rotation") : "", screenRotation, 0, ARRAY_SIZE(screenRotation), I18NCat::CONTROLS, screenManager, text ? nullptr : new LinearLayoutParams(ITEM_HEIGHT, ITEM_HEIGHT)));
+	rot->SetHideTitle(true);
+	rot->SetIconOnly(true);
 	rot->SetChoiceIcons(screenRotationIcons);
+
 	// Portrait Reversed is not recommended on iPhone (and we also ban it in the plist).
 	// However it's recommended to support it on iPad, so maybe we will in the future.
 	rot->HideChoice(4);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -683,7 +683,7 @@ void GamePauseScreen::CreateViews() {
 			screenManager()->push(new GameScreen(gamePath_, true));
 		});
 
-		if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
+		if (true || System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
 			AddRotationPicker(screenManager(), middleColumn, false);
 		}
 

--- a/android/src/org/ppsspp/ppsspp/ContentUri.java
+++ b/android/src/org/ppsspp/ppsspp/ContentUri.java
@@ -128,8 +128,8 @@ public class ContentUri {
 					}
 				}
 				c.close();
+				c = null;
 			}
-			c = null;
 
 			for (Uri childUri : childDirs) {
 				long dirSize = directorySizeRecursion(activity, childUri);

--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -139,9 +139,11 @@ public class InputDeviceState {
 		boolean repeat = event.getRepeatCount() > 0;
 
 		if (isInvalidKeyCode(keyCode) && isEventSentByNintendoSwitchLeftJoyCon(event)) {
-			keyCode = remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(event.getScanCode());
-			// need to pass false for the repeat flag, otherwise pressing two adjacent dpad buttons simultaneously to move diagonally does not work.
-			return NativeApp.keyDown(deviceId, keyCode, false); 
+			int remappedKeyCode = remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(event.getScanCode());
+			if (remappedKeyCode != 0) {
+				// need to pass false for the repeat flag, otherwise pressing two adjacent dpad buttons simultaneously to move diagonally does not work.
+				return NativeApp.keyDown(deviceId, remappedKeyCode, false);
+			}
 		}
 
 		return NativeApp.keyDown(deviceId, keyCode, repeat);
@@ -152,7 +154,10 @@ public class InputDeviceState {
 		int keyCode = event.getKeyCode();
 
 		if (isInvalidKeyCode(keyCode) && isEventSentByNintendoSwitchLeftJoyCon(event)) {
-			keyCode = remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(event.getScanCode());
+			int remappedKeyCode = remapNintendoSwitchLeftJoyConKeyCodeFromScanCode(event.getScanCode());
+			if (remappedKeyCode != 0) {
+				return NativeApp.keyUp(deviceId, remappedKeyCode);
+			}
 		}
 
 		return NativeApp.keyUp(deviceId, keyCode);

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -1096,14 +1096,14 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 	}
 
 	protected String getInputDeviceDebugString() {
-		String buffer = "";
+		StringBuilder buffer = new StringBuilder();
 		for (InputDeviceState input : inputPlayers) {
-			buffer += input.getDebugString();
+			buffer.append(input.getDebugString());
 		}
-		if (buffer.isEmpty()) {
+		if (buffer.length() == 0) {
 			return "(no devices)";
 		}
-		return buffer;
+		return buffer.toString();
 	}
 
 	// We grab the keys before onKeyDown/... even see them. This is also better because it lets us

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -301,13 +301,16 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 		if (list == null) {
 			Log.i(TAG, "getSdCardPaths: Attempting fallback");
 			// Try another method.
-			list = new ArrayList<>();
 			File[] fileList = new File("/storage/").listFiles();
 			if (fileList != null) {
+				list = new ArrayList<>();
 				for (File file : fileList) {
 					if (!file.getAbsolutePath().equalsIgnoreCase(Environment.getExternalStorageDirectory().getAbsolutePath()) && file.isDirectory() && file.canRead()) {
 						list.add(file.getAbsolutePath());
 					}
+				}
+				if (list.isEmpty()) {
+					list = null;
 				}
 			}
 		}
@@ -316,7 +319,7 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 			String[] varNames = { "EXTERNAL_SDCARD_STORAGE", "SECONDARY_STORAGE" };
 			for (String var : varNames) {
 				Log.i(TAG, "getSdCardPaths: Checking env " + var);
-				String secStore = System.getenv("SECONDARY_STORAGE");
+				String secStore = System.getenv(var);
 				if (secStore != null && !secStore.isEmpty()) {
 					list = new ArrayList<>();
 					list.add(secStore);
@@ -518,9 +521,13 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 			}
 		}
 
-		mLocationHelper = new LocationHelper(this);
+		if (mLocationHelper == null) {
+			mLocationHelper = new LocationHelper(this);
+		}
 		try {
-			mInfraredHelper = new InfraredHelper(this);
+			if (mInfraredHelper == null) {
+				mInfraredHelper = new InfraredHelper(this);
+			}
 		} catch (Exception e) {
 			mInfraredHelper = null;
 			Log.i(TAG, "InfraredHelper exception: " + e);

--- a/android/src/org/ppsspp/ppsspp/SimpleFileChooser.java
+++ b/android/src/org/ppsspp/ppsspp/SimpleFileChooser.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Environment;
+import android.widget.Toast;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,7 +56,11 @@ public class SimpleFileChooser {
 			for (File file : fileList) {
 				r.add(file.getName());
 			}
+		} else {
+			// BUG FIX: Notify user if directory is inaccessible
+			Toast.makeText(mActivity, "Cannot read directory", Toast.LENGTH_SHORT).show();
 		}
+		// Strange syntax but correct.
 		mFileList = r.toArray(new String[0]);
 	}
 


### PR DESCRIPTION
This fixes a long-standing issue where toggling "Auto frameskip" would reset frameskip to 1 for no good reason.

Plus, fixes an issue with the rotation button on the pause screen on Android, and cleans up some code.