### PR TITLE
SDL: Fix measuring of multi-line strings.

### DIFF
--- a/Common/Render/Text/draw_text.h
+++ b/Common/Render/Text/draw_text.h
@@ -77,6 +77,7 @@ public:
 protected:
 	TextDrawer(Draw::DrawContext *draw);
 
+	// Implementations of this must handle multi-line strings.
 	virtual void MeasureStringInternal(std::string_view str, float *w, float *h) = 0;
 
 	void ClearCache();

--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -301,15 +301,30 @@ void TextDrawerSDL::MeasureStringInternal(std::string_view str, float *w, float 
 		}
 	}
 
-	int width = 0;
-	int height = 0;
+	std::vector<std::string_view> lines;
+	SplitString(str, '\n', lines);
 
-	// Unfortunately we need to zero-terminate here.
-	std::string text(str);
-	TTF_SizeUTF8(font, text.c_str(), &width, &height);
+	INFO_LOG(Log::G3D, "Measuring string %.*s", STR_VIEW(str));
 
-	*w = (float)width;
-	*h = (float)height;
+	int extW = 0, extH = 0;
+	std::string temp;
+	for (auto line : lines) {
+		int width = 0;
+		int height = 0;
+		if (line.empty()) {
+			// Measure empty lines as if it was a space.
+			line = " ";
+		}
+		temp = line;  // zero-terminate, ugh.
+		TTF_SizeUTF8(font, temp.c_str(), &width, &height);
+
+		if (width > extW)
+			extW = width;
+		extH += height;
+	}
+
+	*w = (float)extW;
+	*h = (float)extH;
 }
 
 bool TextDrawerSDL::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) {

--- a/Common/Render/Text/draw_text_win.cpp
+++ b/Common/Render/Text/draw_text_win.cpp
@@ -137,16 +137,8 @@ void TextDrawerWin32::MeasureStringInternal(std::string_view str, float *w, floa
 		return;
 	}
 
-#if 0 && defined(_DEBUG)
-	if (str.find('\r') != std::string_view::npos) {
-		_dbg_assert_msg_(false, "carriage return found in string to measure");
-	}
-#endif
-
-	std::string toMeasure(str);
-
 	std::vector<std::string_view> lines;
-	SplitString(toMeasure, '\n', lines);
+	SplitString(str, '\n', lines);
 
 	int extW = 0, extH = 0;
 	for (auto &line : lines) {


### PR DESCRIPTION
Also, a small related optimization on Windows.

Fixes the bug reported by @Kethen in #21136 