### PR TITLE
Add workaround for Tales of Phantasia X flicker problem

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -156,6 +156,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "MsgDialogAutoStatus", &flags_.MsgDialogAutoStatus);
 	CheckSetting(iniFile, gameID, "NullPageValid", &flags_.NullPageValid);
 	CheckSetting(iniFile, gameID, "DetectDestBlendSquared", &flags_.DetectDestBlendSquared);
+	CheckSetting(iniFile, gameID, "BoostExactFramebufferMatch", &flags_.BoostExactFramebufferMatch);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -45,7 +45,7 @@
 //
 // We already have the Action Replay-based cheat system for such use cases.
 
-// TODO: Turn into bitfield for smaller mem footprint. Though I think it still fits in a cacheline...
+// TODO: Turn into bitfield for smaller mem footprint.
 struct CompatFlags {
 	bool VertexDepthRounding;
 	bool PixelDepthRounding;
@@ -119,6 +119,7 @@ struct CompatFlags {
 	bool MsgDialogAutoStatus;
 	bool NullPageValid;
 	bool DetectDestBlendSquared;
+	bool BoostExactFramebufferMatch;
 };
 
 struct VRCompat {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2193,8 +2193,10 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 	} else if (dstBuffer) {
 		if (flags & GPUCopyFlag::MEMSET) {
 			gpuStats.numClears++;
+			WARN_LOG_N_TIMES(btucpy, 5, Log::FrameBuf, "Memcpy fbo memset-clear %08x (size: %x)", dst, size);
+		} else {
+			WARN_LOG_N_TIMES(btucpy, 5, Log::FrameBuf, "Memcpy fbo upload %08x -> %08x (size: %x)", src, dst, size);
 		}
-		WARN_LOG_N_TIMES(btucpy, 5, Log::FrameBuf, "Memcpy fbo upload %08x -> %08x (size: %x)", src, dst, size);
 		FlushBeforeCopy();
 
 		// TODO: Hot Shots Golf makes a lot of these during the "meter", to copy back the image to the screen, it copies line by line.

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -449,7 +449,7 @@ protected:
 
 	bool MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, RasterChannel channel, FramebufferMatchInfo *matchInfo) const;
 
-	bool GetBestFramebufferCandidate(const TextureDefinition &entry, u32 texAddrOffset, AttachCandidate *bestCandidate) const;
+	bool GetBestFramebufferCandidate(const TextureDefinition &entry, u32 texAddrOffset, AttachCandidate *bestCandidate, const char *context) const;
 
 	void SetTextureFramebuffer(const AttachCandidate &candidate);
 	bool GetCurrentFramebufferTextureDebug(GPUDebugBuffer &buffer, bool *isFramebuffer);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2121,3 +2121,10 @@ NPUG70125 = true
 ULUS10279 = true
 UCJS10024 = true
 UCAS40096 = true
+
+[BoostExactFramebufferMatch]
+# Tales of Phantasia X, retro subgame. See issue #21162
+ULJS00293 = true
+ULKS46257 = true
+ULJS19073 = true
+NPJH50848 = true


### PR DESCRIPTION
Fixes #21162

There are conflicting goals here, we misdetect the height of a framebuffer causing PPSSPP to try to use it when texturing from another framebuffer overlapping it. This boosts the priority of the exactly matching framebuffer. Since this has the potential of breaking other games (like Juiced 2), I'm putting this behavior behind a compatibility flag for now.