### PR TITLE
Controller autoconfigure improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,8 @@ add_library(Common STATIC
 	Common/UI/IconCache.h
 	Common/UI/UIScreen.cpp
 	Common/UI/UIScreen.h
+	Common/UI/Notice.cpp
+	Common/UI/Notice.h
 	Common/UI/Tween.cpp
 	Common/UI/Tween.h
 	Common/UI/View.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -541,6 +541,7 @@
     <ClInclude Include="UI\AsyncImageFileView.h" />
     <ClInclude Include="UI\Context.h" />
     <ClInclude Include="UI\IconCache.h" />
+    <ClInclude Include="UI\Notice.h" />
     <ClInclude Include="UI\PopupScreens.h" />
     <ClInclude Include="UI\Root.h" />
     <ClInclude Include="UI\Screen.h" />
@@ -992,6 +993,7 @@
     <ClCompile Include="UI\AsyncImageFileView.cpp" />
     <ClCompile Include="UI\Context.cpp" />
     <ClCompile Include="UI\IconCache.cpp" />
+    <ClCompile Include="UI\Notice.cpp" />
     <ClCompile Include="UI\PopupScreens.cpp" />
     <ClCompile Include="UI\Root.cpp" />
     <ClCompile Include="UI\Screen.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -722,6 +722,9 @@
     <ClInclude Include="..\ext\aemu_postoffice\client\sock_impl.h">
       <Filter>ext\aemu_postoffice</Filter>
     </ClInclude>
+    <ClInclude Include="UI\Notice.h">
+      <Filter>UI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -1343,6 +1346,9 @@
     </ClCompile>
     <ClCompile Include="..\ext\aemu_postoffice\client\sock_impl_windows.c">
       <Filter>ext\aemu_postoffice</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\Notice.cpp">
+      <Filter>UI</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -932,7 +932,6 @@ bool VulkanContext::CreateInstanceAndDevice(const CreateInfo &info) {
 		DestroyInstance();
 		return false;
 	}
-
 	return true;
 }
 
