### PR TITLE
Preparations for a rendering refactor

### DIFF
--- a/Common/File/VFS/VFS.cpp
+++ b/Common/File/VFS/VFS.cpp
@@ -20,7 +20,7 @@ void VFS::Register(std::string_view prefix, VFSBackend *reader) {
 
 void VFS::Clear() {
 	for (auto &entry : entries_) {
-		delete entry.reader;
+		delete entry.backend;
 	}
 	entries_.clear();
 }
@@ -37,6 +37,21 @@ static bool IsLocalAbsolutePath(std::string_view path) {
 	return isUnixLocal || isWindowsLocal || isContentURI;
 }
 
+bool VFS::MapPath(std::string_view path, VFSBackend **backend, std::string_view *relativePath) {
+	int fn_len = (int)path.length();
+	for (const auto &entry : entries_) {
+		int prefix_len = (int)entry.prefix.length();
+		if (prefix_len >= fn_len) continue;
+		if (0 == memcmp(path.data(), entry.prefix.data(), prefix_len)) {
+			*backend = entry.backend;
+			*relativePath = path.substr(prefix_len);
+			return true;
+		}
+	}
+	ERROR_LOG(Log::IO, "VFS: '%.*s' has an unknown filesystem prefix.", STR_VIEW(path));
+	return false;
+}
+
 // The returned data should be free'd with delete[].
 uint8_t *VFS::ReadFile(std::string_view filename, size_t *size) {
 	if (IsLocalAbsolutePath(filename)) {
@@ -45,26 +60,13 @@ uint8_t *VFS::ReadFile(std::string_view filename, size_t *size) {
 		return File::ReadLocalFile(Path(filename), size);
 	}
 
-	const int fn_len = (int)filename.length();
-	bool fileSystemFound = false;
-	for (const auto &entry : entries_) {
-		int prefix_len = (int)entry.prefix.length();
-		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(filename.data(), entry.prefix.data(), prefix_len)) {
-			fileSystemFound = true;
-			// INFO_LOG(Log::IO, "Prefix match: %s (%s) -> %s", entries[i].prefix, filename, filename + prefix_len);
-			uint8_t *data = entry.reader->ReadFile(filename.substr(prefix_len), size);
-			if (data)
-				return data;
-			else
-				continue;
-			// Else try the other registered file systems.
-		}
+	VFSBackend *backend = nullptr;
+	std::string_view relativePath;
+	if (!MapPath(filename, &backend, &relativePath)) {
+		return nullptr;
 	}
-	if (!fileSystemFound) {
-		ERROR_LOG(Log::IO, "Missing filesystem for '%.*s'", STR_VIEW(filename));
-	}  // Otherwise, the file was just missing. No need to log.
-	return nullptr;
+
+	return backend->ReadFile(relativePath, size);
 }
 
 bool VFS::GetFileListing(std::string_view path, std::vector<File::FileInfo> *listing, const char *filter) {
@@ -75,23 +77,13 @@ bool VFS::GetFileListing(std::string_view path, std::vector<File::FileInfo> *lis
 		return true;
 	}
 
-	int fn_len = (int)path.length();
-	bool fileSystemFound = false;
-	for (const auto &entry : entries_) {
-		int prefix_len = (int)entry.prefix.length();
-		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(path.data(), entry.prefix.data(), prefix_len)) {
-			fileSystemFound = true;
-			if (entry.reader->GetFileListing(path.substr(prefix_len), listing, filter)) {
-				return true;
-			}
-		}
+	VFSBackend *backend = nullptr;
+	std::string_view relativePath;
+	if (!MapPath(path, &backend, &relativePath)) {
+		return false;
 	}
 
-	if (!fileSystemFound) {
-		ERROR_LOG(Log::IO, "Missing filesystem for %.*s", STR_VIEW(path));
-	}  // Otherwise, the file was just missing. No need to log.
-	return false;
+	return backend->GetFileListing(relativePath, listing, filter);
 }
 
 bool VFS::GetFileInfo(std::string_view path, File::FileInfo *info) {
@@ -101,23 +93,13 @@ bool VFS::GetFileInfo(std::string_view path, File::FileInfo *info) {
 		return File::GetFileInfo(Path(path), info);
 	}
 
-	bool fileSystemFound = false;
-	int fn_len = (int)path.length();
-	for (const auto &entry : entries_) {
-		int prefix_len = (int)entry.prefix.length();
-		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(path.data(), entry.prefix.data(), prefix_len)) {
-			fileSystemFound = true;
-			if (entry.reader->GetFileInfo(path.substr(prefix_len), info))
-				return true;
-			else
-				continue;
-		}
+	VFSBackend *backend = nullptr;
+	std::string_view relativePath;
+	if (!MapPath(path, &backend, &relativePath)) {
+		return false;
 	}
-	if (!fileSystemFound) {
-		ERROR_LOG(Log::IO, "Missing filesystem for '%.*s'", STR_VIEW(path));
-	}  // Otherwise, the file was just missing. No need to log.
-	return false;
+
+	return backend->GetFileInfo(relativePath, info);
 }
 
 bool VFS::Exists(std::string_view path) {
@@ -127,21 +109,11 @@ bool VFS::Exists(std::string_view path) {
 		return File::Exists(Path(path));
 	}
 
-	bool fileSystemFound = false;
-	int fn_len = (int)path.length();
-	for (const auto &entry : entries_) {
-		int prefix_len = (int)entry.prefix.length();
-		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(path.data(), entry.prefix.data(), prefix_len)) {
-			fileSystemFound = true;
-			if (entry.reader->Exists(path.substr(prefix_len)))
-				return true;
-			else
-				continue;
-		}
+	VFSBackend *backend = nullptr;
+	std::string_view relativePath;
+	if (!MapPath(path, &backend, &relativePath)) {
+		return false;
 	}
-	if (!fileSystemFound) {
-		ERROR_LOG(Log::IO, "Missing filesystem for '%.*s'", STR_VIEW(path));
-	}  // Otherwise, the file was just missing. No need to log.
-	return false;
+
+	return backend->Exists(relativePath);
 }

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -81,9 +81,11 @@ public:
 	bool Exists(std::string_view path);
 
 private:
+	bool MapPath(std::string_view filename, VFSBackend **backend, std::string_view *relativePath);
+
 	struct VFSEntry {
 		std::string_view prefix;
-		VFSBackend *reader;
+		VFSBackend *backend;
 	};
 	std::vector<VFSEntry> entries_;
 };

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -661,7 +661,8 @@ void __DisplayFlip(int cyclesLate) {
 			}
 		}
 		if (nextFrame) {
-			gpu->CopyDisplayToOutput(g_displayLayoutConfigCached, fbReallyDirty);
+			gpu->SetCurFramebufferDirty(fbReallyDirty);
+			gpu->CopyDisplayToOutput(g_displayLayoutConfigCached);
 			if (fbReallyDirty) {
 				DisplayFireActualFlip();
 			}

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -795,7 +795,7 @@ static int ptp_send_postoffice(int idx, const void *data, int *len) {
 	}
 	if (ptp_send_status == AEMU_POSTOFFICE_CLIENT_OUT_OF_MEMORY) {
 		// this is pretty critical
-		ERROR_LOG(Log::sceNet, "%s: critical: huge client buf %d what is going on please fix", __func__, len);
+		ERROR_LOG(Log::sceNet, "%s: critical: huge client buf %d what is going on please fix", __func__, len ? *len : 0);
 	}
 
 	return 0;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1536,14 +1536,15 @@ Draw::Texture *FramebufferManagerCommon::MakePixelTexture(const u8 *srcPixels, G
 	return tex;
 }
 
-// This is called from CopyFramebufferToOutput.
+// This is internal, called from CopyDisplayToOutput.
 bool FramebufferManagerCommon::DrawFramebufferToOutput(const DisplayLayoutConfig &config, const u8 *srcPixels, int srcStride, GEBufferFormat srcPixelFormat) {
 	textureCache_->ForgetLastTexture();
 	shaderManager_->DirtyLastShader();
 
 	Draw::Texture *pixelsTex = MakePixelTexture(srcPixels, srcPixelFormat, srcStride, 512, 272);
-	if (!pixelsTex)
+	if (!pixelsTex) {
 		return false;
+	}
 
 	int uvRotation = useBufferedRendering_ ? config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
 	OutputFlags flags = config.iDisplayFilter == SCALE_LINEAR ? OutputFlags::LINEAR : OutputFlags::NEAREST;
@@ -1561,7 +1562,6 @@ bool FramebufferManagerCommon::DrawFramebufferToOutput(const DisplayLayoutConfig
 	presentation_->UpdateUniforms(textureCache_->VideoIsPlaying());
 	presentation_->SourceTexture(pixelsTex, 512, 272);
 	presentation_->RunPostshaderPasses(config, flags, uvRotation, u0, v0, u1, v1);
-	presentation_->CopyToOutput(config, flags);
 
 	// PresentationCommon sets all kinds of state, we can't rely on anything.
 	gstate_c.Dirty(DIRTY_ALL);
@@ -1651,7 +1651,9 @@ void FramebufferManagerCommon::CopyDisplayToOutput(const DisplayLayoutConfig &co
 		if (Memory::IsValidAddress(fbaddr)) {
 			// The game is displaying something directly from RAM. In GTA, it's decoded video.
 			// If successful, this effectively calls presentation_->NotifyPresent();
-			if (!DrawFramebufferToOutput(config, Memory::GetPointerUnchecked(fbaddr), displayStride_, displayFormat_)) {
+			if (DrawFramebufferToOutput(config, Memory::GetPointerUnchecked(fbaddr), displayStride_, displayFormat_)) {
+				presentation_->CopyToOutput(config);
+			} else {
 				if (useBufferedRendering_) {
 					// Bind and clear the backbuffer. This should be the first time during the frame that it's bound.
 					draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "CopyDisplayToOutput_DrawError");
@@ -1730,7 +1732,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput(const DisplayLayoutConfig &co
 		presentation_->UpdateUniforms(textureCache_->VideoIsPlaying());
 		presentation_->SourceFramebuffer(vfb->fbo, actualWidth, actualHeight);
 		presentation_->RunPostshaderPasses(config, flags, uvRotation, u0, v0, u1, v1);
-		presentation_->CopyToOutput(config, flags);
+		presentation_->CopyToOutput(config);
 	} else if (useBufferedRendering_) {
 		WARN_LOG(Log::FrameBuf, "Using buffered rendering, and current VFB lacks an FBO: %08x", vfb->fb_address);
 	} else {
@@ -2802,7 +2804,9 @@ void FramebufferManagerCommon::NotifyBlockTransferAfter(u32 dstBasePtr, int dstS
 		if (isPrevDisplayBuffer || isDisplayBuffer) {
 			FlushBeforeCopy();
 			// HACK
-			DrawFramebufferToOutput(displayLayoutConfigCopy_, Memory::GetPointerUnchecked(dstBasePtr), dstStride, displayFormat_);
+			if (DrawFramebufferToOutput(displayLayoutConfigCopy_, Memory::GetPointerUnchecked(dstBasePtr), dstStride, displayFormat_)) {
+				presentation_->CopyToOutput(displayLayoutConfigCopy_);
+			}
 			return;
 		}
 	}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -655,6 +655,7 @@ void PresentationCommon::RunPostshaderPasses(const DisplayLayoutConfig &config, 
 	draw_->Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
 
 	postShaderOutput_ = nullptr;
+	outputFlags_ = flags;
 
 	// TODO: If shader objects have been created by now, we might have received errors.
 	// GLES can have the shader fail later, shader->failed / shader->error.
@@ -874,11 +875,11 @@ void PresentationCommon::RunPostshaderPasses(const DisplayLayoutConfig &config, 
 	}
 }
 
-void PresentationCommon::CopyToOutput(const DisplayLayoutConfig &config, OutputFlags flags) {
-	bool useNearest = flags & OutputFlags::NEAREST;
+void PresentationCommon::CopyToOutput(const DisplayLayoutConfig &config) {
+	bool useNearest = outputFlags_ & OutputFlags::NEAREST;
 	bool useStereo = gstate_c.Use(GPU_USE_SIMPLE_STEREO_PERSPECTIVE) && stereoPipeline_ != nullptr;  // TODO: Also check that the backend has support for it.
 
-	const bool usePostShader = usePostShader_ && !useStereo && !(flags & OutputFlags::RB_SWIZZLE);
+	const bool usePostShader = usePostShader_ && !useStereo && !(outputFlags_ & OutputFlags::RB_SWIZZLE);
 	const bool isFinalAtOutputResolution = usePostShader && postShaderFramebuffers_.size() < postShaderPipelines_.size();
 	int lastWidth = srcWidth_;
 	int lastHeight = srcHeight_;
@@ -886,7 +887,7 @@ void PresentationCommon::CopyToOutput(const DisplayLayoutConfig &config, OutputF
 	draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "FinalBlit");
 	draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 
-	Draw::Pipeline *pipeline = (flags & OutputFlags::RB_SWIZZLE) ? texColorRBSwizzle_ : texColor_;
+	Draw::Pipeline *pipeline = (outputFlags_ & OutputFlags::RB_SWIZZLE) ? texColorRBSwizzle_ : texColor_;
 
 	if (useStereo) {
 		draw_->BindPipeline(stereoPipeline_);

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -69,6 +69,7 @@ struct ShaderInfo;
 class TextureCacheCommon;
 
 enum class OutputFlags {
+	DEFAULT = 0,
 	LINEAR = 0x0000,
 	NEAREST = 0x0001,
 	RB_SWIZZLE = 0x0002,
@@ -127,7 +128,7 @@ public:
 	void SourceFramebuffer(Draw::Framebuffer *fb, int bufferWidth, int bufferHeight);
 
 	void RunPostshaderPasses(const DisplayLayoutConfig &config, OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1);
-	void CopyToOutput(const DisplayLayoutConfig &config, OutputFlags flags);
+	void CopyToOutput(const DisplayLayoutConfig &config);
 
 	void CalculateRenderResolution(const DisplayLayoutConfig &config, int *width, int *height, int *scaleFactor, bool *upscaling, bool *ssaa) const;
 
@@ -195,4 +196,5 @@ protected:
 	// Carry over info between RunPostShaderPasses and CopyToOutput.
 	Draw::Framebuffer *postShaderOutput_ = nullptr;
 	FRect rc_;
+	OutputFlags outputFlags_ = OutputFlags::DEFAULT;
 };

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -125,7 +125,9 @@ public:
 	void UpdateUniforms(bool hasVideo);
 	void SourceTexture(Draw::Texture *texture, int bufferWidth, int bufferHeight);
 	void SourceFramebuffer(Draw::Framebuffer *fb, int bufferWidth, int bufferHeight);
-	void CopyToOutput(const DisplayLayoutConfig &config, OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1);
+
+	void RunPostshaderPasses(const DisplayLayoutConfig &config, OutputFlags flags, int uvRotation, float u0, float v0, float u1, float v1);
+	void CopyToOutput(const DisplayLayoutConfig &config, OutputFlags flags);
 
 	void CalculateRenderResolution(const DisplayLayoutConfig &config, int *width, int *height, int *scaleFactor, bool *upscaling, bool *ssaa) const;
 
@@ -189,4 +191,8 @@ protected:
 		int h;
 	};
 	std::vector<PrevFBO> postShaderFBOUsage_;
+
+	// Carry over info between RunPostShaderPasses and CopyToOutput.
+	Draw::Framebuffer *postShaderOutput_ = nullptr;
+	FRect rc_;
 };

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -124,7 +124,8 @@ public:
 	uint32_t GetAddrTranslation() override;
 
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) = 0;
-	virtual void CopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty) = 0;
+	virtual void SetCurFramebufferDirty(bool dirty) = 0;
+	virtual void CopyDisplayToOutput(const DisplayLayoutConfig &config) = 0;
 	virtual bool PresentedThisFrame() const = 0;
 
 	// Invalidate any cached content sourced from the specified range.

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -530,7 +530,7 @@ void GPUCommonHW::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
 }
 
-void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty) {
+void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
 	drawEngineCommon_->FlushQueuedDepth();
 	// Flush anything left over.
 	drawEngineCommon_->Flush();
@@ -538,7 +538,8 @@ void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config, bool re
 	shaderManager_->DirtyLastShader();
 
 	// after this, render pass is active.
-	framebufferManager_->CopyDisplayToOutput(config, reallyDirty);
+	framebufferManager_->CopyDisplayToOutput(config, curFramebufferDirty_);
+	curFramebufferDirty_ = false;
 
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -7,10 +7,11 @@
 class GPUCommonHW : public GPUCommon {
 public:
 	GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
-	~GPUCommonHW();
+	~GPUCommonHW() override;
 
 	// This can fail, and if so no render pass is active.
-	void CopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty) override;
+	void SetCurFramebufferDirty(bool dirty) override { curFramebufferDirty_ = dirty; }
+	void CopyDisplayToOutput(const DisplayLayoutConfig &config) override;
 	void DoState(PointerWrap &p) override;
 	void DeviceLost() override;
 	void DeviceRestore(Draw::DrawContext *draw) override;
@@ -105,4 +106,5 @@ protected:
 	int msaaLevel_ = 0;
 	bool sawExactEqualDepth_ = false;
 	ShaderManagerCommon *shaderManager_ = nullptr;
+	bool curFramebufferDirty_ = false;
 };

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -643,7 +643,8 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(const DisplayLayoutConfig &config, 
 	}
 
 	presentation_->SourceTexture(fbTex, desc.width, desc.height);
-	presentation_->CopyToOutput(config, outputFlags, config.iInternalScreenRotation, u0, v0, u1, v1);
+	presentation_->RunPostshaderPasses(config, outputFlags, config.iInternalScreenRotation, u0, v0, u1, v1);
+	presentation_->CopyToOutput(config, outputFlags);
 }
 
 void SoftGPU::CopyDisplayToOutput(const DisplayLayoutConfig &config) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -644,7 +644,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(const DisplayLayoutConfig &config, 
 
 	presentation_->SourceTexture(fbTex, desc.width, desc.height);
 	presentation_->RunPostshaderPasses(config, outputFlags, config.iInternalScreenRotation, u0, v0, u1, v1);
-	presentation_->CopyToOutput(config, outputFlags);
+	presentation_->CopyToOutput(config);
 }
 
 void SoftGPU::CopyDisplayToOutput(const DisplayLayoutConfig &config) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -646,7 +646,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(const DisplayLayoutConfig &config, 
 	presentation_->CopyToOutput(config, outputFlags, config.iInternalScreenRotation, u0, v0, u1, v1);
 }
 
-void SoftGPU::CopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty) {
+void SoftGPU::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
 	drawEngine_->transformUnit.Flush(this, "output");
 	// The display always shows 480x272.
 	CopyToCurrentFboFromDisplayRam(config, FB_WIDTH, FB_HEIGHT);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -137,7 +137,8 @@ public:
 	void UpdateCmdInfo() override {}
 
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
-	void CopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty) override;
+	void SetCurFramebufferDirty(bool dirty) override {}
+	void CopyDisplayToOutput(const DisplayLayoutConfig &config) override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	std::vector<const VirtualFramebuffer *> GetFramebufferList() const override { return std::vector<const VirtualFramebuffer *>(); }
 	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1690,7 +1690,8 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		if (PSP_IsInited() && !skipBufferEffects) {
 			_dbg_assert_(gpu);
 			gpu->BeginHostFrame(displayLayoutConfig);
-			gpu->CopyDisplayToOutput(displayLayoutConfig, true);
+			gpu->SetCurFramebufferDirty(true);
+			gpu->CopyDisplayToOutput(displayLayoutConfig);
 			gpu->EndHostFrame();
 		}
 		if (gpu && gpu->PresentedThisFrame()) {
@@ -1803,7 +1804,8 @@ ScreenRenderFlags EmuScreen::RunEmulation(ScreenRenderMode mode, bool framebuffe
 				// This won't work in non-buffered, but that's fine.
 				if (!framebufferBound && PSP_IsInited()) {
 					// draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, clearColor }, "EmuScreen_Stepping");
-					gpu->CopyDisplayToOutput(displayLayoutConfig, true);
+					gpu->SetCurFramebufferDirty(true);
+					gpu->CopyDisplayToOutput(displayLayoutConfig);
 					framebufferBound = true;
 				}
 			}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1634,13 +1634,12 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 	// If a boot is in progress, update it.
 	ProcessGameBoot(gamePath_);
 
-	ScreenRenderFlags flags = ScreenRenderFlags::NONE;
-	Draw::Viewport viewport{ 0.0f, 0.0f, (float)g_display.pixel_xres, (float)g_display.pixel_yres, 0.0f, 1.0f };
+	const Draw::Viewport viewport{0.0f, 0.0f, (float)g_display.pixel_xres, (float)g_display.pixel_yres, 0.0f, 1.0f};
 	using namespace Draw;
 
 	DrawContext *draw = screenManager()->getDrawContext();
 	if (!draw) {
-		return flags;  // shouldn't really happen but I've seen a suspicious stack trace..
+		return ScreenRenderFlags::NONE;  // shouldn't really happen but I've seen a suspicious stack trace..
 	}
 
 	ProcessQueuedVKeys();
@@ -1648,8 +1647,6 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 	const bool skipBufferEffects = g_Config.bSkipBufferEffects;
 
 	bool framebufferBound = false;
-
-	const DeviceOrientation orientation = GetDeviceOrientation();
 
 	if (mode & ScreenRenderMode::FIRST) {
 		// Actually, always gonna be first when it exists (?)
@@ -1664,9 +1661,9 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		if (skipBufferEffects && !g_Config.bSoftwareRendering) {
 			// We need to clear here already so that drawing during the frame is done on a clean slate.
 			if (Core_IsStepping() && gpuStats.numFlips != 0) {
-				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_BackBuffer");
+				draw->BindFramebufferAsRenderTarget(nullptr, {RPAction::KEEP, RPAction::CLEAR, RPAction::CLEAR}, "EmuScreen_BackBuffer");
 			} else {
-				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "EmuScreen_BackBuffer");
+				draw->BindFramebufferAsRenderTarget(nullptr, {RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000}, "EmuScreen_BackBuffer");
 			}
 
 			draw->SetViewport(viewport);
@@ -1681,6 +1678,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 
 	g_OSD.NudgeIngameNotifications();
 
+	const DeviceOrientation orientation = GetDeviceOrientation();
 	const DisplayLayoutConfig &displayLayoutConfig = g_Config.GetDisplayLayoutConfig(orientation);
 	__DisplaySetDisplayLayoutConfig(displayLayoutConfig);
 
@@ -1699,7 +1697,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 			framebufferBound = true;
 		}
 		if (!framebufferBound) {
-			draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, }, "EmuScreen_Behind");
+			draw->BindFramebufferAsRenderTarget(nullptr, {RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR,}, "EmuScreen_Behind");
 		}
 
 		Draw::BackendState state = draw->GetCurrentBackendState();
@@ -1708,7 +1706,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 			// _dbg_assert_msg_(state.passes >= 1, "skipB: %d sw: %d mode: %d back: %d tag: %s behi: %d", (int)skipBufferEffects, (int)g_Config.bSoftwareRendering, (int)mode, (int)g_Config.iGPUBackend, screenManager()->topScreen()->tag(), (int)g_Config.bRunBehindPauseMenu);
 			// Workaround any remaining bugs like this.
 			if (state.passes == 0) {
-				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, }, "EmuScreen_SafeFallback");
+				draw->BindFramebufferAsRenderTarget(nullptr, {RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR,}, "EmuScreen_SafeFallback");
 			}
 		}
 
