### PR TITLE
Background stretch: Only resort to crop to avoid extreme squishing of the image.

### DIFF
--- a/UI/Background.h
+++ b/UI/Background.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Common/File/Path.h"
+#include "Common/Math/lin/vec3.h"
 
 class UIContext;
 
@@ -8,7 +9,7 @@ extern Path boot_filename;
 
 void UIBackgroundInit(UIContext &dc);
 void UIBackgroundShutdown();
-void DrawGameBackground(UIContext &dc, const Path &gamePath, float x, float y, float z);
-void DrawBackground(UIContext &dc, float alpha, float x, float y, float z);
+void DrawGameBackground(UIContext &dc, const Path &gamePath, Lin::Vec3 focus, float alpha);
+void DrawBackground(UIContext &dc, float alpha, Lin::Vec3 focus);
 
 uint32_t GetBackgroundColorWithAlpha(const UIContext &dc);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -64,6 +64,7 @@
 #include "UI/Store.h"
 #include "UI/UploadScreen.h"
 #include "UI/InstallZipScreen.h"
+#include "UI/Background.h"
 #include "Core/Config.h"
 #include "Core/Loaders.h"
 #include "Common/Data/Text/I18n.h"
@@ -1542,32 +1543,7 @@ void MainScreen::DrawBackground(UIContext &dc) {
 }
 
 bool MainScreen::DrawBackgroundFor(UIContext &dc, const Path &gamePath, float progress) {
-	dc.Flush();
-
-	std::shared_ptr<GameInfo> ginfo;
-	if (!gamePath.empty()) {
-		ginfo = g_gameInfoCache->GetInfo(dc.GetDrawContext(), gamePath, GameInfoFlags::PIC1);
-		// Loading texture data may bind a texture.
-		dc.RebindTexture();
-
-		// Let's not bother if there's no picture.
-		if (!ginfo->Ready(GameInfoFlags::PIC1) || !ginfo->pic1.texture) {
-			return false;
-		}
-	} else {
-		return false;
-	}
-
-	auto pic = ginfo->GetPIC1();
-	Draw::Texture *texture = pic ? pic->texture : nullptr;
-
-	uint32_t color = whiteAlpha(ease(progress)) & 0xFFc0c0c0;
-	if (texture) {
-		dc.GetDrawContext()->BindTexture(0, texture);
-		dc.Draw()->DrawTexRect(dc.GetBounds(), 0, 0, 1, 1, color);
-		dc.Flush();
-		dc.RebindTexture();
-	}
+	::DrawGameBackground(dc, gamePath, Lin::Vec3(0.f, 0.f, 0.f), progress);
 	return true;
 }
 

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -109,13 +109,13 @@ ScreenRenderFlags BackgroundScreen::render(ScreenRenderMode mode) {
 	uiContext->PushTransform({ translation_, scale_, alpha_ });
 
 	uiContext->Begin();
-	float x, y, z;
-	screenManager()->getFocusPosition(x, y, z);
+	Lin::Vec3 focus;
+	screenManager()->getFocusPosition(focus.x, focus.y, focus.z);
 
 	if (!gamePath_.empty()) {
-		::DrawGameBackground(*uiContext, gamePath_, x, y, z);
+		::DrawGameBackground(*uiContext, gamePath_, focus, 1.0f);
 	} else {
-		::DrawBackground(*uiContext, 1.0f, x, y, z);
+		::DrawBackground(*uiContext, 1.0f, focus);
 	}
 
 	uiContext->Flush();


### PR DESCRIPTION
Fixes https://github.com/hrydgard/ppsspp/issues/21206 , while still avoiding squash in portrait mode.