### PR TITLE
Fix bug saving fullscreen state, show icons/background for UMD video ISOs

### DIFF
--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -605,6 +605,7 @@ const char *IdentifiedFileTypeToString(IdentifiedFileType type) {
 	case IdentifiedFileType::PSX_ISO: return "PSX_ISO";
 	case IdentifiedFileType::PS2_ISO: return "PS2_ISO";
 	case IdentifiedFileType::PS3_ISO: return "PS3_ISO";
+	case IdentifiedFileType::PSP_UMD_VIDEO_ISO: return "UMD_VIDEO";
 	case IdentifiedFileType::NORMAL_DIRECTORY: return "NORMAL_DIRECTORY";
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY: return "PSP_SAVEDATA_DIRECTORY";
 	case IdentifiedFileType::PPSSPP_SAVESTATE: return "PPSSPP_SAVESTATE";

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -340,7 +340,9 @@ static bool CPU_Init(FileLoader *fileLoader, IdentifiedFileType type, std::strin
 		// Trying to boot other things lands us here. We need to return a sensible error string.
 		ERROR_LOG(Log::Loader, "CPU_Init didn't recognize file. %s", errorString->c_str());
 		auto sy = GetI18NCategory(I18NCat::SYSTEM);
-		*errorString = sy->T("Not a PSP game");
+		if (errorString->empty()) {
+			*errorString = sy->T("Not a PSP game");
+		}
 		return false;
 	}
 	}

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -364,14 +364,20 @@ bool GameInfo::DeleteAllSaveData() {
 	return true;
 }
 
