### PR TITLE
Make UMD_VIDEO discs with game data detect as games.

### DIFF
--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -399,9 +399,11 @@ GameRegion DetectGameRegionFromID(std::string_view id_full) {
 			return GameRegion::TEST;
 		} else if (id_letters == "UMDT") {
 			return GameRegion::DIAGNOSTIC;
+		} else if (id_letters == "STEA") {
+			// The bizarre Stealth + Wipeout Pure combo.
+			return GameRegion::INTERNAL;
 		}
 	}
-
 	return GameRegion::HOMEBREW;
 }
 

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -22,6 +22,7 @@
 #include "Common/System/OSD.h"
 #include "Common/Log.h"
 #include "Common/Swap.h"
+#include "Common/Data/Text/Parsers.h"
 #include "Common/File/FileUtil.h"
 #include "Common/File/DirListing.h"
 #include "Common/StringUtils.h"
@@ -223,7 +224,7 @@ CISOFileBlockDevice::CISOFileBlockDevice(FileLoader *fileLoader)
 	u64 lastIndexPos = index[indexSize - 1] & 0x7FFFFFFF;
 	u64 expectedFileSize = lastIndexPos << indexShift;
 	if (expectedFileSize > fileSize) {
-		errorString_ = StringFromFormat("Expected CSO to at least be %lld bytes, but file is %lld bytes", expectedFileSize, fileSize);
+		errorString_ = StringFromFormat("CSO file incomplete: expected %s, but is %s", NiceSizeFormat(expectedFileSize).c_str(), NiceSizeFormat(fileSize).c_str());
 		return;
 	}
 

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -152,8 +152,8 @@ inline u32 operator & (const FileLoader::Flags &a, const FileLoader::Flags &b) {
 }
 
 FileLoader *ConstructFileLoader(const Path &filename);
-// Resolve to the target binary, ISO, or other file (e.g. from a directory.)
-FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader);
+// Identifies the file and resolves to the target binary, ISO, or other file (e.g. from a directory.)
+FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader, IdentifiedFileType *fileType, std::string *errorString);
 
 Path ResolvePBPDirectory(const Path &filename);
 Path ResolvePBPFile(const Path &filename);

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -134,19 +134,29 @@ namespace Reporting
 
 		AndroidJNIThreadContext jniContext;
 
-		FileLoader *fileLoader = ResolveFileLoaderTarget(ConstructFileLoader(crcFilename));
+		IdentifiedFileType type;
 
 		std::string errorString;
-		BlockDevice *blockDevice = ConstructBlockDevice(fileLoader, &errorString);
+		FileLoader *fileLoader = ResolveFileLoaderTarget(ConstructFileLoader(crcFilename), &type, &errorString);
+		if (!fileLoader) {
+			ERROR_LOG(Log::Loader, "Failed to construct file loader for CRC: %s", errorString.c_str());
+			std::lock_guard<std::mutex> guard(crcLock);
+			crcResults[crcFilename] = 0;
+			crcPending = false;
+			crcCond.notify_one();
+			return 0;
+		}
+
+		std::unique_ptr<BlockDevice> blockDevice(ConstructBlockDevice(fileLoader, &errorString));
 
 		u32 crc = 0;
 		if (blockDevice) {
-			crc = CalculateCRC(blockDevice, &crcCancel);
+			crc = CalculateCRC(blockDevice.get(), &crcCancel);
 		} else {
 			ERROR_LOG(Log::Loader, "Failed to read from block device for CRC: %s", errorString.c_str());
 		}
 
-		delete blockDevice;
+		blockDevice.reset();
 		delete fileLoader;
 
 		std::lock_guard<std::mutex> guard(crcLock);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -340,7 +340,6 @@ static bool CPU_Init(FileLoader *fileLoader, IdentifiedFileType type, std::strin
 		// Trying to boot other things lands us here. We need to return a sensible error string.
 		ERROR_LOG(Log::Loader, "CPU_Init didn't recognize file. %s", errorString->c_str());
 		auto sy = GetI18NCategory(I18NCat::SYSTEM);
-		*errorString = ApplySafeSubstitutions("%1 (%2)", sy->T("Not a PSP game"), *errorString);  // best string we have.
 		return false;
 	}
 	}
@@ -600,7 +599,7 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 	}
 	g_CoreParameter.errorString.clear();
 
-	std::string *error_string = &g_CoreParameter.errorString;
+	std::string *errorString = &g_CoreParameter.errorString;
 
 	INFO_LOG(Log::Loader, "Starting loader thread...");
 