@@ -1550,7 +1549,7 @@ bool VulkanContext::InitSwapchain(VkPresentModeKHR desiredPresentMode) {
 
 	res = vkCreateSwapchainKHR(device_, &swap_chain_info, NULL, &swapchain_);
 	if (res != VK_SUCCESS) {
-		ERROR_LOG(Log::G3D, "vkCreateSwapchainKHR failed!");
+		ERROR_LOG(Log::G3D, "vkCreateSwapchainKHR failed! %s", VulkanResultToString(res));
 		return false;
 	}
 	INFO_LOG(Log::G3D, "Created swapchain: %dx%d %s", swap_chain_info.imageExtent.width, swap_chain_info.imageExtent.height, (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) ? "(TRANSFER_SRC_BIT supported)" : "");

--- a/Common/Render/AtlasGen.cpp
+++ b/Common/Render/AtlasGen.cpp
@@ -175,7 +175,7 @@ void Bucket::Pack2(int image_width) {
 	// These are just temporary storage (the API is allocation-free otherwise).
 	// About one node is needed for each horizontal unit of width.
 	std::vector<stbrp_node> nodes(image_width * 2);
-	stbrp_init_target(&context, image_width, image_width * 2, nodes.data(), nodes.size());
+	stbrp_init_target(&context, image_width, image_width * 2, nodes.data(), (int)nodes.size());
 	// Transfer the rectangles to the rect_pack structs from Data.
 	std::vector<stbrp_rect> rects(data.size());
 	for (int i = 0; i < data.size(); i++) {
@@ -184,7 +184,7 @@ void Bucket::Pack2(int image_width) {
 		rects[i].id = i;
 	}
 	{
-		stbrp_pack_rects(&context, rects.data(), rects.size());
+		stbrp_pack_rects(&context, rects.data(), (int)rects.size());
 	}
 	for (int i = 0; i < (int)data.size(); i++) {
 		int index = rects[i].id;

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -260,6 +260,7 @@ enum class SystemNotification {
 	UI_STATE_CHANGED,
 	AUDIO_MODE_CHANGED,
 	APP_SWITCH_MODE_CHANGED,
+	PAD_STATE_CHANGED,
 };
 
 // I guess it's not super great architecturally to centralize this, since it's not general - but same with a lot of

--- a/Common/UI/Notice.cpp
+++ b/Common/UI/Notice.cpp
@@ -72,7 +72,7 @@ void MeasureNotice(const UIContext &dc, NoticeLevel level, const std::string &te
 	// We currently don't wrap the title.
 
 	float titleWidth, titleHeight;
-	dc.MeasureText(dc.GetTheme().uiFont, 1.0f, 1.0f, text, &titleWidth, &titleHeight, align);
+	dc.MeasureTextRect(dc.GetTheme().uiFont, 1.0f, 1.0f, text, availableWidth, &titleWidth, &titleHeight, align);
 
 	*width = std::min(titleWidth, availableWidth);
 	*height1 = titleHeight;
@@ -145,7 +145,12 @@ void RenderNotice(UIContext &dc, Bounds bounds, float height1, NoticeLevel level
 	Bounds primaryBounds = bounds;
 	primaryBounds.h = height1;
 
-	dc.DrawTextShadowRect(text, primaryBounds.Inset(2.0f, 0.0f, 1.0f, 0.0f), foreGround, (align & FLAG_DYNAMIC_ASCII) | ALIGN_VCENTER | FLAG_ELLIPSIZE_TEXT);
+	int titleAlign = (align & (FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT)) | ALIGN_VCENTER | FLAG_ELLIPSIZE_TEXT;
+	if (!(titleAlign & FLAG_WRAP_TEXT)) {
+		titleAlign |= FLAG_ELLIPSIZE_TEXT;
+	}
+
+	dc.DrawTextShadowRect(text, primaryBounds.Inset(2.0f, 0.0f, 1.0f, 0.0f), foreGround, titleAlign);
 
 	if (!details.empty()) {
 		Bounds bottomTextBounds = bounds.Inset(3.0f, height1 + 5.0f, 3.0f, 3.0f);

--- a/Common/UI/Notice.cpp
+++ b/Common/UI/Notice.cpp
@@ -1,0 +1,160 @@
+#include "Common/UI/UI.h"
+#include "Common/UI/Notice.h"
+#include "Common/UI/IconCache.h"
+#include "Common/UI/Context.h"
+#include "Common/StringUtils.h"
+#include "Common/System/OSD.h"
+
+static const float extraTextScale = 0.7f;
+
+uint32_t GetNoticeBackgroundColor(NoticeLevel type) {
+	// Colors from Infima
+	switch (type) {
+	case NoticeLevel::ERROR: return 0x3530d5;  // danger-darker
+	case NoticeLevel::WARN: return 0x009ed9;  // warning-darker
+	case NoticeLevel::INFO: return 0x706760;  // gray-700
+	case NoticeLevel::SUCCESS: return 0x008b00;  // nice green
+	default: return 0x606770;
+	}
+}
+
+ImageID GetOSDIcon(NoticeLevel level) {
+	switch (level) {
+	case NoticeLevel::INFO: return ImageID("I_INFO");
+	case NoticeLevel::ERROR: return ImageID("I_CROSS");
+	case NoticeLevel::WARN: return ImageID("I_WARNING");
+	case NoticeLevel::SUCCESS: return ImageID("I_CHECKMARK");
+	default: return ImageID::invalid();
+	}
+}
+
+NoticeLevel GetNoticeLevel(OSDType type) {
+	switch (type) {
+	case OSDType::MESSAGE_INFO:
+		return NoticeLevel::INFO;
+	case OSDType::MESSAGE_ERROR:
+	case OSDType::MESSAGE_ERROR_DUMP:
+	case OSDType::MESSAGE_CENTERED_ERROR:
+		return NoticeLevel::ERROR;
+	case OSDType::MESSAGE_WARNING:
+	case OSDType::MESSAGE_CENTERED_WARNING:
+		return NoticeLevel::WARN;
+	case OSDType::MESSAGE_SUCCESS:
+		return NoticeLevel::SUCCESS;
+	default:
+		return NoticeLevel::SUCCESS;
+	}
+}
+
+// Align only matters here for the ASCII-only flag.
+void MeasureNotice(const UIContext &dc, NoticeLevel level, const std::string &text, const std::string &details, const std::string &iconName, int align, float maxWidth, float *width, float *height, float *height1) {
+	float iconW = 0.0f;
+	float iconH = 0.0f;
+	if (!iconName.empty() && !startsWith(iconName, "I_")) {  // Check for atlas image. Bit hacky, but we choose prefixes for icon IDs anyway in a way that this is safe.
+		// Normal entry but with a cached icon.
+		int iconWidth, iconHeight;
+		if (g_iconCache.GetDimensions(iconName, &iconWidth, &iconHeight)) {
+			*width += 5.0f + iconWidth;
+			iconW = iconWidth;
+			iconH = iconHeight;
+		}
+	} else {
+		ImageID iconID = iconName.empty() ? GetOSDIcon(level) : ImageID(iconName.c_str());
+		if (iconID.isValid()) {
+			dc.Draw()->GetAtlas()->measureImage(iconID, &iconW, &iconH);
+		}
+	}
+
+	float chromeWidth = iconW + 5.0f + 12.0f;
+	float availableWidth = maxWidth - chromeWidth;
+
+	// OK, now that we have figured out how much space we have for the text, we can measure it (with wrapping if needed).
+	// We currently don't wrap the title.
+
+	float titleWidth, titleHeight;
+	dc.MeasureText(dc.GetTheme().uiFont, 1.0f, 1.0f, text, &titleWidth, &titleHeight, align);
+
+	*width = std::min(titleWidth, availableWidth);
+	*height1 = titleHeight;
+
+	float width2 = 0.0f, height2 = 0.0f;
+	if (!details.empty()) {
+		dc.MeasureTextRect(dc.GetTheme().uiFont, extraTextScale, extraTextScale, details, availableWidth, &width2, &height2, align | FLAG_WRAP_TEXT);
+		*width = std::max(*width, width2);
+	}
+
+	*width += chromeWidth;
+	if (height2 == 0.0f && iconH < 2.0f * *height1) {
+		// Center vertically using the icon.
+		*height1 = std::max(*height1, iconH + 2.0f);
+	}
+	*height = std::max(*height1 + height2 + 8.0f, iconH + 5.0f);
+}
+
+void RenderNotice(UIContext &dc, Bounds bounds, float height1, NoticeLevel level, const std::string &text, const std::string &details, const std::string &iconName, int align, float alpha, OSDMessageFlags flags, float timeVal) {
+	UI::Drawable background = UI::Drawable(colorAlpha(GetNoticeBackgroundColor(level), alpha));
+
+	dc.SetFontStyle(dc.GetTheme().uiFont);
+
+	uint32_t foreGround = whiteAlpha(alpha);
+
+	if (!(flags & OSDMessageFlags::Transparent)) {
+		dc.DrawRectDropShadow(bounds, 12.0f, 0.7f * alpha);
+		dc.FillRect(background, bounds);
+	}
+
+	float iconW = 0.0f;
+	float iconH = 0.0f;
+	if (!iconName.empty() && !startsWith(iconName, "I_")) {
+		dc.Flush();
+		// Normal entry but with a cached icon.
+		Draw::Texture *texture = g_iconCache.BindIconTexture(&dc, iconName);
+		if (texture) {
+			iconW = texture->Width();
+			iconH = texture->Height();
+			dc.Draw()->DrawTexRect(Bounds(bounds.x + 2.5f, bounds.y + 2.5f, iconW, iconH), 0.0f, 0.0f, 1.0f, 1.0f, foreGround);
+			dc.Flush();
+			dc.RebindTexture();
+		}
+		dc.Begin();
+	} else {
+		ImageID iconID = iconName.empty() ? GetOSDIcon(level) : ImageID(iconName.c_str());
+		if (iconID.isValid()) {
+			// Atlas icon.
+			dc.Draw()->GetAtlas()->measureImage(iconID, &iconW, &iconH);
+			if (!iconName.empty()) {
+				Bounds iconBounds = Bounds(bounds.x + 2.5f, bounds.y + 2.5f, iconW, iconH);
+				// If it's not a preset OSD icon, give it some background to blend in. The RA icon for example
+				// easily melts into the orange of warnings otherwise.
+				dc.FillRect(UI::Drawable(0x50000000), iconBounds.Expand(2.0f));
+			}
+
+			if (flags & (OSDMessageFlags::SpinLeft | OSDMessageFlags::SpinRight)) {
+				const float direction = (flags & OSDMessageFlags::SpinLeft) ? -1.5f : 1.5f;
+				dc.DrawImageRotated(iconID, bounds.x + 2.5f + iconW * 0.5f, bounds.y + 2.5f + iconW * 0.5f, 1.0f, direction * timeVal, foreGround, false);
+			} else {
+				dc.DrawImageVGradient(iconID, foreGround, foreGround, Bounds(bounds.x + 2.5f, bounds.y + 2.5f, iconW, iconH));
+			}
+		}
+	}
+
+	// Make room
+	bounds.x += iconW + 5.0f;
+	bounds.w -= iconW + 5.0f;
+
+	Bounds primaryBounds = bounds;
+	primaryBounds.h = height1;
+
+	dc.DrawTextShadowRect(text, primaryBounds.Inset(2.0f, 0.0f, 1.0f, 0.0f), foreGround, (align & FLAG_DYNAMIC_ASCII) | ALIGN_VCENTER | FLAG_ELLIPSIZE_TEXT);
+
+	if (!details.empty()) {
+		Bounds bottomTextBounds = bounds.Inset(3.0f, height1 + 5.0f, 3.0f, 3.0f);
+		if (!(flags & OSDMessageFlags::Transparent)) {
+			UI::Drawable backgroundDark = UI::Drawable(colorAlpha(darkenColor(GetNoticeBackgroundColor(level)), alpha));
+			dc.FillRect(backgroundDark, bottomTextBounds);
+		}
+		dc.SetFontScale(extraTextScale, extraTextScale);
+		dc.DrawTextRect(details, bottomTextBounds.Inset(1.0f, 1.0f), foreGround, (align & FLAG_DYNAMIC_ASCII) | ALIGN_LEFT | FLAG_WRAP_TEXT);
+	}
+	dc.SetFontScale(1.0f, 1.0f);
+}

--- a/Common/UI/Notice.h
+++ b/Common/UI/Notice.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "Common/UI/View.h"
+#include "Common/System/OSD.h"
+
+#undef ERROR
+
+enum class NoticeLevel {
+	SUCCESS,
+	INFO,
+	WARN,
+	ERROR,
+};
+
+class NoticeView : public UI::InertView {
+public:
+	NoticeView(NoticeLevel level, std::string_view text, std::string_view detailsText, UI::LayoutParams *layoutParams = 0)
+		: InertView(layoutParams), level_(level), text_(text), detailsText_(detailsText) {}
+
+	void SetIconName(std::string_view name) {
+		iconName_ = name;
+	}
+	void SetText(std::string_view text) {
+		text_ = text;
+	}
+	void SetLevel(NoticeLevel level) {
+		level_ = level;
+	}
+	void SetSquishy(bool squishy) {
+		squishy_ = squishy;
+	}
+
+	void GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const override;
+	void Draw(UIContext &dc) override;
+
+private:
+	std::string text_;
+	std::string detailsText_;
+	std::string iconName_;
+	NoticeLevel level_;
+	mutable float height1_ = 0.0f;
+	bool squishy_ = false;
+};
+
+ImageID GetOSDIcon(NoticeLevel level);
+NoticeLevel GetNoticeLevel(OSDType type);
+uint32_t GetNoticeBackgroundColor(NoticeLevel type);
+void MeasureNotice(const UIContext &dc, NoticeLevel level, const std::string &text, const std::string &details, const std::string &iconName, int align, float maxWidth, float *width, float *height, float *height1);
+void RenderNotice(UIContext &dc, Bounds bounds, float height1, NoticeLevel level, const std::string &text, const std::string &details, const std::string &iconName, int align, float alpha, OSDMessageFlags flags, float timeVal);

--- a/Common/UI/Notice.h
+++ b/Common/UI/Notice.h
@@ -33,6 +33,9 @@ public:
 	void SetSquishy(bool squishy) {
 		squishy_ = squishy;
 	}
+	void SetWrapText(bool wrapText) {
+		wrapText_ = wrapText;
+	}
 
 	void GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
@@ -44,6 +47,7 @@ private:
 	NoticeLevel level_;
 	mutable float height1_ = 0.0f;
 	bool squishy_ = false;
+	bool wrapText_ = false;
 };
 
 ImageID GetOSDIcon(NoticeLevel level);

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -6,6 +6,7 @@
 #include "Common/UI/ViewGroup.h"
 #include "Common/UI/Context.h"
 #include "Common/UI/Root.h"
+#include "Common/UI/Notice.h"
 #include "Common/StringUtils.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/System/System.h"
@@ -163,6 +164,10 @@ void PopupScreen::CreateViews() {
 		box_->Add(title);
 	}
 
+	if (!notificationString_.empty()) {
+		box_->Add(new NoticeView(notificationLevel_, notificationString_, "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(8, 4))))->SetWrapText(true);
+	}
+
 	CreatePopupContents(box_);
 	root_->Recurse([](View *view) {
 		view->SetPopupStyle(true);
@@ -215,6 +220,8 @@ void MessagePopupScreen::OnCompleted(DialogResult result) {
 			callback_(false);
 	}
 }
+
+ListPopupScreen::~ListPopupScreen() {}
 
 void ListPopupScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	using namespace UI;

--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -7,9 +7,11 @@
 #include "Common/UI/UI.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ScrollView.h"
+#include "Common/UI/Notice.h"
 
 // from StringUtils
 enum class StringRestriction;
+enum class OSDType;  // From OSD
 
 namespace UI {
 
@@ -37,6 +39,10 @@ public:
 
 	// For the postproc param sliders on DisplayLayoutScreen
 	bool wantBrightBackground() const override { return !hasDropShadow_; }
+	void SetNotification(NoticeLevel noticeLevel, std::string_view str) {
+		notificationLevel_ = noticeLevel;
+		notificationString_ = str;
+	}
 
 protected:
 	virtual bool FillVertical() const { return false; }
@@ -70,6 +76,8 @@ private:
 	bool alignTop_ = false;
 
 	bool hasDropShadow_ = true;
+	NoticeLevel notificationLevel_{};
+	std::string notificationString_;
 };
 
 class ListPopupScreen : public PopupScreen {
@@ -81,6 +89,7 @@ public:
 	ListPopupScreen(std::string_view title, const std::vector<std::string> &items, int selected, bool showButtons = false)
 		: PopupScreen(title, "OK", "Cancel"), adaptor_(items, selected), showButtons_(showButtons) {
 	}
+	~ListPopupScreen() override;
 
 	int GetChoice() const {
 		return listView_->GetSelected();

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <map>
 #include <vector>
 #include <set>
@@ -209,17 +210,19 @@ namespace KeyMap {
 
 	void UpdateNativeMenuKeys();
 
-	void NotifyPadConnected(InputDeviceID deviceId, const std::string &name);
-	bool IsNvidiaShield(const std::string &name);
-	bool IsNvidiaShieldTV(const std::string &name);
-	bool IsXperiaPlay(const std::string &name);
-	bool IsMOQII7S(const std::string &name);
-	bool IsRetroid(const std::string &name);
-	bool HasBuiltinController(const std::string &name);
+	void NotifyPadConnected(InputDeviceID deviceId, std::string_view name);
+	void NotifyPadDisconnected(InputDeviceID deviceId);
+
+	bool IsNvidiaShield(std::string_view name);
+	bool IsNvidiaShieldTV(std::string_view name);
+	bool IsXperiaPlay(std::string_view name);
+	bool IsMOQII7S(std::string_view name);
+	bool IsRetroid(std::string_view name);
+	bool HasBuiltinController(std::string_view name);
 
 	const std::set<std::string> &GetSeenPads();
 	std::string PadName(InputDeviceID deviceId);
-	void AutoConfForPad(const std::string &name);
+	void AutoConfForPad(std::string_view name);
 
 	bool IsKeyMapped(InputDeviceID device, int key);
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -753,19 +753,6 @@ void PSP_Shutdown(bool success) {
 	IncrementDebugCounter(DebugCounter::GAME_SHUTDOWN);
 }
 
-// Do not use. Currently only used from the websocket debugger
-BootState PSP_Reboot(std::string *error_string) {
-	if (g_bootState != BootState::Complete) {
-		return g_bootState;
-	}
-
-	Core_Stop();
-	Core_WaitInactive();
-	PSP_Shutdown(true);
-	std::string resetError;
-	return PSP_Init(PSP_CoreParameter(), error_string);
-}
-
 void PSP_RunLoopWhileState() {
 	// We just run the CPU until we get to vblank. This will quickly sync up pretty nicely.
 	// The actual number of cycles doesn't matter so much here as we will break due to CORE_NEXTFRAME, most of the time hopefully...

--- a/Core/System.h
+++ b/Core/System.h
@@ -76,7 +76,6 @@ BootState PSP_InitUpdate(std::string *error_string);
 BootState PSP_Init(const CoreParameter &coreParam, std::string *error_string);
 
 void PSP_Shutdown(bool success);
-BootState PSP_Reboot(std::string *error_string);
 
 FileLoader *PSP_LoadedFile();
 

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -314,7 +314,11 @@ void DrawEngineD3D11::Flush() {
 		}
 
 		if (textureNeedsApply) {
+			gstate_c.dstSquared = false;
 			textureCache_->ApplyTexture();
+			if (gstate_c.dstSquared) {
+				gstate_c.Dirty(DIRTY_BLEND_STATE);
+			}
 		}
 
 		// Need to ApplyDrawState after ApplyTexture because depal can launch a render pass and that wrecks the state.

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -398,7 +398,11 @@ void DrawEngineGLES::Flush() {
 
 		if (textureNeedsApply) {
 			gstate_c.pixelMapped = result.pixelMapped;
+			gstate_c.dstSquared = false;
 			textureCache_->ApplyTexture();
+			if (gstate_c.dstSquared) {
+				gstate_c.Dirty(DIRTY_BLEND_STATE);
+			}
 			gstate_c.pixelMapped = false;
 		}
 

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -22,32 +22,26 @@
 #include <unordered_map>
 
 #include "Common/Render/TextureAtlas.h"
-#include "Common/UI/Root.h"
-#include "Common/UI/UI.h"
 #include "Common/UI/Context.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
+#include "Common/UI/Notice.h"
 #include "Common/VR/PPSSPPVR.h"
-
 #include "Common/Log.h"
 #include "Common/Data/Color/RGBAUtil.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Input/KeyCodes.h"
 #include "Common/Input/InputState.h"
 #include "Common/StringUtils.h"
-#include "Common/System/Display.h"
 #include "Common/System/System.h"
 #include "Common/System/Request.h"
 #include "Common/TimeUtil.h"
 #include "Core/KeyMap.h"
 #include "Core/HLE/sceCtrl.h"
-#include "Core/System.h"
 #include "Core/Config.h"
 #include "UI/ControlMappingScreen.h"
 #include "UI/PopupScreens.h"
-#include "UI/GameSettingsScreen.h"
 #include "UI/JoystickHistoryView.h"
-#include "UI/OnScreenDisplay.h"
 
 #if PPSSPP_PLATFORM(ANDROID)
 #include "android/jni/app-android.h"
@@ -57,7 +51,10 @@ using KeyMap::MultiInputMapping;
 
 class SingleControlMapper : public UI::LinearLayout {
 public:
-	SingleControlMapper(int pspKey, std::string keyName, bool portrait, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams = nullptr);
+	SingleControlMapper(int pspKey, std::string_view keyName, bool portrait, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams = nullptr)
+		: UI::LinearLayout(ORIENT_VERTICAL, layoutParams), pspKey_(pspKey), keyName_(keyName), scrm_(scrm), portrait_(portrait) {
+		Refresh();
+	}
 	~SingleControlMapper() {
 		g_IsMappingMouseInput = false;
 	}
@@ -81,11 +78,6 @@ private:
 	ScreenManager *scrm_;
 	bool portrait_;
 };
-
-SingleControlMapper::SingleControlMapper(int pspKey, std::string keyName, bool portrait, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams)
-	: UI::LinearLayout(ORIENT_VERTICAL, layoutParams), pspKey_(pspKey), keyName_(keyName), scrm_(scrm), portrait_(portrait) {
-	Refresh();
-}
 
 void SingleControlMapper::Refresh() {
 	Clear();

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -302,7 +302,9 @@ void ControlMappingScreen::OnAutoConfigure(UI::EventParams &params) {
 		items.push_back(*s);
 	}
 	auto km = GetI18NCategory(I18NCat::KEYMAPPING);
+	auto di = GetI18NCategory(I18NCat::DIALOG);
 	UI::ListPopupScreen *autoConfList = new UI::ListPopupScreen(km->T("Autoconfigure for device"), items, -1);
+	autoConfList->SetNotification(NoticeLevel::WARN, di->T("This will overwrite the existing configuration"));
 	if (params.v)
 		autoConfList->SetPopupOrigin(params.v);
 	screenManager()->push(autoConfList);

--- a/UI/DriverManagerScreen.cpp
+++ b/UI/DriverManagerScreen.cpp
@@ -6,6 +6,7 @@
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
 #include "Common/UI/PopupScreens.h"
+#include "Common/UI/Notice.h"
 
 #include "Core/Config.h"
 #include "Core/System.h"

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -24,6 +24,7 @@
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
 #include "Common/UI/PopupScreens.h"
+#include "Common/UI/Notice.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/Data/Encoding/Utf8.h"

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -29,6 +29,7 @@
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
 #include "Common/UI/Context.h"
+#include "Common/UI/Notice.h"
 #include "Common/Render/ManagedTexture.h"
 #include "Common/VR/PPSSPPVR.h"
 #include "Common/BitSet.h"
@@ -37,7 +38,6 @@
 #include "Common/System/OSD.h"
 #include "Common/System/NativeApp.h"
 #include "Common/Data/Color/RGBAUtil.h"
-#include "Common/Math/curves.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/UI/PopupScreens.h"
@@ -66,8 +66,6 @@
 
 #include "Common/File/FileUtil.h"
 #include "Common/File/AndroidContentURI.h"
-#include "Common/OSVersion.h"
-#include "Common/TimeUtil.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -79,11 +77,7 @@
 #include "Core/HLE/sceUsbCam.h"
 #include "Core/HLE/sceUsbMic.h"
 #include "Core/HLE/sceUtility.h"
-#include "GPU/Common/TextureReplacer.h"
 #include "GPU/Common/PostShader.h"
-#include "GPU/Common/FramebufferManagerCommon.h"
-
-#include "Core/Core.h" // for Core_IsStepping
 
 #if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
 #include "UI/DarwinFileSystemServices.h"

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -18,6 +18,7 @@
 #include "Common/UI/UI.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
+#include "Common/UI/Notice.h"
 
 #include "Common/StringUtils.h"
 #include "Common/File/FileUtil.h"

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -152,9 +152,13 @@ public:
 		bool showInfo = false;
 
 		if (HasFocus() && UI::IsInfoKey(key)) {
-			// If the button mapped to triangle, then show the info.
-			if (key.flags & KeyInputFlags::UP) {
+			// If it's the button that's mapped to triangle, then show the info.
+			if (key.flags & KeyInputFlags::DOWN) {
+				infoKeyPressed_ = true;
+			}
+			if ((key.flags & KeyInputFlags::UP) && infoKeyPressed_) {
 				showInfo = true;
+				infoKeyPressed_ = false;
 			}
 		} else if (hovering_ && key.deviceId == DEVICE_ID_MOUSE && key.keyCode == NKCODE_EXT_MOUSEBUTTON_2) {
 			// If it's the right mouse button, and it's not otherwise mapped, show the info also.
@@ -214,6 +218,7 @@ private:
 	double holdStart_ = 0.0;
 	bool holdEnabled_ = true;
 	bool showInfoPressed_ = false;
+	bool infoKeyPressed_ = false;
 	bool hovering_ = false;
 };
 

--- a/UI/MemStickScreen.cpp
+++ b/UI/MemStickScreen.cpp
@@ -40,6 +40,7 @@
 
 #include "Common/Thread/ThreadManager.h"
 #include "Common/UI/ScrollView.h"
+#include "Common/UI/Notice.h"
 
 #include "Core/Config.h"
 #include "Core/Reporting.h"

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -14,6 +14,7 @@
 #include "UI/DebugOverlay.h"
 
 #include "Common/UI/Context.h"
+#include "Common/UI/Notice.h"
 #include "Common/System/OSD.h"
 
 #include "Common/TimeUtil.h"
@@ -26,91 +27,6 @@ static inline const char *DeNull(const char *ptr) {
 extern bool g_TakeScreenshot;
 
 static const float g_atlasIconSize = 36.0f;
-static const float extraTextScale = 0.7f;
-
-static uint32_t GetNoticeBackgroundColor(NoticeLevel type) {
-	// Colors from Infima
-	switch (type) {
-	case NoticeLevel::ERROR: return 0x3530d5;  // danger-darker
-	case NoticeLevel::WARN: return 0x009ed9;  // warning-darker
-	case NoticeLevel::INFO: return 0x706760;  // gray-700
-	case NoticeLevel::SUCCESS: return 0x008b00;  // nice green
-	default: return 0x606770;
-	}
-}
-
-static ImageID GetOSDIcon(NoticeLevel level) {
-	switch (level) {
-	case NoticeLevel::INFO: return ImageID("I_INFO");
-	case NoticeLevel::ERROR: return ImageID("I_CROSS");
-	case NoticeLevel::WARN: return ImageID("I_WARNING");
-	case NoticeLevel::SUCCESS: return ImageID("I_CHECKMARK");
-	default: return ImageID::invalid();
-	}
-}
-
-static NoticeLevel GetNoticeLevel(OSDType type) {
-	switch (type) {
-	case OSDType::MESSAGE_INFO:
-		return NoticeLevel::INFO;
-	case OSDType::MESSAGE_ERROR:
-	case OSDType::MESSAGE_ERROR_DUMP:
-	case OSDType::MESSAGE_CENTERED_ERROR:
-		return NoticeLevel::ERROR;
-	case OSDType::MESSAGE_WARNING:
-	case OSDType::MESSAGE_CENTERED_WARNING:
-		return NoticeLevel::WARN;
-	case OSDType::MESSAGE_SUCCESS:
-		return NoticeLevel::SUCCESS;
-	default:
-		return NoticeLevel::SUCCESS;
-	}
-}
-
-// Align only matters here for the ASCII-only flag.
-static void MeasureNotice(const UIContext &dc, NoticeLevel level, const std::string &text, const std::string &details, const std::string &iconName, int align, float maxWidth, float *width, float *height, float *height1) {
-	float iconW = 0.0f;
-	float iconH = 0.0f;
-	if (!iconName.empty() && !startsWith(iconName, "I_")) {  // Check for atlas image. Bit hacky, but we choose prefixes for icon IDs anyway in a way that this is safe.
-		// Normal entry but with a cached icon.
-		int iconWidth, iconHeight;
-		if (g_iconCache.GetDimensions(iconName, &iconWidth, &iconHeight)) {
-			*width += 5.0f + iconWidth;
-			iconW = iconWidth;
-			iconH = iconHeight;
-		}
-	} else {
-		ImageID iconID = iconName.empty() ? GetOSDIcon(level) : ImageID(iconName.c_str());
-		if (iconID.isValid()) {
-			dc.Draw()->GetAtlas()->measureImage(iconID, &iconW, &iconH);
-		}
-	}
-
-	float chromeWidth = iconW + 5.0f + 12.0f;
-	float availableWidth = maxWidth - chromeWidth;
-
-	// OK, now that we have figured out how much space we have for the text, we can measure it (with wrapping if needed).
-	// We currently don't wrap the title.
-
-	float titleWidth, titleHeight;
-	dc.MeasureText(dc.GetTheme().uiFont, 1.0f, 1.0f, text, &titleWidth, &titleHeight, align);
-
-	*width = std::min(titleWidth, availableWidth);
-	*height1 = titleHeight;
-
-	float width2 = 0.0f, height2 = 0.0f;
-	if (!details.empty()) {
-		dc.MeasureTextRect(dc.GetTheme().uiFont, extraTextScale, extraTextScale, details, availableWidth, &width2, &height2, align | FLAG_WRAP_TEXT);
-		*width = std::max(*width, width2);
-	}
-
-	*width += chromeWidth;
-	if (height2 == 0.0f && iconH < 2.0f * *height1) {
-		// Center vertically using the icon.
-		*height1 = std::max(*height1, iconH + 2.0f);
-	}
-	*height = std::max(*height1 + height2 + 8.0f, iconH + 5.0f);
-}
 
 // Align only matters here for the ASCII-only flag.
 static void MeasureOSDEntry(const UIContext &dc, const OnScreenDisplay::Entry &entry, int align, float maxWidth, float *width, float *height, float *height1) {
@@ -122,74 +38,6 @@ static void MeasureOSDEntry(const UIContext &dc, const OnScreenDisplay::Entry &e
 	} else {
 		MeasureNotice(dc, GetNoticeLevel(entry.type), entry.text, entry.text2, entry.iconName, align, maxWidth, width, height, height1);
 	}
-}
-
-static void RenderNotice(UIContext &dc, Bounds bounds, float height1, NoticeLevel level, const std::string &text, const std::string &details, const std::string &iconName, int align, float alpha, OSDMessageFlags flags, float timeVal) {
-	UI::Drawable background = UI::Drawable(colorAlpha(GetNoticeBackgroundColor(level), alpha));
-
-	dc.SetFontStyle(dc.GetTheme().uiFont);
-
-	uint32_t foreGround = whiteAlpha(alpha);
-
-	if (!(flags & OSDMessageFlags::Transparent)) {
-		dc.DrawRectDropShadow(bounds, 12.0f, 0.7f * alpha);
-		dc.FillRect(background, bounds);
-	}
-
-	float iconW = 0.0f;
-	float iconH = 0.0f;
-	if (!iconName.empty() && !startsWith(iconName, "I_")) {
-		dc.Flush();
-		// Normal entry but with a cached icon.
-		Draw::Texture *texture = g_iconCache.BindIconTexture(&dc, iconName);
-		if (texture) {
-			iconW = texture->Width();
-			iconH = texture->Height();
-			dc.Draw()->DrawTexRect(Bounds(bounds.x + 2.5f, bounds.y + 2.5f, iconW, iconH), 0.0f, 0.0f, 1.0f, 1.0f, foreGround);
-			dc.Flush();
-			dc.RebindTexture();
-		}
-		dc.Begin();
-	} else {
-		ImageID iconID = iconName.empty() ? GetOSDIcon(level) : ImageID(iconName.c_str());
-		if (iconID.isValid()) {
-			// Atlas icon.
-			dc.Draw()->GetAtlas()->measureImage(iconID, &iconW, &iconH);
-			if (!iconName.empty()) {
-				Bounds iconBounds = Bounds(bounds.x + 2.5f, bounds.y + 2.5f, iconW, iconH);
-				// If it's not a preset OSD icon, give it some background to blend in. The RA icon for example
-				// easily melts into the orange of warnings otherwise.
-				dc.FillRect(UI::Drawable(0x50000000), iconBounds.Expand(2.0f));
-			}
-
-			if (flags & (OSDMessageFlags::SpinLeft | OSDMessageFlags::SpinRight)) {
-				const float direction = (flags & OSDMessageFlags::SpinLeft) ? -1.5f : 1.5f;
-				dc.DrawImageRotated(iconID, bounds.x + 2.5f + iconW * 0.5f, bounds.y + 2.5f + iconW * 0.5f, 1.0f, direction * timeVal, foreGround, false);
-			} else {
-				dc.DrawImageVGradient(iconID, foreGround, foreGround, Bounds(bounds.x + 2.5f, bounds.y + 2.5f, iconW, iconH));
-			}
-		}
-	}
-
-	// Make room
-	bounds.x += iconW + 5.0f;
-	bounds.w -= iconW + 5.0f;
-
-	Bounds primaryBounds = bounds;
-	primaryBounds.h = height1;
-
-	dc.DrawTextShadowRect(text, primaryBounds.Inset(2.0f, 0.0f, 1.0f, 0.0f), foreGround, (align & FLAG_DYNAMIC_ASCII) | ALIGN_VCENTER | FLAG_ELLIPSIZE_TEXT);
-
-	if (!details.empty()) {
-		Bounds bottomTextBounds = bounds.Inset(3.0f, height1 + 5.0f, 3.0f, 3.0f);
-		if (!(flags & OSDMessageFlags::Transparent)) {
-			UI::Drawable backgroundDark = UI::Drawable(colorAlpha(darkenColor(GetNoticeBackgroundColor(level)), alpha));
-			dc.FillRect(backgroundDark, bottomTextBounds);
-		}
-		dc.SetFontScale(extraTextScale, extraTextScale);
-		dc.DrawTextRect(details, bottomTextBounds.Inset(1.0f, 1.0f), foreGround, (align & FLAG_DYNAMIC_ASCII) | ALIGN_LEFT | FLAG_WRAP_TEXT);
-	}
-	dc.SetFontScale(1.0f, 1.0f);
 }
 
 static void RenderOSDEntry(UIContext &dc, const OnScreenDisplay::Entry &entry, Bounds bounds, float height1, int align, float alpha, float now) {

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -433,7 +433,8 @@ void NoticeView::GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec
 		layoutWidth = horiz.size;
 	}
 	ApplyBoundBySpec(layoutWidth, horiz);
-	MeasureNotice(dc, level_, text_, detailsText_, iconName_, 0, layoutWidth, &w, &h, &height1_);
+	const int align = wrapText_ ? FLAG_WRAP_TEXT : 0;
+	MeasureNotice(dc, level_, text_, detailsText_, iconName_, align, layoutWidth, &w, &h, &height1_);
 	// Layout hack! Some weird problems with the layout that I can't figure out right now..
 	if (squishy_) {
 		w = 50.0;
@@ -442,6 +443,7 @@ void NoticeView::GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec
 
 void NoticeView::Draw(UIContext &dc) {
 	dc.PushScissor(bounds_);
-	RenderNotice(dc, bounds_, height1_, level_, text_, detailsText_, iconName_, 0, 1.0f, OSDMessageFlags::None, 0.0f);
+	const int align = wrapText_ ? FLAG_WRAP_TEXT : 0;
+	RenderNotice(dc, bounds_, height1_, level_, text_, detailsText_, iconName_, align, 1.0f, OSDMessageFlags::None, 0.0f);
 	dc.PopScissor();
 }

--- a/UI/OnScreenDisplay.h
+++ b/UI/OnScreenDisplay.h
@@ -51,39 +51,3 @@ private:
 	OnScreenMessagesView *osmView_ = nullptr;
 };
 
-enum class NoticeLevel {
-	SUCCESS,
-	INFO,
-	WARN,
-	ERROR,
-};
-
-class NoticeView : public UI::InertView {
-public:
-	NoticeView(NoticeLevel level, std::string_view text, std::string_view detailsText, UI::LayoutParams *layoutParams = 0)
-		: InertView(layoutParams), level_(level), text_(text), detailsText_(detailsText), iconName_("") {}
-
-	void SetIconName(std::string_view name) {
-		iconName_ = name;
-	}
-	void SetText(std::string_view text) {
-		text_ = text;
-	}
-	void SetLevel(NoticeLevel level) {
-		level_ = level;
-	}
-	void SetSquishy(bool squishy) {
-		squishy_ = squishy;
-	}
-
-	void GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const override;
-	void Draw(UIContext &dc) override;
-
-private:
-	std::string text_;
-	std::string detailsText_;
-	std::string iconName_;
-	NoticeLevel level_;
-	mutable float height1_ = 0.0f;
-	bool squishy_ = false;
-};

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -24,6 +24,7 @@
 #include "Common/UI/Context.h"
 #include "Common/UI/UIScreen.h"
 #include "Common/UI/PopupScreens.h"
+#include "Common/UI/Notice.h"
 #include "Common/GPU/thin3d.h"
 
 #include "Common/Data/Text/I18n.h"

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -36,6 +36,7 @@
 
 #include "Common/File/PathBrowser.h"
 #include "Common/UI/PopupScreens.h"
+#include "Common/UI/Notice.h"
 #include "Common/Data/Format/JSONReader.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Common.h"

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -7,6 +7,7 @@
 #include "Common/UI/Context.h"
 #include "Common/UI/IconCache.h"
 #include "Common/UI/PopupScreens.h"
+#include "Common/UI/Notice.h"
 #include "Common/StringUtils.h"
 
 #include "Core/Config.h"

--- a/UI/SystemInfoScreen.cpp
+++ b/UI/SystemInfoScreen.cpp
@@ -18,6 +18,7 @@
 #include "Common/Render/Text/draw_text.h"
 #include "Common/System/Request.h"
 #include "Common/UI/Context.h"
+#include "Common/UI/Notice.h"
 #include "Core/System.h"
 #include "Core/Config.h"
 #include "GPU/GPUState.h"  // ugh

--- a/UI/UIAtlas.cpp
+++ b/UI/UIAtlas.cpp
@@ -409,7 +409,7 @@ static bool GenerateUIAtlasImage(Atlas *atlas, float dpiScale, Image *dest, int 
 	int imageWidth = RoundToNextPowerOf2((int)sqrtf(area));
 
 	Instant bucketStart = Instant::Now();
-	bucket.Pack(imageWidth);
+	bucket.Pack2(imageWidth);
 	INFO_LOG(Log::G3D, " - Packed in %.2f ms (image size: %dx%d)", bucketStart.ElapsedMs(), bucket.w, bucket.h);
 
 	Instant resolveStart = Instant::Now();

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -217,6 +217,7 @@
     <ClInclude Include="..\..\Common\UI\AsyncImageFileView.h" />
     <ClInclude Include="..\..\Common\UI\Context.h" />
     <ClInclude Include="..\..\Common\UI\IconCache.h" />
+    <ClInclude Include="..\..\Common\UI\Notice.h" />
     <ClInclude Include="..\..\Common\UI\PopupScreens.h" />
     <ClInclude Include="..\..\Common\UI\Root.h" />
     <ClInclude Include="..\..\Common\UI\Screen.h" />
@@ -385,6 +386,7 @@
     <ClCompile Include="..\..\Common\UI\AsyncImageFileView.cpp" />
     <ClCompile Include="..\..\Common\UI\Context.cpp" />
     <ClCompile Include="..\..\Common\UI\IconCache.cpp" />
+    <ClCompile Include="..\..\Common\UI\Notice.cpp" />
     <ClCompile Include="..\..\Common\UI\PopupScreens.cpp" />
     <ClCompile Include="..\..\Common\UI\Root.cpp" />
     <ClCompile Include="..\..\Common\UI\Screen.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -544,6 +544,9 @@
     <ClCompile Include="..\..\ext\aemu_postoffice\client\sock_impl_windows.c">
       <Filter>ext\aemu_postoffice</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\UI\Notice.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="targetver.h" />
@@ -1040,6 +1043,9 @@
     </ClInclude>
     <ClInclude Include="..\..\ext\aemu_postoffice\client\delay_impl.h">
       <Filter>ext\aemu_postoffice</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\UI\Notice.h">
+      <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -173,6 +173,8 @@ DinputDevice::DinputDevice(int devnum) {
 }
 
 DinputDevice::~DinputDevice() {
+	KeyMap::NotifyPadDisconnected(DEVICE_ID_PAD_0 + pDevNum);
+
 	if (pJoystick) {
 		pJoystick = nullptr;
 	}

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -174,6 +174,7 @@ DinputDevice::DinputDevice(int devnum) {
 
 DinputDevice::~DinputDevice() {
 	KeyMap::NotifyPadDisconnected(DEVICE_ID_PAD_0 + pDevNum);
+	ReleaseAllKeys();
 
 	if (pJoystick) {
 		pJoystick = nullptr;
@@ -187,6 +188,48 @@ DinputDevice::~DinputDevice() {
 	//unsafe as well anyway
 	if (pInstances == 0 && pDI) {
 		pDI = nullptr;
+	}
+}
+
+void DinputDevice::ReleaseAllKeys() {
+	KeyInput key;
+	key.deviceId = DEVICE_ID_PAD_0 + pDevNum;
+	key.flags = KeyInputFlags::UP;
+	for (int i = 0; i < ARRAY_SIZE(dinput_buttons); ++i) {
+		if (lastButtons_[i] != 0) {
+			key.keyCode = dinput_buttons[i];
+			NativeKey(key);
+			lastButtons_[i] = 0;
+		}
+	}
+
+	// Release DPad
+	static const InputKeyCode dpadCodes[] = {
+		NKCODE_DPAD_UP,
+		NKCODE_DPAD_DOWN,
+		NKCODE_DPAD_LEFT,
+		NKCODE_DPAD_RIGHT
+	};
+	for (int i = 0; i < ARRAY_SIZE(dpadCodes); ++i) {
+		key.keyCode = dpadCodes[i];
+		NativeKey(key);
+	}
+
+	// Release axes
+	static const InputAxis axes[] = {
+		JOYSTICK_AXIS_X,
+		JOYSTICK_AXIS_Y,
+		JOYSTICK_AXIS_Z,
+		JOYSTICK_AXIS_RX,
+		JOYSTICK_AXIS_RY,
+		JOYSTICK_AXIS_RZ
+	};
+	for (int i = 0; i < ARRAY_SIZE(axes); ++i) {
+		AxisInput axis;
+		axis.deviceId = DEVICE_ID_PAD_0 + pDevNum;
+		axis.axisId = axes[i];
+		axis.value = 0.0f;
+		NativeAxis(&axis, 1);
 	}
 }
 

--- a/Windows/DinputDevice.h
+++ b/Windows/DinputDevice.h
@@ -45,6 +45,7 @@ public:
 	}
 
 private:
+	void ReleaseAllKeys();
 	void ApplyButtons(DIJOYSTATE2 &state);
 	//unfortunate and unclean way to keep only one DirectInput instance around
 	static LPDIRECTINPUT8 getPDI();

--- a/Windows/HidInputDevice.h
+++ b/Windows/HidInputDevice.h
@@ -47,6 +47,7 @@ private:
 
 	HIDControllerType subType_{};
 	HANDLE controller_;
+	std::string name_;
 	int pad_ = 0;
 	int pollCount_ = 0;
 	int reportSize_ = 0;

--- a/Windows/XinputDevice.h
+++ b/Windows/XinputDevice.h
@@ -16,13 +16,18 @@ private:
 	void ApplyButtons(int pad, const XINPUT_STATE &state);
 	void ApplyVibration(int pad, XINPUT_VIBRATION &vibration);
 
-	bool connected_[4]{};
-	int checkDelayUpdates_[4]{};
-	XINPUT_STATE prevState_[4]{};
-	XINPUT_VIBRATION prevVibration_[4]{};
+	struct PadData {
+		bool notified = false;
+		bool connected = false;
+		int checkDelayUpdates = 0;
+		XINPUT_STATE prevState{};
+		XINPUT_VIBRATION prevVibration{};
+		u16 vendorId = 0;
+		u16 productId = 0;
+		float prevAxisValue[6]{};
+		u32 prevButtons = 0;
+	};
+	PadData padData_[XUSER_MAX_COUNT];
 	double prevVibrationTime_ = 0.0;
-	float prevAxisValue_[4][6]{};
-	bool notified_[XUSER_MAX_COUNT]{};
-	u32 prevButtons_[4]{};
 	double newVibrationTime_ = 0.0;
 };

--- a/Windows/XinputDevice.h
+++ b/Windows/XinputDevice.h
@@ -12,12 +12,15 @@ public:
 
 private:
 	void UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATION &vibration);
+	void ReleaseAllKeys(int pad);
 	void ApplyButtons(int pad, const XINPUT_STATE &state);
 	void ApplyVibration(int pad, XINPUT_VIBRATION &vibration);
-	int check_delay[4]{};
-	XINPUT_STATE prevState[4]{};
-	XINPUT_VIBRATION prevVibration[4]{};
-	double prevVibrationTime = 0.0;
+
+	bool connected_[4]{};
+	int checkDelayUpdates_[4]{};
+	XINPUT_STATE prevState_[4]{};
+	XINPUT_VIBRATION prevVibration_[4]{};
+	double prevVibrationTime_ = 0.0;
 	float prevAxisValue_[4][6]{};
 	bool notified_[XUSER_MAX_COUNT]{};
 	u32 prevButtons_[4]{};

--- a/Windows/XinputDevice.h
+++ b/Windows/XinputDevice.h
@@ -17,7 +17,6 @@ private:
 	void ApplyVibration(int pad, XINPUT_VIBRATION &vibration);
 
 	struct PadData {
-		bool notified = false;
 		bool connected = false;
 		int checkDelayUpdates = 0;
 		XINPUT_STATE prevState{};

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -361,6 +361,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/UI/Context.cpp \
   $(SRC)/Common/UI/UIScreen.cpp \
   $(SRC)/Common/UI/Tween.cpp \
+  $(SRC)/Common/UI/Notice.cpp \
   $(SRC)/Common/UI/IconCache.cpp \
   $(SRC)/Common/UI/View.cpp \
   $(SRC)/Common/UI/ViewGroup.cpp \

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -863,8 +863,11 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 			if (mSurface != null) {
 				// applyFramerate is called in here.
 				startRenderLoopThread();
+			} else {
+				Log.i(TAG, "Notified surface is null, not starting thread.");
 			}
 		} else if (mSurface != null) {
+			// JavaGL path.
 			applyFrameRate(mSurface, 60.0f);
 		}
 		updateSustainedPerformanceMode();

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -495,6 +495,7 @@ Submit = ‎تقديم
 Supported = مدعوم
 There is no data = ‎ليس هناك بيانات.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = سيؤدي ذلك إلى الكتابة فوق الإعدادات الحالية # AI translated
 Toggle All = ‎تبديل الكل
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -491,6 +491,7 @@ Submit = Göndər
 Supported = Dəstəklənir
 There is no data = Verilən yoxdur
 This change will not take effect until PPSSPP is restarted. = PPSSPP yenidən başladılmadan bu dəyişim işə düşməyəcək.
+This will overwrite the existing configuration = Bu, mövcud konfiqurasiyanı üstələyəcək # AI translated
 Toggle All = Hamısını keçirt
 Toggle List = Sıralığı keçirt
 Top Center = Üst orta

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -487,6 +487,7 @@ Submit = Адправіць
 Supported = Падтрымліваецца
 There is no data = Няма дадзеных.
 This change will not take effect until PPSSPP is restarted. = Гэта змяненне не ўступіць у сілу, пакуль PPSSPP не будзе перазапушчаны.
+This will overwrite the existing configuration = Гэта перапіша існуючую канфігурацыю # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Уверсе па цэнтры

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Supported
 There is no data = Няма данни.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Това ще презапише съществуващата конфигурация # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -487,6 +487,7 @@ Submit = Enviar
 Supported = Suportat
 There is no data = No hi han dades
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Això substituirà la configuració existent # AI translated
 Toggle All = Canviar tot
 Toggle List = Veure llista
 Top Center = Top center

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -487,6 +487,7 @@ Submit = Odeslat
 Supported = Supported
 There is no data = Žádná data k dispozici.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = To přepíše stávající konfiguraci # AI translated
 Toggle All = Přepnout vše
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -487,6 +487,7 @@ Submit = Indsend
 Supported = Supported
 There is no data = Der findes ingen data.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Dette vil overskrive den eksisterende konfiguration # AI translated
 Toggle All = Skift alle
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -477,6 +477,7 @@ SSID = SSID
 Submit = Einreichen
 Supported = Unterstützt
 There is no data = Keine Daten vorhanden
+This will overwrite the existing configuration = Dies überschreibt die vorhandene Konfiguration # AI translated
 Toggle All = Alle umschalten
 Toggle List = Liste umschalten
 Top Center = Mitte oben

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Supported
 There is no data = Ai edda data mane.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Ini akan menimpa konfigurasi yang ada # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -511,6 +511,7 @@ Submit = Submit
 Supported = Supported
 There is no data = There is no data.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = This will overwrite the existing configuration
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -488,6 +488,7 @@ Submit = Enviar
 Supported = Soportado
 There is no data = No hay datos.
 This change will not take effect until PPSSPP is restarted. = Este cambio no tendrá efecto hasta que se reinicie PPSSPP.
+This will overwrite the existing configuration = Esto sobrescribirá la configuración existente # AI translated
 Toggle All = Cambiar todo
 Toggle List = Ver lista
 Top Center = Superior centrado

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -487,6 +487,7 @@ Submit = Enviar
 Supported = Soportado
 There is no data = No se han encontrado datos del juego.
 This change will not take effect until PPSSPP is restarted. = Este cambio no tendrá efecto hasta que se reinicie PPSSPP.
+This will overwrite the existing configuration = Esto sobrescribirá la configuración existente # AI translated
 Toggle All = Cambiar todo
 Toggle List = Cambiar lista
 Top Center = Arriba centrado

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -487,6 +487,7 @@ Submit = تایید کردن
 Supported = حمایت میشود
 There is no data = ‎.داده‌ای وجود ندارد
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = این تنظیمات موجود را بازنویسی خواهد کرد # AI translated
 Toggle All = تغییر وضعیت همه
 Toggle List = تغییر وضعیت لیست
 Top Center = Top center

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Tuettu
 There is no data = Dataa ei ole.
 This change will not take effect until PPSSPP is restarted. = Tämä muutos ei tule voimaan ennen kuin PPSSPPP on uudelleen käynnistetty.
+This will overwrite the existing configuration = Tämä ylikirjoittaa olemassa olevan kokoonpanon # AI translated
 Toggle All = Vaihda kaikki
 Toggle List = Vaihda lista
 Top Center = Ylhäällä keskellä

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -487,6 +487,7 @@ Submit = Envoyer
 Supported = Supporté
 There is no data = Aucune donnée trouvée.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Cela écrasera la configuration existante # AI translated
 Toggle All = Tout cocher
 Toggle List = Afficher liste
 Top Center = En haut au centre

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -487,6 +487,7 @@ Submit = Enviar
 Supported = Supported
 There is no data = A tarxeta de memoria está baleira.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Isto sobrescribir á configuración existente # AI translated
 Toggle All = Cambiar todo
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -487,6 +487,7 @@ Submit = ΥΠΟΒΟΛΗ
 Supported = Supported
 There is no data = ΔΕΝ ΥΠΑΡΧΟΥΝ ΔΕΔΟΜΕΝΑ
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Αυτό θα αντικαταστήσει την υπάρχουσα διαμόρφωση # AI translated
 Toggle All = ΕΝΑΛΛΑΓΗ ΟΛΩΝ
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Supported
 There is no data = .םינותנ ןיא
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = זה יחליף את התצורה הקיימת # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -484,6 +484,7 @@ Submit = Submit
 Supported = Supported
 There is no data = .םינותנ ןיא
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = זה יחליף את התצורה הקיימת # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Podržano
 There is no data = Nema date.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = To će prepisati postojeću konfiguraciju # AI translated
 Toggle All = Uključi sve
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -487,6 +487,7 @@ Submit = Elküld
 Supported = Támogatott
 There is no data = Nincs adat.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Ez felülírja a meglévő konfigurációt # AI translated
 Toggle All = Összes át-\nkapcsolása
 Toggle List = Lista
 Top Center = Felül középen

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -487,6 +487,7 @@ Submit = Ajukan
 Supported = Didukung
 There is no data = Tidak ada data.
 This change will not take effect until PPSSPP is restarted. = Mulai ulang PPSSPP untuk melihat perubahan pengaturan.
+This will overwrite the existing configuration = Ini akan menimpa konfigurasi yang ada # AI translated
 Toggle All = Aktifkan semua
 Toggle List = Daftar pengalihan
 Top Center = Tengah atas

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -487,6 +487,7 @@ Submit = Invia
 Supported = Supportato
 There is no data = Non ci sono dati.
 This change will not take effect until PPSSPP is restarted. = Questa modifica non avrà effetto fino al riavvio di PPSSPP.
+This will overwrite the existing configuration = Questo sovrascriverà la configurazione esistente # AI translated
 Toggle All = Attiva Tutto
 Toggle List = Mostra lista
 Top Center = In alto al centro

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -487,6 +487,7 @@ Submit = 決定
 Supported = サポートしています
 There is no data = データがありません。
 This change will not take effect until PPSSPP is restarted. = この変更はPPSSPPを再起動するまで有効になりません。
+This will overwrite the existing configuration = これは既存の設定を上書きします # AI translated
 Toggle All = 全て反転する
 Toggle List = 切り替えリスト
 Top Center = 上中央

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -487,6 +487,7 @@ Submit = Kerem
 Supported = Supported
 There is no data = Ora ana data.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Iki bakal nulis ulang konfigurasi sing ana # AI translated
 Toggle All = Peleh kabeh
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -487,6 +487,7 @@ Submit = 전송
 Supported = 지원
 There is no data = 데이터가 없습니다.
 This change will not take effect until PPSSPP is restarted. = 이 변경 사항은 PPSSPP를 다시 시작할 때까지 적용되지 않습니다.
+This will overwrite the existing configuration = 이것은 기존 구성을 덮어씁니다 # AI translated
 Toggle All = 모두 토글
 Toggle List = 토글 목록
 Top Center = 상단 중앙

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -501,6 +501,7 @@ Submit = Submit
 Supported = Supported
 There is no data = زانیاری بوونی نیە لەسەری
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Vê, konfigurasiyê hebe nûser dike # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -487,6 +487,7 @@ Submit = ຍອມຮັບ
 Supported = Supported
 There is no data = ບໍ່ມີຂໍ້ມູນ.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = ນີ້ຈະເຂົ້າໃສ່ການຕັ້ງຄ່າທີ່ມີຢູ່ # AI translated
 Toggle All = ເລືອກທັງໝົດ
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -487,6 +487,7 @@ Submit = Patvirtinti
 Supported = Supported
 There is no data = Čia nėra jokių duomenų.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Tai perrašys esamą konfigūraciją # AI translated
 Toggle All = Perjungti visus
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Supported
 There is no data = Tiada data disini.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Ini akan menimpa konfigurasi yang ada # AI translated
 Toggle All = Periksa semua
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -487,6 +487,7 @@ Submit = Verzenden
 Supported = Ondersteund
 There is no data = Er zijn geen data.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Dit zal de bestaande configuratie overschrijven # AI translated
 Toggle All = Alles schakelen
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -487,6 +487,7 @@ Submit = Submit
 Supported = Supported
 There is no data = Det finnes ingen data.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Dette vil overskrive eksisterende konfigurasjon # AI translated
 Toggle All = Toggle all
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -485,6 +485,7 @@ Submit = Wyślij
 Supported = Wspierane
 There is no data = Brak danych.
 This change will not take effect until PPSSPP is restarted. = Ta zmiana nie wejdzie w życie, dopóki PPSSPP nie zostanie ponownie uruchomiony.
+This will overwrite the existing configuration = To nadpisze istniejącą konfigurację # AI translated
 Toggle All = Wybierz wszystko
 Toggle List = Wybierz listę
 Top Center = Górny środek

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -510,6 +510,7 @@ Submit = Submeter
 Supported = Suportado
 There is no data = Não há dados.
 This change will not take effect until PPSSPP is restarted. = Esta mudança não terá efeito até o PPSSPP ser reiniciado.
+This will overwrite the existing configuration = Isto irá sobrescrever a configuração existente # AI translated
 Toggle All = Alternar todos
 Toggle List = Alternar lista
 Top Center = No centro do topo

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -511,6 +511,7 @@ Submit = Enviar
 Supported = Compatível
 There is no data = Não existem dados.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Isto irá sobrescrever a configuração existente # AI translated
 Toggle All = Alternar todos
 Toggle List = Alternar lista
 Top Center = Centro superior

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -488,6 +488,7 @@ Submit = Trimite
 Supported = Supported
 There is no data = Salvare inexistentă
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Acesta va suprascrie configurația existentă # AI translated
 Toggle All = Schimbă tot
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -487,6 +487,7 @@ Submit = Выполнение
 Supported = Поддерживается
 There is no data = Нет данных
 This change will not take effect until PPSSPP is restarted. = Изменение будет применено только после перезапуска PPSSPP.
+This will overwrite the existing configuration = Это перепишет существующую конфигурацию # AI translated
 Toggle All = Переключить все
 Toggle List = Переключить список
 Top Center = Вверху в центре

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -488,6 +488,7 @@ Submit = Skicka
 Supported = Stöds
 There is no data = Det finns ingen data.
 This change will not take effect until PPSSPP is restarted. = Denna ändring träder inte i kraft förrän PPSSPP har startats om.
+This will overwrite the existing configuration = Detta kommer att skriva över den befintliga konfigurationen # AI translated
 Toggle All = Vänd alla
 Toggle List = Vänd lista
 Top Center = Överkant centrerad

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -488,6 +488,7 @@ Submit = I-Submit
 Supported = Suportado
 There is no data = Walang Datos
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Ин ин конфигуратсияи пойгоҳии мавҷударо дигар мекунад # AI translated
 Toggle All = I-toggle lahat
 Toggle List = I-Toggle list
 Top Center = Gitnang paitaas

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -503,6 +503,7 @@ Submit = ตกลง
 Supported = รองรับ
 There is no data = ไม่มีข้อมูล
 This change will not take effect until PPSSPP is restarted. = การเปลี่ยนแปลงนี้จะไม่มีผลจนกว่าจะรีสตาร์ท PPSSPP
+This will overwrite the existing configuration = นี้จะเขียนทับการตั้งค่าที่มีอยู่ # AI translated
 Toggle All = ทั้งหมด
 Toggle List = รายการ
 Top Center = มุมบนกลางจอ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -489,6 +489,7 @@ Submit = Gönder
 Supported = Destekleniyor
 There is no data = Veri yok.
 This change will not take effect until PPSSPP is restarted. = Bu değişiklik PPSSPP yeniden başlatılana kadar geçerli olmayacaktır.
+This will overwrite the existing configuration = Bu, mevcut yapılandırmayı geçersiz kılacak # AI translated
 Toggle All = Tümünü Değiştir
 Toggle List = Listeyi Değiştir
 Top Center = Orta Üst

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -487,6 +487,7 @@ Submit = Виконання
 Supported = Підтримується
 There is no data = Немає даних
 This change will not take effect until PPSSPP is restarted. = Ця зміна не набуде чинності, доки PPSSPP не буде перезапущено.
+This will overwrite the existing configuration = Це перезапише існуючу конфігурацію # AI translated
 Toggle All = Переключити все
 Toggle List = Переключити список
 Top Center = Верхній центр

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -487,6 +487,7 @@ Submit = Gửi đi
 Supported = Được hỗ trợ
 There is no data = Không có dữ liệu.
 This change will not take effect until PPSSPP is restarted. = This change will not take effect until PPSSPP is restarted.
+This will overwrite the existing configuration = Điều này sẽ ghi đè cấu hình hiện có # AI translated
 Toggle All = Tất cả
 Toggle List = Toggle list
 Top Center = Top center

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -487,6 +487,7 @@ Submit = 提交
 Supported = 支持
 There is no data = 存档不存在。
 This change will not take effect until PPSSPP is restarted. = 重启 PPSSPP 后配置才会生效。
+This will overwrite the existing configuration = 这将覆盖现有配置 # AI translated
 Toggle All = 全选/不选
 Toggle List = 展开列表
 Top Center = 正上方

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -487,6 +487,7 @@ Submit = 提交
 Supported = 支援
 There is no data = 沒有資料
 This change will not take effect until PPSSPP is restarted. = 重啟 PPSSPP 後配置才會生效。
+This will overwrite the existing configuration = 這將覆蓋現有配置 # AI translated
 Toggle All = 切換全部
 Toggle List = 切換清單
 Top Center = 正上

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -525,6 +525,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/UI/UI.cpp \
 	$(COMMONDIR)/UI/Context.cpp \
 	$(COMMONDIR)/UI/UIScreen.cpp \
+	$(COMMONDIR)/UI/Notice.cpp \
 	$(COMMONDIR)/UI/Tween.cpp \
 	$(COMMONDIR)/UI/IconCache.cpp \
 	$(COMMONDIR)/UI/View.cpp \


### PR DESCRIPTION
* Make gamepad autoconf work with DualSense/DualShock on Windows
* Add warning about resetting the configuration
* Don't zap non-pad controls when autoconfiguring
* Release all keys on disconnect for XInput and DInput controllers
* Some code cleanup

Plus, sneak in some missing changes from #21151

Fixes part of #20418