-void GameInfo::ParseParamSFO() {
+void GameInfo::ParseParamSFO(IdentifiedFileType type) {
 	title = paramSFO.GetValueString("TITLE");
-	id = paramSFO.GetValueString("DISC_ID");
-	id_version = id + "_" + paramSFO.GetValueString("DISC_VERSION");
-	disc_total = paramSFO.GetValueInt("DISC_TOTAL");
-	disc_number = paramSFO.GetValueInt("DISC_NUMBER");
-	// region = paramSFO.GetValueInt("REGION");  // Always seems to be 32768?
-	region = DetectGameRegionFromID(id);
+	if (type != IdentifiedFileType::PSP_UMD_VIDEO_ISO) {
+		id = paramSFO.GetValueString("DISC_ID");
+		id_version = id + "_" + paramSFO.GetValueString("DISC_VERSION");
+		disc_total = paramSFO.GetValueInt("DISC_TOTAL");
+		disc_number = paramSFO.GetValueInt("DISC_NUMBER");
+		// region = paramSFO.GetValueInt("REGION");  // Always seems to be 32768?
+		region = DetectGameRegionFromID(id);
+	} else {
+		id.clear();
+		id_version.clear();
+		region = GameRegion::UNKNOWN;
+	}
 }
 
 std::string GameInfo::GetTitle() {
@@ -437,13 +443,14 @@ void GameInfo::SetupTexture(Draw::DrawContext *thin3d, GameInfoTex &tex) {
 	}
 }
 
-static bool ReadFileToString(IFileSystem *fs, const char *filename, std::string *contents, std::mutex *mtx) {
-	PSPFileInfo info = fs->GetFileInfo(filename);
+static bool ReadFileToString(IFileSystem *fs, std::string_view filename, std::string *contents, std::mutex *mtx) {
+	std::string fn(filename);
+	PSPFileInfo info = fs->GetFileInfo(fn);
 	if (!info.exists) {
 		return false;
 	}
 
-	int handle = fs->OpenFile(filename, FILEACCESS_READ);
+	int handle = fs->OpenFile(fn, FILEACCESS_READ);
 	if (handle < 0) {
 		return false;
 	}
@@ -561,7 +568,6 @@ public:
 		switch (info_->fileType) {
 		case IdentifiedFileType::PSP_PBP:
 		case IdentifiedFileType::PSP_PBP_DIRECTORY:
-		case IdentifiedFileType::PSP_UMD_VIDEO_ISO:
 			{
 				auto pbpLoader = info_->GetFileLoader();
 				if (info_->fileType == IdentifiedFileType::PSP_PBP_DIRECTORY) {
@@ -590,7 +596,7 @@ public:
 					if (pbp.GetSubFile(PBP_PARAM_SFO, &sfoData)) {
 						std::lock_guard<std::mutex> lock(info_->lock);
 						info_->paramSFO.ReadSFO(sfoData);
-						info_->ParseParamSFO();
+						info_->ParseParamSFO(info_->fileType);
 
 						// Assuming PSP_PBP_DIRECTORY without ID or with disc_total < 1 in GAME dir must be homebrew
 						if ((info_->id.empty() || !info_->disc_total)
@@ -697,7 +703,7 @@ handleELF:
 				if (ReadFileToString(&umd, "/PARAM.SFO", &paramSFOcontents, 0)) {
 					std::lock_guard<std::mutex> lock(info_->lock);
 					info_->paramSFO.ReadSFO((const u8 *)paramSFOcontents.data(), paramSFOcontents.size());
-					info_->ParseParamSFO();
+					info_->ParseParamSFO(info_->fileType);
 					info_->MarkReadyNoLock(GameInfoFlags::PARAM_SFO);
 				}
 			}
@@ -754,7 +760,7 @@ handleELF:
 					if (ReadFileToString(&umd, "/PSP_GAME/PARAM.SFO", &paramSFOcontents, nullptr)) {
 						std::lock_guard<std::mutex> lock(info_->lock);
 						info_->paramSFO.ReadSFO((const u8 *)paramSFOcontents.data(), paramSFOcontents.size());
-						info_->ParseParamSFO();
+						info_->ParseParamSFO(info_->fileType);
 					}
 				}
 
@@ -779,7 +785,9 @@ handleELF:
 
 		case IdentifiedFileType::PSP_ISO:
 		case IdentifiedFileType::PSP_ISO_NP:
+		case IdentifiedFileType::PSP_UMD_VIDEO_ISO:
 			{
+				std::string_view gameRoot = info_->fileType == IdentifiedFileType::PSP_UMD_VIDEO_ISO ? "/UMD_VIDEO/" : "/PSP_GAME/";
 				SequentialHandleAllocator handles;
 				// Let's assume it's an ISO.
 				// TODO: This will currently read in the whole directory tree. Not really necessary for just a
@@ -804,11 +812,12 @@ handleELF:
 				// Alright, let's fetch the PARAM.SFO.
 				if (flags_ & GameInfoFlags::PARAM_SFO) {
 					std::string paramSFOcontents;
-					if (ReadFileToString(&umd, "/PSP_GAME/PARAM.SFO", &paramSFOcontents, nullptr)) {
+
+					if (ReadFileToString(&umd, join(gameRoot, "PARAM.SFO"), &paramSFOcontents, nullptr)) {
 						{
 							std::lock_guard<std::mutex> lock(info_->lock);
 							info_->paramSFO.ReadSFO((const u8 *)paramSFOcontents.data(), paramSFOcontents.size());
-							info_->ParseParamSFO();
+							info_->ParseParamSFO(info_->fileType);
 
 							// quick-update the info while we have the lock, so we don't need to wait for the image load to display the title.
 							info_->MarkReadyNoLock(GameInfoFlags::PARAM_SFO);
@@ -819,15 +828,15 @@ handleELF:
 				}
 
 				if (flags_ & GameInfoFlags::PIC0) {
-					info_->pic0.dataLoaded = ReadFileToString(&umd, "/PSP_GAME/PIC0.PNG", &info_->pic0.data, &info_->lock);
+					info_->pic0.dataLoaded = ReadFileToString(&umd, join(gameRoot, "PIC0.PNG"), &info_->pic0.data, &info_->lock);
 				}
 
 				if (flags_ & GameInfoFlags::PIC1) {
-					info_->pic1.dataLoaded = ReadFileToString(&umd, "/PSP_GAME/PIC1.PNG", &info_->pic1.data, &info_->lock);
+					info_->pic1.dataLoaded = ReadFileToString(&umd, join(gameRoot, "PIC1.PNG"), &info_->pic1.data, &info_->lock);
 				}
 
 				if (flags_ & GameInfoFlags::SND) {
-					info_->sndDataLoaded = ReadFileToString(&umd, "/PSP_GAME/SND0.AT3", &info_->sndFileData, &info_->lock);
+					info_->sndDataLoaded = ReadFileToString(&umd, join(gameRoot, "SND0.AT3"), &info_->sndFileData, &info_->lock);
 				}
 
 				// Fall back to unknown icon if ISO is broken/is a homebrew ISO, override is allowed though
@@ -835,7 +844,7 @@ handleELF:
 				if (flags_ & GameInfoFlags::ICON) {
 					if (LoadReplacementImage(info_.get(), &info_->icon, "icon.png")) {
 						// Nothing more to do
-					} else if (ReadFileToString(&umd, "/PSP_GAME/ICON0.PNG", &info_->icon.data, &info_->lock)) {
+					} else if (ReadFileToString(&umd, join(gameRoot, "ICON0.PNG"), &info_->icon.data, &info_->lock)) {
 						info_->icon.dataLoaded = true;
 					} else {
 						Path screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.jpg");

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -881,6 +881,9 @@ handleELF:
 			case IdentifiedFileType::NORMAL_DIRECTORY:
 			default:
 				info_->title = info_->GetFilePath().GetFilename();
+				if (info_->errorString.empty()) {
+					info_->errorString = errorString;
+				}
 				break;
 		}
 

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -95,7 +95,7 @@ public:
 	// NOTE: This one actually performs I/O directly, not cached.
 	std::string GetMTime() const;
 
-	void ParseParamSFO();
+	void ParseParamSFO(IdentifiedFileType type);
 	const ParamSFOData &GetParamSFO() const {
 		_dbg_assert_(hasFlags & GameInfoFlags::PARAM_SFO);
 		return paramSFO;

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -167,6 +167,8 @@ public:
 	u64 saveDataSize = 0;
 	u64 installDataSize = 0;
 
+	std::string errorString;
+
 protected:
 	ParamSFOData paramSFO;
 	// Note: this can change while loading, use GetTitle().

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -126,13 +126,13 @@ static bool FileTypeHasIcon(IdentifiedFileType fileType) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_ISO_NP:
 	case IdentifiedFileType::PSP_ISO:
+	case IdentifiedFileType::PSP_UMD_VIDEO_ISO:
 		return true;
 	default:
 		return false;
 	}
 }
 
-// Reverse logic.
 static bool FileTypeIsPlayable(IdentifiedFileType fileType) {
 	switch (fileType) {
 	case IdentifiedFileType::ERROR_IDENTIFYING:
@@ -145,6 +145,8 @@ static bool FileTypeIsPlayable(IdentifiedFileType fileType) {
 	case IdentifiedFileType::UNKNOWN_ISO:
 	case IdentifiedFileType::NORMAL_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
+	case IdentifiedFileType::PSP_UMD_VIDEO_ISO:
+		// Reverse logic.
 		return false;
 	default:
 		return true;
@@ -233,9 +235,18 @@ void GameScreen::CreateContentViews(UI::ViewGroup *parent) {
 	LinearLayout *infoLayout = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(10, 200, NONE, NONE));
 	leftColumn->Add(infoLayout);
 
+	if (info_->fileType == IdentifiedFileType::PSP_UMD_VIDEO_ISO) {
+		auto er = GetI18NCategory(I18NCat::ERRORS);
+		leftColumn->Add(new NoticeView(NoticeLevel::INFO, er->T("PPSSPP doesn't support UMD Video."), ""));
+		leftColumn->Add(new Choice(di->T("More info"), ImageID("I_LINK_OUT_QUESTION"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT)))->OnClick.Add([](UI::EventParams &e) {
+			System_LaunchUrl(LaunchUrlType::BROWSER_URL, "https://www.ppsspp.org/docs/reference/umd-video/");
+		});
+	}
+
 	if ((knownFlags_ & GameInfoFlags::UNCOMPRESSED_SIZE) && (knownFlags_ & GameInfoFlags::SIZE)) {
+		auto st = GetI18NCategory(I18NCat::STORE);  // Borrow the size string from here
 		char temp[256];
-		snprintf(temp, sizeof(temp), "%s: %s", ga->T_cstr("Game"), NiceSizeFormat(info_->gameSizeOnDisk).c_str());
+		snprintf(temp, sizeof(temp), "%s: %s", st->T_cstr("Size"), NiceSizeFormat(info_->gameSizeOnDisk).c_str());
 		if (info_->gameSizeUncompressed != info_->gameSizeOnDisk) {
 			size_t len = strlen(temp);
 			snprintf(temp + len, sizeof(temp) - len, " (%s: %s)", ga->T_cstr("Uncompressed"), NiceSizeFormat(info_->gameSizeUncompressed).c_str());

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -224,6 +224,10 @@ void GameScreen::CreateContentViews(UI::ViewGroup *parent) {
 
 		TextView *tvID = mainGameInfo->Add(new TextView(regionID, ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvID->SetShadow(true);
+
+		if (!info_->errorString.empty()) {
+			mainGameInfo->Add(new NoticeView(NoticeLevel::WARN, info_->errorString, ""));
+		}
 	}
 
 	LinearLayout *infoLayout = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(10, 200, NONE, NONE));


### PR DESCRIPTION
Fixed a bug instroduced in #21189 where we'd immediately cancel fullscreen during bootup.

Now UMD Video isos  show icons and backgrounds on the info screen.

Also, now we display an error if you try to play a truncated CSO file.