### PR TITLE
libretro: build fix

### DIFF
--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstring>
 #include "Common/Math/SIMDHeaders.h"
 
 #define TEST_FALLBACK 0
@@ -244,7 +245,8 @@ struct Vec4F32 {
 	void StoreConvertToU8(uint8_t *dst) {
 		__m128i zero = _mm_setzero_si128();
 		__m128i ivalue = _mm_packus_epi16(_mm_packs_epi32(_mm_cvttps_epi32(v), zero), zero);
-		_mm_storeu_si32(dst, ivalue);
+		int32_t lo = _mm_cvtsi128_si32(ivalue);
+		memcpy(dst, &lo, 4);
 	}
 
 	static Vec4F32 FromVec4S32(Vec4S32 other) { return Vec4F32{ _mm_cvtepi32_ps(other.v) }; }

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -531,7 +531,6 @@ SOURCES_CXX += \
 	$(COMMONDIR)/UI/View.cpp \
 	$(COMMONDIR)/UI/ViewGroup.cpp \
 	$(COMMONDIR)/UI/ScrollView.cpp \
-	$(COMMONDIR)/UI/PopupScreens.cpp \
 	$(COMMONDIR)/System/Display.cpp \
 	$(COMMONDIR)/System/Request.cpp \
 	$(COMMONDIR)/System/OSD.cpp \


### PR DESCRIPTION
gcc9 and the version of msvc19 that the libretro builders use don't have _mm_storeu_si32. Using _m_cvtsi128_si32 followed by memcpy is picked up by compilers that support _mm_storeu_si32 as being the same and they generate the same assembly, so this is no harm to them.

Also Windows on libretro had a linker error because some functions from NoticeView are in OnScreenDisplay.cpp (GetContentDimensionsBySpec and Draw). It seems easy enough to fix it just by removing the caller of those, PopupScreens.cpp. I'm not sure why PopupScreens was included in the libretro build? Removing it doesn't seem to cause any linker problems.

https://git.libretro.com/libretro/ppsspp/-/pipelines/43760