### PR TITLE
Android: Filter device-connected notification to only apply to gamepads

### DIFF
--- a/Common/Data/Convert/SmallDataConvert.h
+++ b/Common/Data/Convert/SmallDataConvert.h
@@ -132,25 +132,11 @@ inline void Uint8x3ToInt4(int i[4], uint32_t u) {
 	i[3] = 0;
 }
 
-inline void Uint8x3ToInt4_Alpha(int i[4], uint32_t u, uint8_t alpha) {
-	i[0] = ((u >> 0) & 0xFF);
-	i[1] = ((u >> 8) & 0xFF);
-	i[2] = ((u >> 16) & 0xFF);
-	i[3] = alpha;
-}
-
 inline void Uint8x3ToFloat4_Alpha(float f[4], uint32_t u, float alpha) {
 	f[0] = ((u >> 0) & 0xFF) * (1.0f / 255.0f);
 	f[1] = ((u >> 8) & 0xFF) * (1.0f / 255.0f);
 	f[2] = ((u >> 16) & 0xFF) * (1.0f / 255.0f);
 	f[3] = alpha;
-}
-
-inline void Uint8x1ToFloat4(float f[4], uint32_t u) {
-	f[0] = ((u >> 0) & 0xFF) * (1.0f / 255.0f);
-	f[1] = 0.0f;
-	f[2] = 0.0f;
-	f[3] = 0.0f;
 }
 
 // These are just for readability.
@@ -206,6 +192,7 @@ inline void CopyMatrix4x4(float dest[16], const float src[16]) {
 	memcpy(dest, src, sizeof(float) * 16);
 }
 
+// WARNING: This can quietly "over-load" src by 4 bytes.
 inline void ExpandFloat24x3ToFloat4(float dest[4], const uint32_t src[3]) {
 #ifdef _M_SSE
 	__m128i values = _mm_slli_epi32(_mm_loadu_si128((const __m128i *)src), 8);

--- a/Common/Math/fast/fast_matrix.h
+++ b/Common/Math/fast/fast_matrix.h
@@ -2,7 +2,6 @@
 
 #include "ppsspp_config.h"
 
-
 #include "Common/Math/SIMDHeaders.h"
 #include "Common/Common.h"
 

--- a/Windows/HidInputDevice.cpp
+++ b/Windows/HidInputDevice.cpp
@@ -188,14 +188,14 @@ static const HIDControllerInfo g_psInfos[] = {
 static const HIDControllerInfo *GetGamepadInfo(HANDLE handle) {
 	HIDD_ATTRIBUTES attr{sizeof(HIDD_ATTRIBUTES)};
 	if (!HidD_GetAttributes(handle, &attr)) {
-		return false;
+		return nullptr;
 	}
 	for (const auto &info : g_psInfos) {
 		if (attr.VendorID == info.vendorId && attr.ProductID == info.productId) {
 			return &info;
 		}
 	}
-	return false;
+	return nullptr;
 }
 
 template<class T>

--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -5,6 +5,7 @@ import android.view.InputDevice;
 import android.view.InputDevice.MotionRange;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+
 import java.util.Set;
 import java.util.HashSet;
 
@@ -108,7 +109,7 @@ public class InputDeviceState {
 				(source & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD;
 	}
 
-	public InputDeviceState(InputDevice device) {
+	public InputDeviceState(InputDevice device, boolean fromConnectedNotification) {
 		sources = device.getSources();
 		// First, anything that's a gamepad is a gamepad, even if it has a keyboard or pointer.
 		// We also don't bother supporting multiple gamepads, we send them all to PAD0.
@@ -140,12 +141,16 @@ public class InputDeviceState {
 
 		Log.i(TAG, "Registering input device with " + numAxes + " axes: " + device.getName());
 		logAdvanced(device);
-		NativeApp.sendMessageFromJava("inputDeviceConnectedID", String.valueOf(this.deviceId));
-		NativeApp.sendMessageFromJava("inputDeviceConnected", device.getName());
+		if (deviceId == NativeApp.DEVICE_ID_PAD_0 && fromConnectedNotification) {
+			NativeApp.sendMessageFromJava("inputDeviceConnectedID", String.valueOf(this.deviceId));
+			NativeApp.sendMessageFromJava("inputDeviceConnected", device.getName());
+		}
 	}
 
 	public void Disconnect() {
-		NativeApp.sendMessageFromJava("inputDeviceDisconnectedID", String.valueOf(this.deviceId));
+		if (deviceId == NativeApp.DEVICE_ID_PAD_0) {
+			NativeApp.sendMessageFromJava("inputDeviceDisconnectedID", String.valueOf(this.deviceId));
+		}
 		// Also reset all the buttons and axes.
 		for (int value : pressedKeys) {
 			NativeApp.keyUp(deviceId, value);

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -14,7 +14,6 @@ import android.app.UiModeManager;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
@@ -35,7 +34,6 @@ import android.os.Environment;
 import android.os.Looper;
 import android.os.PowerManager;
 import android.provider.MediaStore;
-import android.renderscript.ScriptGroup;
 import android.text.InputType;
 import android.util.Log;
 import android.database.Cursor;
@@ -786,7 +784,7 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 					}
 
 					// None was found, just add and return it.
-					InputDeviceState state = new InputDeviceState(device);
+					InputDeviceState state = new InputDeviceState(device, true);
 					inputPlayers.add(state);
 					Log.i(TAG, "Input player registered on connect: desc = " + device.getDescriptor());
 				}
@@ -1144,7 +1142,7 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 		}
 
 		// None was found, just add and return it.
-		InputDeviceState state = new InputDeviceState(device);
+		InputDeviceState state = new InputDeviceState(device, false);
 		inputPlayers.add(state);
 		Log.i(TAG, "Input player post-registered: desc = " + device.getDescriptor());
 		return state;


### PR DESCRIPTION
The new code started notifying when you pressed volume up/down, which is a little ridiculous. Fix that.

Also merge an old forgotten branch with a unit test for matrix multiplication.