@@ -608,7 +607,7 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 
 	Core_NotifyLifecycle(CoreLifecycle::STARTING);
 
-	g_loadingThread = std::thread([error_string]() {
+	g_loadingThread = std::thread([errorString]() {
 		SetCurrentThreadName("ExecLoader");
 
 		AndroidJNIThreadContext jniContext;
@@ -618,7 +617,7 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 		Path filename = g_CoreParameter.fileToStart;
 
 		IdentifiedFileType fileType;
-		FileLoader *loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename), &fileType, error_string);
+		FileLoader *loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename), &fileType, errorString);
 
 		if (System_GetPropertyBool(SYSPROP_ENOUGH_RAM_FOR_FULL_ISO)) {
 			if (g_Config.bCacheFullIsoInRam) {
@@ -641,9 +640,9 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 		if (!CPU_Init(loadedFile, fileType, &g_CoreParameter.errorString)) {
 			CPU_Shutdown(false);
 			g_CoreParameter.fileToStart.clear();
-			*error_string = g_CoreParameter.errorString;
-			if (error_string->empty()) {
-				*error_string = "Failed initializing CPU/Memory";
+			*errorString = g_CoreParameter.errorString;
+			if (errorString->empty()) {
+				*errorString = "Failed initializing CPU/Memory";
 			}
 			g_bootState = BootState::Failed;
 			return;
@@ -652,7 +651,7 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 		// Initialize the GPU as far as we can here (do things like load cache files).
 		_dbg_assert_(!gpu);
 #ifndef __LIBRETRO__
-		InitGPU(error_string);
+		InitGPU(errorString);
 #endif
 		g_bootState = BootState::Complete;
 	});

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1457,7 +1457,7 @@ void EmuScreen::update() {
 		std::string errLoadingFile = gamePath_.ToVisualString() + "\n\n";
 		errLoadingFile.append(err->T("Error loading file", "Could not load game"));
 		errLoadingFile.append("\n");
-		errLoadingFile.append(err->T(errorMessage_.c_str()));
+		errLoadingFile.append(errorMessage_);
 
 		screenManager()->push(new PromptScreen(gamePath_, errLoadingFile, di->T("OK"), ""));
 		errorMessage_.clear();

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -121,6 +121,8 @@ struct ImConfig {
 
 	bool sasShowAllVoices = false;
 
+	float fbViewerZoom = 1.0f;
+
 
 	// We use a separate ini file from the main PPSSPP config.
 	void LoadConfig(const Path &iniFile);

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -79,10 +79,12 @@ void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebuffer
 	}
 
 	if (cfg.selectedFramebuffer != -1) {
+		ImGui::SliderFloat("Scale", &cfg.fbViewerZoom, 0.5f, 16.0f, "%.2f", ImGuiSliderFlags_Logarithmic);
+
 		// Now, draw the image of the selected framebuffer.
 		Draw::Framebuffer *fb = vfbs[cfg.selectedFramebuffer]->fbo;
 		ImTextureID texId = ImGui_ImplThin3d_AddFBAsTextureTemp(fb, Draw::Aspect::COLOR_BIT, ImGuiPipeline::TexturedOpaque);
-		ImGui::Image(texId, ImVec2(fb->Width(), fb->Height()));
+		ImGui::Image(texId, ImVec2(fb->Width() * cfg.fbViewerZoom, fb->Height() * cfg.fbViewerZoom));
 	}
 
 	ImGui::End();

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -231,13 +231,14 @@ NPUH90087 = true  # demo
 NPEH90042 = true  # demo
 
 [Force04154000Download]
-# This applies a hack to Dangan Ronpa, its demo, and its sequel.
+# This applies a hack to Dangan Ronpa, its demo, and its sequel, Super Dangan Ronpa 2.
 # The game draws solid colors to a small framebuffer, and then reads this directly in VRAM.
 # We force this framebuffer to 1x and force download it automatically.
 NPJH50631 = true
 NPJH50372 = true
 NPJH90164 = true
 NPJH50515 = true
+
 # Let's also apply to Me & My Katamari.
 ULUS10094 = true
 ULES00339 = true


### PR DESCRIPTION
Add special case for region for wacky STEALTH + Wipeout Pure disc, see #21166

Also makes it tolerate PSP game ISOs with the wrong system ID (it does an extra check though), and also identifies UMD_VIDEO with game data as being games.

Additionally, very slightly speeds up game bootup by only identifying files once instead of twice for no good reason.

@NABN00B 

Also, if we see an unknown ISO system id on boot, we show it on the error screen. Some other errors like truncated CSO files now also bubble up.