### PR TITLE
Fix dissidia adhoc in aemu_postoffice relay mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2086,6 +2086,7 @@ set(GPU_SOURCES
 
 set(aemu_postoffice
 	ext/aemu_postoffice/client/postoffice.c
+	ext/aemu_postoffice/client/postoffice_mem_stdc.c
 	ext/aemu_postoffice/client/mutex_impl_cpp.cpp
 	ext/aemu_postoffice/client/delay_impl_cpp.cpp
 	ext/aemu_postoffice/client/log_impl_ppsspp.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -288,6 +288,7 @@
     <ClInclude Include="..\ext\aemu_postoffice\client\log_impl.h" />
     <ClInclude Include="..\ext\aemu_postoffice\client\mutex_impl.h" />
     <ClInclude Include="..\ext\aemu_postoffice\client\postoffice_client.h" />
+    <ClInclude Include="..\ext\aemu_postoffice\client\postoffice_mem.h" />
     <ClInclude Include="..\ext\aemu_postoffice\client\sock_impl.h" />
     <ClInclude Include="..\ext\at3_standalone\at3_decoders.h" />
     <ClInclude Include="..\ext\at3_standalone\atrac.h" />
@@ -561,6 +562,7 @@
     <ClCompile Include="..\ext\aemu_postoffice\client\log_impl_ppsspp.cpp" />
     <ClCompile Include="..\ext\aemu_postoffice\client\mutex_impl_cpp.cpp" />
     <ClCompile Include="..\ext\aemu_postoffice\client\postoffice.c" />
+    <ClCompile Include="..\ext\aemu_postoffice\client\postoffice_mem_stdc.c" />
     <ClCompile Include="..\ext\aemu_postoffice\client\sock_impl_windows.c" />
     <ClCompile Include="..\ext\at3_standalone\atrac.cpp" />
     <ClCompile Include="..\ext\at3_standalone\atrac3.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -719,6 +719,9 @@
     <ClInclude Include="..\ext\aemu_postoffice\client\postoffice_client.h">
       <Filter>ext\aemu_postoffice</Filter>
     </ClInclude>
+    <ClInclude Include="..\ext\aemu_postoffice\client\postoffice_mem.h">
+      <Filter>ext\aemu_postoffice</Filter>
+    </ClInclude>
     <ClInclude Include="..\ext\aemu_postoffice\client\sock_impl.h">
       <Filter>ext\aemu_postoffice</Filter>
     </ClInclude>
@@ -1339,6 +1342,9 @@
       <Filter>ext\aemu_postoffice</Filter>
     </ClCompile>
     <ClCompile Include="..\ext\aemu_postoffice\client\postoffice.c">
+      <Filter>ext\aemu_postoffice</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ext\aemu_postoffice\client\postoffice_mem_stdc.c">
       <Filter>ext\aemu_postoffice</Filter>
     </ClCompile>
     <ClCompile Include="..\ext\aemu_postoffice\client\sock_impl_windows.c">

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -780,7 +780,7 @@ int DoBlockingPdpSend(AdhocSocketRequest& req, s64& result, AdhocSendTargets& ta
 static int ptp_send_postoffice(int idx, const void *data, int *len) {
 	AdhocSocket *internal = adhocSockets[idx];
 
-	if (*len > AEMU_POSTOFFICE_PTP_BLOCK_MAX){
+	if (*len > AEMU_POSTOFFICE_PTP_BLOCK_MAX) {
 		// force fragmentation for giant sends
 		*len = AEMU_POSTOFFICE_PTP_BLOCK_MAX;
 	}

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -508,9 +508,11 @@ static int pdp_recv_postoffice(int idx, SceNetEtherAddr *saddr, uint16_t *sport,
 	SceNetEtherAddr saddr_copy;
 	int len_copy = *len;
 
-	if (len_copy > 2048) {
+	if (len_copy > AEMU_POSTOFFICE_PDP_BLOCK_MAX) {
 		// trim, library limites pdp packets
-		len_copy = 2048;
+		// some games just provide amazingly huge buffer sizes during recv
+		// if a huge packet cannot be sent, it is logged on the sender side
+		len_copy = AEMU_POSTOFFICE_PDP_BLOCK_MAX;
 	}
 
 	int pdp_recv_status = pdp_recv(pdp_sock, (char *)&saddr_copy, &sport_copy, (char *)data, &len_copy, true);
@@ -870,9 +872,11 @@ static int ptp_recv_postoffice(int idx, void *data, int *len) {
 	AdhocSocket *internal = adhocSockets[idx];
 
 	int len_copy = *len;
-	if (len_copy > 50 * 1024) {
+	if (len_copy > AEMU_POSTOFFICE_PTP_BLOCK_MAX) {
 		// trim, library limit
-		len_copy = 50 * 1024;
+		// some games just provide amazingly huge buffer sizes during recv
+		// if a huge burst cannot be sent, it is logged on the sender side
+		len_copy = AEMU_POSTOFFICE_PTP_BLOCK_MAX;
 	}
 
 	int ptp_recv_status = ptp_recv(internal->postofficeHandle, (char *)data, &len_copy, true);

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -240,6 +240,7 @@
     <ClInclude Include="..\..\ext\aemu_postoffice\client\delay_impl.h" />
     <ClInclude Include="..\..\ext\aemu_postoffice\client\log_impl.h" />
     <ClInclude Include="..\..\ext\aemu_postoffice\client\postoffice_client.h" />
+    <ClInclude Include="..\..\ext\aemu_postoffice\client\postoffice_mem.h" />
     <ClInclude Include="..\..\ext\aemu_postoffice\client\sock_impl.h" />
     <ClInclude Include="..\..\ext\at3_standalone\aac_defines.h" />
     <ClInclude Include="..\..\ext\at3_standalone\at3_decoders.h" />
@@ -409,6 +410,7 @@
     <ClCompile Include="..\..\ext\aemu_postoffice\client\log_impl_ppsspp.cpp" />
     <ClCompile Include="..\..\ext\aemu_postoffice\client\mutex_impl_cpp.cpp" />
     <ClCompile Include="..\..\ext\aemu_postoffice\client\postoffice.c" />
+    <ClCompile Include="..\..\ext\aemu_postoffice\client\postoffice_mem_stdc.c" />
     <ClCompile Include="..\..\ext\aemu_postoffice\client\sock_impl_windows.c" />
     <ClCompile Include="..\..\ext\at3_standalone\atrac.cpp" />
     <ClCompile Include="..\..\ext\at3_standalone\atrac3.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -538,6 +538,9 @@
     <ClCompile Include="..\..\ext\aemu_postoffice\client\postoffice.c">
       <Filter>ext\aemu_postoffice</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\ext\aemu_postoffice\client\postoffice_mem_psp.c">
+      <Filter>ext\aemu_postoffice</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\ext\aemu_postoffice\client\sock_impl_windows.c">
       <Filter>ext\aemu_postoffice</Filter>
     </ClCompile>
@@ -1033,6 +1036,9 @@
       <Filter>ext\aemu_postoffice</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ext\aemu_postoffice\client\postoffice_client.h">
+      <Filter>ext\aemu_postoffice</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\aemu_postoffice\client\postoffice_mem.h">
       <Filter>ext\aemu_postoffice</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ext\aemu_postoffice\client\delay_impl.h">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -713,6 +713,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/HLE/NetAdhocCommon.cpp \
   $(SRC)/Core/HLE/sceNetAdhoc.cpp \
   $(SRC)/ext/aemu_postoffice/client/postoffice.c \
+  $(SRC)/ext/aemu_postoffice/client/postoffice_mem_stdc.c \
   $(SRC)/ext/aemu_postoffice/client/sock_impl_linux.c \
   $(SRC)/ext/aemu_postoffice/client/mutex_impl_cpp.cpp \
   $(SRC)/ext/aemu_postoffice/client/delay_impl_cpp.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -694,7 +694,8 @@ SOURCES_CXX += \
 endif
 
 SOURCES_C += \
-	       $(EXTDIR)/aemu_postoffice/client/postoffice.c
+	       $(EXTDIR)/aemu_postoffice/client/postoffice.c \
+	       $(EXTDIR)/aemu_postoffice/client/postoffice_mem_stdc.c
 
 SOURCES_CXX += \
 	       $(EXTDIR)/aemu_postoffice/client/mutex_impl_cpp.cpp \


### PR DESCRIPTION
User reported large packet sending failing in Dissidia (large pspnet_matching hello data, large PTP send calls). These changes allow Dissidia to function through aemu_postoffice relay. [Server update is required to also update the server side PDP block size cap.](https://github.com/Kethen/aemu_postoffice/releases/tag/2026-02-06)

- Bump aemu_postoffice
  - Raise PDP send max block size
  - Compilation changes caused by experimental PSP 1000 mode introduced on the console side
- Sanitize receive buffer sizes using aemu_postoffice defines
- Trim huge PTP send requests before handing data to aemu_postoffice `ptp_send`

