### PR TITLE
Fix #20356 - Flatpak application doesn't close until controller is unplugged

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1797,8 +1797,12 @@ int main(int argc, char *argv[]) {
 		while (true) {
 			SDL_Event event;
 			while (SDL_WaitEventTimeout(&event, 100)) {
+				if (g_QuitRequested || g_RestartRequested)
+					break;
+
 				ProcessSDLEvent(window, event, &inputTracker);
 			}
+
 			if (g_QuitRequested || g_RestartRequested)
 				break;
 


### PR DESCRIPTION
When the controller is connected SLD sends a lot of events (`SDL_JOYAXISMOTION` and etc.), so PPSSPP is stuck in the loop to process these events. Fixed by duplicating the `if` statement to check whether the quit was requested inside the loop.

Fixes https://github.com/hrydgard/ppsspp/issues/20356