@@ -1717,7 +1715,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		draw->SetViewport(viewport);
 		draw->SetScissorRect(0, 0, g_display.pixel_xres, g_display.pixel_yres);
 		darken();
-		return flags;
+		return ScreenRenderFlags::NONE;
 	}
 
 	if (!PSP_IsInited() || readyToFinishBoot_) {
@@ -1726,13 +1724,13 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		if (mode & ScreenRenderMode::TOP) {
 			checkPowerDown();
 		}
-		draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_Invalid");
+		draw->BindFramebufferAsRenderTarget(nullptr, {RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR}, "EmuScreen_Invalid");
 		// Need to make sure the UI texture is available, for "darken".
 		screenManager()->getUIContext()->BeginFrame();
 		draw->SetViewport(viewport);
 		draw->SetScissorRect(0, 0, g_display.pixel_xres, g_display.pixel_yres);
 		renderUI();
-		return flags;
+		return ScreenRenderFlags::NONE;
 	}
 
 	// Freeze-frame functionality (loads a savestate on every frame).
@@ -1748,13 +1746,24 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		}
 	}
 
-	PSP_UpdateDebugStats((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS || g_Config.bLogFrameDrops);
-
 	// Running it early allows things like direct readbacks of buffers, things we can't do
 	// when we have started the final render pass. Well, technically we probably could with some manipulation
 	// of pass order in the render managers..
 	runImDebugger();
 
+	return RunEmulation(mode, framebufferBound, skipBufferEffects);
+}
+
+ScreenRenderFlags EmuScreen::RunEmulation(ScreenRenderMode mode, bool framebufferBound, bool skipBufferEffects) {
+	using namespace Draw;
+	ScreenRenderFlags flags = ScreenRenderFlags::NONE;
+
+	const DeviceOrientation orientation = GetDeviceOrientation();
+	const DisplayLayoutConfig &displayLayoutConfig = g_Config.GetDisplayLayoutConfig(orientation);
+	DrawContext *draw = screenManager()->getDrawContext();
+	const Draw::Viewport viewport{0.0f, 0.0f, (float)g_display.pixel_xres, (float)g_display.pixel_yres, 0.0f, 1.0f};
+
+	PSP_UpdateDebugStats((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS || g_Config.bLogFrameDrops);
 	bool blockedExecution = Achievements::IsBlockingExecution();
 	uint32_t clearColor = 0;
 	if (!blockedExecution) {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -73,6 +73,7 @@ protected:
 
 private:
 	void CreateViews() override;
+	ScreenRenderFlags RunEmulation(ScreenRenderMode mode, bool framebufferBound, bool skipBufferEffects);
 	void OnDevTools(UI::EventParams &params);
 	void OnChat(UI::EventParams &params);
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1405,6 +1405,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
 		auto co = GetI18NCategory(I18NCat::CONTROLS);
 
+		// Display rotation 
 		AddRotationPicker(screenManager(), systemSettings, true);
 
 		if (System_GetPropertyBool(SYSPROP_SUPPORTS_SUSTAINED_PERF_MODE)) {

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -245,8 +245,10 @@ void AddRotationPicker(ScreenManager *screenManager, UI::ViewGroup *parent, bool
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
 
 	PopupMultiChoice *rot = parent->Add(new PopupMultiChoice(&g_Config.iScreenRotation, text ? co->T("Screen Rotation") : "", screenRotation, 0, ARRAY_SIZE(screenRotation), I18NCat::CONTROLS, screenManager, text ? nullptr : new LinearLayoutParams(ITEM_HEIGHT, ITEM_HEIGHT)));
-	rot->SetHideTitle(true);
-	rot->SetIconOnly(true);
+	if (!text) {
+		rot->SetHideTitle(true);
+		rot->SetIconOnly(true);
+	}
 	rot->SetChoiceIcons(screenRotationIcons);
 
 	// Portrait Reversed is not recommended on iPhone (and we also ban it in the plist).

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -268,8 +268,10 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 	if (draw) {
 		draw->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Headless");
 		// Vulkan may get angry if we don't do a final present.
-		if (gpu)
-			gpu->CopyDisplayToOutput(g_Config.GetDisplayLayoutConfig(DeviceOrientation::Landscape), true);
+		if (gpu) {
+			gpu->SetCurFramebufferDirty(true);
+			gpu->CopyDisplayToOutput(g_Config.GetDisplayLayoutConfig(DeviceOrientation::Landscape));
+		}
 
 		draw->EndFrame();
 	}


### PR DESCRIPTION
PPSSPP's render pass management, the combination of gameplay graphics and UI in EmuScreen.cpp, is bug-prone and overly complicated so I'm going to clean things up, eliminating a whole class of bugs that have been annoying me. But first I need to restructure things a little bit, introducing a split between game and post-processing render passes on one side, and the final renderpass to the backbuffer on the other.

The actual refactor will come in a followup PR, getting these first changes in first.