### PR TITLE
Fix Clang build warnings

### DIFF
--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -69,7 +69,7 @@ private:
 	Draw::Texture *texture_ = nullptr;
 	Draw::DrawContext *draw_;
 	std::string filename_;  // Textures that are loaded from files can reload themselves automatically.
-	bool generateMips_ = false;
+	bool generateMips = false;
 	ImageFileType type_ = ImageFileType::DETECT;
 	LimitedWaitable *taskWaitable_ = nullptr;
 	TempImage pendingImage_;

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1030,7 +1030,7 @@ void RadioButton::Draw(UIContext &dc) {
 }
 
 ImageView::ImageView(ImageID atlasImage, const std::string &text, ImageSizeMode sizeMode, LayoutParams *layoutParams)
-	: InertView(layoutParams), text_(text), atlasImage_(atlasImage), sizeMode_(sizeMode) {}
+	: InertView(layoutParams), text_(text), atlasImage_(atlasImage) {}
 
 void ImageView::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
 	dc.Draw()->GetAtlas()->measureImage(atlasImage_, &w, &h);

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -1133,7 +1133,6 @@ public:
 private:
 	std::string text_;
 	ImageID atlasImage_;
-	ImageSizeMode sizeMode_;  // TODO: Not actually used yet.
 	float scale_ = 1.0f;
 };
 

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -625,13 +625,10 @@ void actOnHelloPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * se
 		// Peer not found
 		if (peer == NULL) {
 			// Allocate Memory
-			peer = (SceNetAdhocMatchingMemberInternal *)malloc(sizeof(SceNetAdhocMatchingMemberInternal));
+			peer = new SceNetAdhocMatchingMemberInternal{};
 
 			// Allocated Memory
 			if (peer != NULL) {
-				// Clear Memory
-				memset(peer, 0, sizeof(SceNetAdhocMatchingMemberInternal));
-
 				// Copy Sender MAC
 				peer->mac = *sendermac;
 
@@ -702,13 +699,10 @@ void actOnJoinPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * sen
 				// New Peer
 				if (peer == NULL) {
 					// Allocate Memory
-					peer = (SceNetAdhocMatchingMemberInternal *)malloc(sizeof(SceNetAdhocMatchingMemberInternal));
+					peer = new SceNetAdhocMatchingMemberInternal{};
 
 					// Allocated Memory
 					if (peer != NULL) {
-						// Clear Memory
-						memset(peer, 0, sizeof(SceNetAdhocMatchingMemberInternal));
-
 						// Copy Sender MAC
 						peer->mac = *sendermac;
 
@@ -1025,15 +1019,12 @@ void actOnBirthPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * se
 	memcpy(&mac, context->rxbuf + 1, sizeof(SceNetEtherAddr));
 
 	// Allocate Memory
-	SceNetAdhocMatchingMemberInternal * sibling = (SceNetAdhocMatchingMemberInternal *)malloc(sizeof(SceNetAdhocMatchingMemberInternal));
+	SceNetAdhocMatchingMemberInternal * sibling = new SceNetAdhocMatchingMemberInternal{};
 
 	if (sibling == NULL) {
 		// Failed to allocate memory
 		return;
 	}
-
-	// Clear Memory
-	memset(sibling, 0, sizeof(SceNetAdhocMatchingMemberInternal));
 
 	// Save MAC Address
 	sibling->mac = mac;
@@ -1775,16 +1766,13 @@ static int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbufle
 	}
 
 	// Allocate Context Memory
-	SceNetAdhocMatchingContext * context = (SceNetAdhocMatchingContext *)malloc(sizeof(SceNetAdhocMatchingContext));
+	SceNetAdhocMatchingContext * context = new SceNetAdhocMatchingContext{};
 
 	// Allocated Memory
 	if (context != NULL) {
 		// Create PDP Socket
 		SceNetEtherAddr localmac;
 		getLocalMac(&localmac);
-
-		// Clear Memory
-		memset(context, 0, sizeof(SceNetAdhocMatchingContext));
 
 		// Allocate Receive Buffer
 		context->rxbuf = (uint8_t*)malloc(rxbuflen);
@@ -2659,7 +2647,7 @@ const HLEFunction sceNetAdhocMatching[] = {
 	{0X7945ECDA, &WrapI_V<sceNetAdhocMatchingTerm>,                    "sceNetAdhocMatchingTerm",                'i', ""         },
 	{0XCA5EDA6F, &WrapI_IIIIIIIIU<sceNetAdhocMatchingCreate>,          "sceNetAdhocMatchingCreate",              'i', "iiiiiiiix"},
 	{0X93EF3843, &WrapI_IIIIIIU<sceNetAdhocMatchingStart>,             "sceNetAdhocMatchingStart",               'i', "iiiiiix"  },
-	{0xE8454C65, &WrapI_IIIIIIIIU<sceNetAdhocMatchingStart2>,          "sceNetAdhocMatchingStart2",              'i', "iiiiiiiix"},
+	{0XE8454C65, &WrapI_IIIIIIIIU<sceNetAdhocMatchingStart2>,          "sceNetAdhocMatchingStart2",              'i', "iiiiiiiix"},
 	{0X32B156B3, &WrapI_I<sceNetAdhocMatchingStop>,                    "sceNetAdhocMatchingStop",                'i', "i"        },
 	{0XF16EAF4F, &WrapI_I<sceNetAdhocMatchingDelete>,                  "sceNetAdhocMatchingDelete",              'i', "i"        },
 	{0X5E3D4B79, &WrapI_ICIU<sceNetAdhocMatchingSelectTarget>,         "sceNetAdhocMatchingSelectTarget",        'i', "isix"     },

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -1830,7 +1830,7 @@ static int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbufle
 		}
 
 		// Free Memory
-		free(context);
+		delete context;
 	}
 
 	// Out of Memory

--- a/UI/ImDebugger/ImJitViewer.h
+++ b/UI/ImDebugger/ImJitViewer.h
@@ -33,7 +33,6 @@ private:
 	int curBlockNum_ = -1;
 
 	int lastCpuStepCount_ = -1;
-	int blockSortColumn_ = 0;
 
 	bool refresh_ = false;
 	int core_ = -1;

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -197,8 +197,6 @@ private:
 	// Symbol cache
 	std::vector<SymbolEntry> symCache_;
 	bool symsDirty_ = true;
-	int selectedSymbol_ = -1;
-	char selectedSymbolName_[128];
 
 	bool drawZeroDark_ = false;
 	bool editableMemory_ = false;
@@ -209,7 +207,6 @@ private:
 	char searchStr_[512];
 	// store the state of the search form
 	ImMemView memView_;
-	char searchTerm_[64]{};
 
 	u32 gotoAddr_ = 0x08800000;
 };

--- a/UI/JitCompareScreen.h
+++ b/UI/JitCompareScreen.h
@@ -18,11 +18,9 @@ private:
 	// Uses the current ListType
 	void FillBlockList();
 
-	UI::LinearLayout *comparisonView_ = nullptr;
 	UI::LinearLayout *leftDisasm_ = nullptr;
 	UI::LinearLayout *rightDisasm_ = nullptr;
 
-	UI::LinearLayout *blockListView_ = nullptr;
 	UI::LinearLayout *blockListContainer_ = nullptr;
 
 	void OnSelectBlock(UI::EventParams &e);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -296,6 +296,19 @@ void GameButton::Draw(UIContext &dc) {
 	case IdentifiedFileType::PPSSPP_SAVESTATE:
 	case IdentifiedFileType::ERROR_IDENTIFYING:
 	case IdentifiedFileType::UNKNOWN_BIN: imageIcon = ImageID("I_FILE"); break;
+	case IdentifiedFileType::PSP_PBP_DIRECTORY:
+	case IdentifiedFileType::PSP_PBP:
+	case IdentifiedFileType::PSP_ELF:
+	case IdentifiedFileType::PSP_ISO:
+	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
+	case IdentifiedFileType::PSP_ISO_NP:
+	case IdentifiedFileType::PSP_DISC_DIRECTORY:
+	case IdentifiedFileType::ARCHIVE_RAR:
+	case IdentifiedFileType::ARCHIVE_ZIP:
+	case IdentifiedFileType::ARCHIVE_7Z:
+	case IdentifiedFileType::NORMAL_DIRECTORY:
+	case IdentifiedFileType::UNKNOWN:
+		break;
 	}
 
 	if (imageIcon.isValid()) {

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -43,7 +43,7 @@ CopyableText::CopyableText(ImageID imageID, std::string_view text, UI::LinearLay
 	});
 }
 
-TopBar::TopBar(const UIContext &ctx, TopBarFlags flags, std::string_view title, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams), flags_(flags) {
+TopBar::TopBar(const UIContext &ctx, TopBarFlags flags, std::string_view title, UI::LayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
 	using namespace UI;
 	SetSpacing(10.0f);
 	if (!layoutParams) {

--- a/UI/MiscViews.h
+++ b/UI/MiscViews.h
@@ -36,7 +36,6 @@ public:
 private:
 	UI::Choice *backButton_ = nullptr;
 	UI::Choice *contextMenuButton_ = nullptr;
-	TopBarFlags flags_ = TopBarFlags::Default;
 };
 
 class ShinyIcon : public UI::ImageView {


### PR DESCRIPTION
Needs accurate code review, so how could I change the behavior

My build log before fixes from PR:
```
====================[ Build | all | Debug ]=====================================
/home/devuan/Downloads/clion-2024.2.1/bin/cmake/linux/x64/bin/cmake --build /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/cmake-build-debug --target all -j 70
[0/2] Re-checking globbed directories...
[114/1085] Building CXX object ext/imgui/CMakeFiles/imgui.dir/imgui_widgets.cpp.o
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/imgui/imgui_widgets.cpp:4949:58: warning: variable 'empty_string' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
 4949 |                 stb_textedit_replace(state, state->Stb, &empty_string, 0);
      |                                                          ^~~~~~~~~~~~
1 warning generated.
[242/1085] Generating something_that_never_exists
-- Found Git: /usr/bin/git (found version "2.51.0")
[310/1085] Building CXX object CMakeFiles/Common.dir/Common/Render/ManagedTexture.cpp.o
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/Common/Render/ManagedTexture.cpp:58:7: warning: private field 'generateMips_' is not used [-Wunused-private-field]
   58 |         bool generateMips_;  // not yet used
      |              ^
1 warning generated.
[359/1085] Building CXX object CMakeFiles/vma.dir/ext/vma/vk_mem_alloc.cpp.o
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/vma/vk_mem_alloc.cpp:15:
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/vma/vk_mem_alloc.h:6291:11: warning: private field 'placeholder' is not used [-Wunused-private-field]
 6291 |     void* placeholder = VMA_NULL;
      |           ^
1 warning generated.
[369/1085] Building CXX object ext/glslang/glslang/CMakeFiles/MachineIndependent.dir/MachineIndependent/glslang_tab.cpp.o
MachineIndependent/glslang_tab.cpp:4963:9: warning: variable 'yynerrs' set but not used [-Wunused-but-set-variable]
 4963 |     int yynerrs = 0;
      |         ^
1 warning generated.
[371/1085] Building CXX object CMakeFiles/Common.dir/Common/UI/View.cpp.o
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/Common/UI/View.cpp:11:
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/Common/UI/View.h:1136:16: warning: private field 'sizeMode_' is not used [-Wunused-private-field]
 1136 |         ImageSizeMode sizeMode_;  // TODO: Not actually used yet.
      |                       ^
1 warning generated.
[441/1085] Building CXX object ext/at3_standalone/CMakeFiles/at3_standalone.dir/mem.cpp.o
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/at3_standalone/mem.cpp:27:9: warning: '_XOPEN_SOURCE' macro redefined [-Wmacro-redefined]
   27 | #define _XOPEN_SOURCE 600
      |         ^
<command line>:12:9: note: previous definition is here
   12 | #define _XOPEN_SOURCE 700
      |         ^
1 warning generated.
[612/1085] Building CXX object CMakeFiles/basis_universal.dir/ext/basis_universal/basisu_transcoder.cpp.o
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16613:10: warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'ktx2_header' [-Wnontrivial-memcall]
 16613 |                 memset(&m_header, 0, sizeof(m_header));
       |                        ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16613:10: note: explicitly cast the pointer to silence this warning
 16613 |                 memset(&m_header, 0, sizeof(m_header));
       |                        ^
       |                        (void*)
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16617:10: warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'ktx2_etc1s_global_data_header' [-Wnontrivial-memcall]
 16617 |                 memset(&m_etc1s_header, 0, sizeof(m_etc1s_header));
       |                        ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16617:10: note: explicitly cast the pointer to silence this warning
 16617 |                 memset(&m_etc1s_header, 0, sizeof(m_etc1s_header));
       |                        ^
       |                        (void*)
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16664:10: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'ktx2_header' [-Wnontrivial-memcall]
 16664 |                 memcpy(&m_header, pData, sizeof(m_header));
       |                        ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16664:10: note: explicitly cast the pointer to silence this warning
 16664 |                 memcpy(&m_header, pData, sizeof(m_header));
       |                        ^
       |                        (void*)
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16760:10: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'basist::ktx2_level_index' [-Wnontrivial-memcall]
 16760 |                 memcpy(&m_levels[0], m_pData + sizeof(ktx2_header), level_index_size_in_bytes);
       |                        ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:16760:10: note: explicitly cast the pointer to silence this warning
 16760 |                 memcpy(&m_levels[0], m_pData + sizeof(ktx2_header), level_index_size_in_bytes);
       |                        ^
       |                        (void*)
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:17271:10: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'ktx2_etc1s_global_data_header' [-Wnontrivial-memcall]
 17271 |                 memcpy(&m_etc1s_header, pSrc, sizeof(ktx2_etc1s_global_data_header));
       |                        ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:17271:10: note: explicitly cast the pointer to silence this warning
 17271 |                 memcpy(&m_etc1s_header, pSrc, sizeof(ktx2_etc1s_global_data_header));
       |                        ^
       |                        (void*)
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:17304:30: warning: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'basist::ktx2_etc1s_image_desc' [-Wnontrivial-memcall]
 17304 |                 memcpy(m_etc1s_image_descs.data(), pSrc, sizeof(ktx2_etc1s_image_desc) * image_count);
       |                                            ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/basis_universal/basisu_transcoder.cpp:17304:30: note: explicitly cast the pointer to silence this warning
 17304 |                 memcpy(m_etc1s_image_descs.data(), pSrc, sizeof(ktx2_etc1s_image_desc) * image_count);
       |                                            ^
       |                        (void*)
6 warnings generated.
[826/1085] Building CXX object CMakeFiles/Core.dir/Core/HLE/sceNetAdhocMatching.cpp.o
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/Core/HLE/sceNetAdhocMatching.cpp:1787:10: warning: first argument in call to 'memset' is a pointer to non-trivially copyable type 'SceNetAdhocMatchingContext' [-Wnontrivial-memcall]
 1787 |                 memset(context, 0, sizeof(SceNetAdhocMatchingContext));
      |                        ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/Core/HLE/sceNetAdhocMatching.cpp:1787:10: note: explicitly cast the pointer to silence this warning
 1787 |                 memset(context, 0, sizeof(SceNetAdhocMatchingContext));
      |                        ^
      |                        (void*)
1 warning generated.
[1028/1085] Building CXX object CMakeFiles/PPSSPPSDL.dir/UI/ImDebugger/ImJitViewer.cpp.o
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImJitViewer.cpp:3:
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImJitViewer.h:36:6: warning: private field 'blockSortColumn_' is not used [-Wunused-private-field]
   36 |         int blockSortColumn_ = 0;
      |             ^
1 warning generated.
[1036/1085] Building CXX object CMakeFiles/PPSSPPSDL.dir/UI/MiscViews.cpp.o
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/MiscViews.cpp:10:
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/MiscViews.h:39:14: warning: private field 'flags_' is not used [-Wunused-private-field]
   39 |         TopBarFlags flags_ = TopBarFlags::Default;
      |                     ^
1 warning generated.
[1038/1085] Building CXX object CMakeFiles/PPSSPPSDL.dir/UI/ImDebugger/ImMemView.cpp.o
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImMemView.cpp:21:
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImDebugger.h:21:
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImMemView.h:200:6: warning: private field 'selectedSymbol_' is not used [-Wunused-private-field]
  200 |         int selectedSymbol_ = -1;
      |             ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImMemView.h:201:7: warning: private field 'selectedSymbolName_' is not used [-Wunused-private-field]
  201 |         char selectedSymbolName_[128];
      |              ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/ImDebugger/ImMemView.h:212:7: warning: private field 'searchTerm_' is not used [-Wunused-private-field]
  212 |         char searchTerm_[64]{};
      |              ^
3 warnings generated.
[1062/1085] Building CXX object CMakeFiles/PPSSPPSDL.dir/UI/JitCompareScreen.cpp.o
In file included from /media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/JitCompareScreen.cpp:3:
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/JitCompareScreen.h:21:20: warning: private field 'comparisonView_' is not used [-Wunused-private-field]
   21 |         UI::LinearLayout *comparisonView_ = nullptr;
      |                           ^
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/JitCompareScreen.h:25:20: warning: private field 'blockListView_' is not used [-Wunused-private-field]
   25 |         UI::LinearLayout *blockListView_ = nullptr;
      |                           ^
2 warnings generated.
[1077/1085] Building CXX object CMakeFiles/PPSSPPSDL.dir/UI/MainScreen.cpp.o
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/UI/MainScreen.cpp:287:10: warning: 12 enumeration values not handled in switch: 'PSP_PBP_DIRECTORY', 'PSP_PBP', 'PSP_ELF'... [-Wswitch]
  287 |         switch (ginfo->fileType) {
      |                 ^~~~~~~~~~~~~~~
1 warning generated.
[1082/1085] Linking CXX executable PPSSPPSDL
/usr/bin/x86_64-linux-gnu-ld.bfd: lib/liblua.a(loslib.c.o): in function `os_tmpname':
/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/lua/loslib.c:174:(.text+0x761): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
[1084/1085] Linking CXX static library lib/libspirv-cross-msl.a

Build finished
```