### PR TITLE
Fix RNG of Bouncing Icon BG animation

### DIFF
--- a/UI/Background.cpp
+++ b/UI/Background.cpp
@@ -276,26 +276,27 @@ public:
 		dc.Flush();
 
 		// Switch direction if within border.
-		bool should_recolor = true;
-		if (xbase > xres - border || xbase < border) {
-			xspeed *= -1.0f;
-			RandomizeColor();
-			should_recolor = false;
+		float xmax = xres - border;
+		float ymax = yres - border;
+		bool should_recolor = false;
+
+		if (xbase > xmax || xbase < border) {
+			xspeed = -xspeed;
+			should_recolor = true;
 		}
 
-		if (ybase > yres - border || ybase < border) {
-			yspeed *= -1.0f;
+		if (ybase > ymax || ybase < border) {
+			yspeed = -yspeed;
+			should_recolor = true;
+		}
 
-			if (should_recolor) {
-				RandomizeColor();
-			}
+		if (should_recolor) {
+			RandomizeColor();
 		}
 
 		// Place to border if out of bounds.
-		if (xbase > xres - border) xbase = xres - border;
-		else if (xbase < border) xbase = border;
-		if (ybase > yres - border) ybase = yres - border;
-		else if (ybase < border) ybase = border;
+		xbase = Clamp(xbase, border, xmax);
+		ybase = Clamp(ybase, border, ymax);
 
 		// Update location.
 		xbase += xspeed;
@@ -306,6 +307,7 @@ private:
 	static constexpr int COLOR_COUNT = 11;
 	static constexpr Color COLORS[COLOR_COUNT] = {0xFFFFFFFF, 0xFFFFFF00, 0xFFFF0000, 0xFF00FF00, 0xFF0000FF,
 			0xFF00FFFF, 0xFFFF00FF, 0xFF4111D1, 0xFF3577F3, 0xFFAA77FF, 0xFF623B84};
+	static constexpr float BORDER_SIZE = 35.0f;
 
 	float xbase = 0.0f;
 	float ybase = 0.0f;
@@ -314,7 +316,7 @@ private:
 	float xspeed = 1.0f;
 	float yspeed = 1.0f;
 	float scale = 1.0f;
-	float border = 35.0f;
+	float border = BORDER_SIZE;
 	int color_ix = 0;
 	int last_color_ix = -1;
 	GMRng rng;
@@ -327,16 +329,17 @@ private:
 			last_color_ix = 0;
 
 			// Determine initial direction.
-			if ((int)(rng.F() * xres) % 2) xspeed *= -1.0f;
-			if ((int)(rng.F() * yres) % 2) yspeed *= -1.0f;
+			rng.Init(time_now_d() * 100239);
+			if (rng.R32() % 2 != 0) xspeed = -xspeed;
+			if (rng.R32() % 2 != 0) yspeed = -yspeed;
 		}
 
 		// Scale certain attributes to resolution.
 		scale = std::min(xres, yres) / 400.0f;
 		float speed = scale < 2.5f ? scale * 0.58f : scale * 0.46f;
-		xspeed = std::signbit(xspeed) ? speed * -1.0f : speed;
-		yspeed = std::signbit(yspeed) ? speed * -1.0f : speed;
-		border = 35.0f * scale;
+		xspeed = std::copysign(speed, xspeed);
+		yspeed = std::copysign(speed, yspeed);
+		border = BORDER_SIZE * scale;
 
 		last_xres = xres;
 		last_yres = yres;
@@ -344,7 +347,7 @@ private:
 
 	void RandomizeColor() {
 		do {
-			color_ix = (int)(rng.F() * xbase) % COLOR_COUNT;
+			color_ix = rng.R32() % COLOR_COUNT;
 		} while (color_ix == last_color_ix);
 
 		last_color_ix = color_ix;


### PR DESCRIPTION
I had botched this in more ways than one, super embarrassing. 😅 

Also simplifies some of the operations for better readability (and maybe performance?).

Initially I wanted to use `std::clamp`, but that requires the `<algorithm>` library. Which one do you prefer?

Improves #20211.