### PR TITLE
Windows: Enable tilt input for Switch Pro controllers, make it work on bluetooth

### DIFF
--- a/Windows/Hid/DualShock.cpp
+++ b/Windows/Hid/DualShock.cpp
@@ -16,6 +16,7 @@ static const ButtonInputMapping g_psInputMappings[] = {
 	{PS_BTN_OPTIONS, NKCODE_BUTTON_10},
 	{PS_BTN_L1, NKCODE_BUTTON_7},
 	{PS_BTN_R1, NKCODE_BUTTON_8},
+	{PS_BTN_TOUCHPAD, NKCODE_BUTTON_11},
 	// {PS_BTN_L2, NKCODE_BUTTON_L2},  // These are done by the analog triggers.
 	// {PS_BTN_R2, NKCODE_BUTTON_R2},
 	{PS_BTN_L3, NKCODE_BUTTON_THUMBL},

--- a/Windows/Hid/HidInputDevice.h
+++ b/Windows/Hid/HidInputDevice.h
@@ -27,7 +27,9 @@ struct HIDControllerState {
 	u32 buttons;  // Bitmask, PSButton enum
 
 	bool accValid = false;
+	bool gyroValid = false;
 	float accelerometer[3];  // X, Y, Z
+	float gyro[3];
 };
 
 struct ButtonInputMapping {
@@ -45,7 +47,14 @@ public:
 
 	static void AddSupportedDevices(std::set<u32> *deviceVIDPIDs);
 	bool HasAccelerometer() const override {
-		return subType_ == HIDControllerType::DualSense;
+		switch (subType_) {
+		case HIDControllerType::DualSense:
+		case HIDControllerType::SwitchPro:
+			return true;
+		default:
+			break;
+		}
+		return false;
 	}
 private:
 	void ReleaseAllKeys(const ButtonInputMapping *buttonMappings, int count);

--- a/Windows/Hid/SwitchPro.cpp
+++ b/Windows/Hid/SwitchPro.cpp
@@ -66,19 +66,45 @@ constexpr int SwitchPro_RUMBLE_REPORT_LEN = 64;
 
 static const u8 g_switchProCmdBufHeader[] = {0x0, 0x1, 0x40, 0x40, 0x0, 0x1, 0x40, 0x40};
 
-bool InitializeSwitchPro(HANDLE handle) {
-	return true;
-}
+constexpr int SwitchPro_IMU_DATA_OFFSET = 13; // Where IMU starts in 0x30 report
+constexpr float ACCEL_SCALE = 0.000244f;      // Raw to G (range ±8G)
+constexpr float GYRO_SCALE = 0.070f;          // Raw to deg/s (range ±2000dps)
 
 struct SwitchProInputReport {
 	u8 reportId;
 	u8 padding;
-	u8 battery;
+	u8 batteryLevel;
 	u8 buttons[3];
 	u8 lStick[3]; // 2 12-bit values.
 	u8 rStick[3]; // 2 12-bit values.
-	// Next up is gyro and all sorts of stuff we don't care about right now.
+
+	u8 vibrator_report;
+	u8 imu_data[36]; // 3 samples of 6-axis data (12 bytes each)
 };
+
+static void ProcessIMU(const u8 *data, HIDControllerState *state) {
+	// Data contains 3 samples to account for Bluetooth jitter.
+	// We usually just take the latest one (index 2).
+	const u8* s = &data[24];
+
+	// Raw values are Little Endian int16
+	short ax = (short)(s[0] | (s[1] << 8));
+	short ay = (short)(s[2] | (s[3] << 8));
+	short az = (short)(s[4] | (s[5] << 8));
+
+	short gx = (short)(s[6] | (s[7] << 8));
+	short gy = (short)(s[8] | (s[9] << 8));
+	short gz = (short)(s[10] | (s[11] << 8));
+
+	// Convert to physical units
+	state->accelerometer[0] = ax * ACCEL_SCALE;
+	state->accelerometer[1] = ay * ACCEL_SCALE;
+	state->accelerometer[2] = az * ACCEL_SCALE;
+
+	state->gyro[0] = gx * GYRO_SCALE;
+	state->gyro[1] = gy * GYRO_SCALE;
+	state->gyro[2] = gz * GYRO_SCALE;
+}
 
 static void DecodeSwitchProStick(const u8 *stickData, s8 *outX, s8 *outY) {
 	int x = ((stickData[1] & 0xF) << 8) | (stickData[0]);
@@ -87,34 +113,69 @@ static void DecodeSwitchProStick(const u8 *stickData, s8 *outX, s8 *outY) {
 	// For some reason the values are not really centered. Let's approximate.
 	// We probably should add some low level calibration?
 	x = (x - 2048) / 12;
-	y = (y - 1950) / 12;
+	y = -(y - 1950) / 12;
 
 	*outX = (s8)clamp_value(x, -128, 127);
 	*outY = (s8)clamp_value(y, -128, 127);
 	// INFO_LOG(Log::sceCtrl, "Switch Pro input: x=%d, y=%d, cx=%d, cy=%d", x, y, *outX, *outY);
 }
 
+// Subcommand helper
+static bool SendSwitchSubcommand(HANDLE handle, u8 subcommand, const u8 *data, u8 len) {
+	u8 buf[64] = {0x01}; // Report ID 0x01 for subcommands
+	static u8 global_packet_num = 0;
+	buf[1] = global_packet_num++;
+	// ... Fill in rumble data (required even if zero)
+	buf[10] = subcommand;
+	if (data && len > 0) memcpy(&buf[11], data, len);
+
+	DWORD written;
+	return WriteFile(handle, buf, 64, &written, nullptr);
+}
+
+bool InitializeSwitchPro(HANDLE handle) {
+	// 1. USB Handshake (only needed for wired, safe for BT)
+	u8 cmd_usb_enable = 0x01;
+	DWORD w;
+	u8 handshake[2] = {0x80, 0x01};
+	WriteFile(handle, handshake, 2, &w, nullptr);
+	handshake[1] = 0x02; // Handshake 2
+	WriteFile(handle, handshake, 2, &w, nullptr);
+
+	// 2. Set Full Input Mode (0x30)
+	u8 mode = 0x30;
+	SendSwitchSubcommand(handle, 0x03, &mode, 1);
+
+	// 3. Enable IMU
+	u8 enable = 0x01;
+	SendSwitchSubcommand(handle, 0x40, &enable, 1);
+
+	return true;
+}
+
 bool ReadSwitchProInput(HANDLE handle, HIDControllerState *state) {
-	BYTE inputReport[SwitchPro_INPUT_REPORT_LEN]{}; // 64-byte input report for Switch Pro
+	BYTE inputReport[SwitchPro_INPUT_REPORT_LEN]{};
 	DWORD bytesRead = 0;
 	if (!ReadFile(handle, inputReport, sizeof(inputReport), &bytesRead, nullptr)) {
 		u32 error = GetLastError();
 		return false;
 	}
 
-	if (inputReport[0] != 0x30) {
-		// Not a Switch Pro controller input report.
-		return false;
+	// Bluetooth often uses 0x21 for sub-command responses, 0x30 for standard data
+	if (inputReport[0] != 0x30 && inputReport[0] != 0x21) return false;
+
+	const SwitchProInputReport* report = (const SwitchProInputReport*)inputReport;
+	u32 buttons = 0;
+	memcpy(&state->buttons, &report->buttons[0], 3);
+	// Decode Sticks (Keep your existing logic)
+	DecodeSwitchProStick(report->lStick, &state->stickAxes[HID_STICK_LX], &state->stickAxes[HID_STICK_LY]);
+	DecodeSwitchProStick(report->rStick, &state->stickAxes[HID_STICK_RX], &state->stickAxes[HID_STICK_RY]);
+
+	// Decode IMU if report type is 0x30
+	if (inputReport[0] == 0x30) {
+		state->accValid = true;
+		ProcessIMU(report->imu_data, state);
 	}
 
-	SwitchProInputReport report{};
-	memcpy(&report, inputReport, sizeof(report));
-
-	u32 buttons = 0;
-	memcpy(&state->buttons, &report.buttons[0], 3);
-	// INFO_LOG(Log::sceCtrl, "Switch Pro input: buttons=%08x", state->buttons);
-
-	DecodeSwitchProStick(report.lStick, &state->stickAxes[HID_STICK_LX], &state->stickAxes[HID_STICK_LY]);
-	DecodeSwitchProStick(report.rStick, &state->stickAxes[HID_STICK_RX], &state->stickAxes[HID_STICK_RY]);
 	return true;
 }


### PR DESCRIPTION
As it say on the tin.

Thanks Gemini AI for parts of the fix.

Note: This does not yet fetch the analog stick calibration data, so the sticks may be way off. My controller is spot on though :)