### PR TITLE
Refactor mainloop renderpass management

### DIFF
--- a/Common/GPU/Vulkan/VulkanFramebuffer.cpp
+++ b/Common/GPU/Vulkan/VulkanFramebuffer.cpp
@@ -292,6 +292,11 @@ static VkAttachmentStoreOp ConvertStoreAction(VKRRenderPassStoreAction action) {
 
 VkRenderPass CreateRenderPass(VulkanContext *vulkan, const RPKey &key, RenderPassType rpType, VkSampleCountFlagBits sampleCount) {
 	bool isBackbuffer = rpType == RenderPassType::BACKBUFFER;
+	if (isBackbuffer) {
+		_dbg_assert_(key.colorLoadAction != VKRRenderPassLoadAction::KEEP);
+		_dbg_assert_(key.depthLoadAction != VKRRenderPassLoadAction::KEEP);
+		_dbg_assert_(key.stencilLoadAction != VKRRenderPassLoadAction::KEEP);
+	}
 	bool hasDepth = RenderPassTypeHasDepth(rpType);
 	bool multiview = RenderPassTypeHasMultiView(rpType);
 	bool multisample = RenderPassTypeHasMultisample(rpType);

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1839,6 +1839,8 @@ DataFormat VKContext::PreferredFramebufferReadbackFormat(Framebuffer *src) {
 }
 
 void VKContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
+	_dbg_assert_(fbo != nullptr || equals(tag, "BackBuffer"))
+
 	VKFramebuffer *fb = (VKFramebuffer *)fbo;
 	VKRRenderPassLoadAction color = (VKRRenderPassLoadAction)rp.color;
 	VKRRenderPassLoadAction depth = (VKRRenderPassLoadAction)rp.depth;

--- a/Common/System/OSD.cpp
+++ b/Common/System/OSD.cpp
@@ -129,6 +129,16 @@ void OnScreenDisplay::Show(OSDType type, std::string_view text, std::string_view
 	entries_.insert(entries_.begin(), msg);
 }
 
+void OnScreenDisplay::CancelById(std::string_view id) {
+	for (auto iter = entries_.begin(); iter != entries_.end();) {
+		if (iter->id == id) {
+			iter = entries_.erase(iter);
+		} else {
+			iter++;
+		}
+	}
+}
+
 void OnScreenDisplay::ShowOnOff(std::string_view message, bool on, float duration_s) {
 	std::string msg(message);
 	msg += ": ";

--- a/Common/System/OSD.h
+++ b/Common/System/OSD.h
@@ -61,6 +61,7 @@ public:
 	void Show(OSDType type, std::string_view text, std::string_view text2, std::string_view icon, float duration_s = 0.0f, const char *id = nullptr);
 
 	void ShowOnOff(std::string_view message, bool on, float duration_s = 0.0f);
+	void CancelById(std::string_view id);
 
 	bool IsEmpty() const { return entries_.empty(); }  // Shortcut to skip rendering.
 

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -215,8 +215,13 @@ ScreenRenderFlags ScreenManager::render() {
 
 	// First, go through the whole stack and have every screen render any non-backbuffer render passes.
 	// In EmuScreen, this might result in running emulation.
-	for (auto &layer : stack_) {
-		flags |= layer.screen->PreRender();
+	for (size_t i = 0; i < stack_.size(); i++) {
+		const auto &layer = stack_[i];
+		ScreenRenderMode mode = ScreenRenderMode::DEFAULT;
+		if (i == stack_.size() - 1) {
+			mode |= ScreenRenderMode::TOP;
+		}
+		flags |= layer.screen->PreRender(mode);
 	}
 
 	// Now, start the final render pass. This is now the ONLY place where binding the null fb is allowed.

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -209,7 +209,25 @@ void ScreenManager::resized() {
 }
 
 ScreenRenderFlags ScreenManager::render() {
+	using namespace Draw;
+
 	ScreenRenderFlags flags = ScreenRenderFlags::NONE;
+
+	// First, go through the whole stack and have every screen render any non-backbuffer render passes.
+	// In EmuScreen, this might result in running emulation.
+	for (auto &layer : stack_) {
+		flags |= layer.screen->PreRender();
+	}
+
+	// Now, start the final render pass. This is now the ONLY place where binding the null fb is allowed.
+	draw_->BindFramebufferAsRenderTarget(nullptr, {RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR}, "BackBuffer");
+	getUIContext()->BeginFrame();
+
+	const Draw::Viewport viewport{0.0f, 0.0f, (float)g_display.pixel_xres, (float)g_display.pixel_yres, 0.0f, 1.0f};
+	draw_->SetViewport(viewport);
+	draw_->SetScissorRect(0, 0, g_display.pixel_xres, g_display.pixel_yres);
+	draw_->SetTargetSize(g_display.pixel_xres, g_display.pixel_yres);
+
 	if (!stack_.empty()) {
 		// Collect the screens to render
 		TinySet<Screen *, 6> layers;

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -72,11 +72,12 @@ ENUM_CLASS_BITOPS(ScreenRenderRole);
 
 class Screen {
 public:
-	Screen() : screenManager_(nullptr) { }
+	Screen() = default;
 	virtual ~Screen();
 
 	virtual void onFinish(DialogResult reason) {}
 	virtual void update() {}
+	virtual ScreenRenderFlags PreRender() { return ScreenRenderFlags::NONE; }
 	virtual ScreenRenderFlags render(ScreenRenderMode mode) = 0;
 	virtual void resized() {}
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}
@@ -114,7 +115,7 @@ protected:
 	}
 
 private:
-	ScreenManager *screenManager_;
+	ScreenManager *screenManager_ = nullptr;
 	int token_ = -1;
 
 	DISALLOW_COPY_AND_ASSIGN(Screen);

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -77,7 +77,7 @@ public:
 
 	virtual void onFinish(DialogResult reason) {}
 	virtual void update() {}
-	virtual ScreenRenderFlags PreRender() { return ScreenRenderFlags::NONE; }
+	virtual ScreenRenderFlags PreRender(ScreenRenderMode mode) { return ScreenRenderFlags::NONE; }
 	virtual ScreenRenderFlags render(ScreenRenderMode mode) = 0;
 	virtual void resized() {}
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -147,13 +147,6 @@ void UIScreen::update() {
 
 	DoRecreateViews();
 
-	if (root_) {
-		DialogResult result = UpdateViewHierarchy(root_);
-		if (result != DR_NONE) {
-			TriggerFinish(result);
-		}
-	}
-
 	while (true) {
 		QueuedEvent ev{};
 		{
@@ -186,6 +179,13 @@ void UIScreen::update() {
 		case QueuedEventType::AXIS:
 			axis(ev.axis);
 			break;
+		}
+	}
+
+	if (root_) {
+		DialogResult result = UpdateViewHierarchy(root_);
+		if (result != DR_NONE) {
+			TriggerFinish(result);
 		}
 	}
 }

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -200,30 +200,7 @@ void UIScreen::deviceRestored(Draw::DrawContext *draw) {
 		root_->DeviceRestored(draw);
 }
 
-void UIScreen::SetupViewport() {
-	using namespace Draw;
-	Draw::DrawContext *draw = screenManager()->getDrawContext();
-	_dbg_assert_(draw != nullptr);
-	// Bind and clear the back buffer
-	draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
-	screenManager()->getUIContext()->BeginFrame();
-
-	Draw::Viewport viewport;
-	viewport.TopLeftX = 0;
-	viewport.TopLeftY = 0;
-	viewport.Width = g_display.pixel_xres;
-	viewport.Height = g_display.pixel_yres;
-	viewport.MaxDepth = 1.0;
-	viewport.MinDepth = 0.0;
-	draw->SetViewport(viewport);
-	draw->SetTargetSize(g_display.pixel_xres, g_display.pixel_yres);
-}
-
 ScreenRenderFlags UIScreen::render(ScreenRenderMode mode) {
-	if (mode & ScreenRenderMode::FIRST) {
-		SetupViewport();
-	}
-
 	DoRecreateViews();
 
 	UIContext &uiContext = *screenManager()->getUIContext();

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -77,7 +77,6 @@ protected:
 	virtual void DrawBackground(UIContext &ui) {}
 	virtual void DrawForeground(UIContext &ui) {}
 
-	void SetupViewport();
 	void DoRecreateViews();
 
 	bool recreateViews_ = true;

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -68,7 +68,6 @@ void Event::Add(std::function<void(EventParams&)> func) {
 	func_ = func;
 }
 
-// Call this from input thread or whatever, it doesn't matter
 void Event::Trigger(EventParams &e) {
 	if (!func_) {
 		return;
@@ -76,7 +75,6 @@ void Event::Trigger(EventParams &e) {
 	EventTriggered(this, e);
 }
 
-// Call this from UI thread
 void Event::Dispatch(EventParams &e) {
 	if (func_)
 		func_(e);

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -237,7 +237,7 @@ typedef std::function<void(EventParams &)> EventCallback;
 
 class Event {
 public:
-	Event() {}
+	Event() = default;
 	~Event();
 	// Call this from input thread or whatever, it doesn't matter
 	void Trigger(EventParams &e);

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -321,17 +321,17 @@ float GetTargetScore(const Point2D &originPos, int originIndex, const View *orig
 		distance = 0.001f;
 	}
 	float overlap = 0.0f;
-	float dirX = dx / distance;
-	float dirY = dy / distance;
+	const float dirX = dx / distance;
+	const float dirY = dy / distance;
 
 	bool wrongDirection = false;
 	bool vertical = false;
-	float horizOverlap = HorizontalOverlap(origin->GetBounds(), destination->GetBounds());
-	float vertOverlap = VerticalOverlap(origin->GetBounds(), destination->GetBounds());
+	const float horizOverlap = HorizontalOverlap(origin->GetBounds(), destination->GetBounds());
+	const float vertOverlap = VerticalOverlap(origin->GetBounds(), destination->GetBounds());
 	if (horizOverlap == 1.0f && vertOverlap == 1.0f) {
 		if (direction != FOCUS_PREV_PAGE && direction != FOCUS_NEXT_PAGE) {
-			INFO_LOG(Log::UI, "Contain overlap");
-			return 0.0;
+			INFO_LOG(Log::UI, "Contain overlap: %s, %s", origin->Tag().c_str(), destination->Tag().c_str());
+			return 0.0f;
 		}
 	}
 	float originSize = 0.0f;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -90,7 +90,7 @@ struct DisplayLayoutConfig : public ConfigBlock {
 	int iCardboardScreenSize = 50; // Screen Size (in %)
 	int iCardboardXShift = 0; // X-Shift of Screen (in %)
 	int iCardboardYShift = 0; // Y-Shift of Screen (in %)
-	bool bImmersiveMode = true;  // Mode on Android Kitkat 4.4 and later that hides the back button etc.
+	bool bImmersiveMode = false;  // Mode on Android Kitkat 4.4 and later that hides the back button etc.
 
 	bool InternalRotationIsPortrait() const;
 	bool CanResetToDefault() const override { return true; }

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -662,7 +662,6 @@ void __DisplayFlip(int cyclesLate) {
 		}
 		if (nextFrame) {
 			gpu->SetCurFramebufferDirty(fbReallyDirty);
-			gpu->CopyDisplayToOutput(g_displayLayoutConfigCached);
 			if (fbReallyDirty) {
 				DisplayFireActualFlip();
 			}

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -110,7 +110,11 @@ namespace SaveState {
 	bool IsOldVersion();
 
 	// Check if there's any save stating needing to be done.  Normally called once per frame.
-	bool Process();
+	void Process();
+
+	// Separate function to just process screenshots, as they need to be done at a specific time in a frame.
+	// Returns true if a screenshot was taken.
+	bool ProcessScreenshot(bool skipBufferEffects);
 
 	// Notify save state code that new save data has been written.
 	void NotifySaveData();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -252,17 +252,23 @@ static void ShowCompatWarnings(const Compatibility &compat) {
 	// UI changes are best done after PSP_InitStart.
 	if (compat.flags().RequireBufferedRendering && g_Config.bSkipBufferEffects && !g_Config.bSoftwareRendering) {
 		auto gr = GetI18NCategory(I18NCat::GRAPHICS);
-		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("BufferedRenderingRequired", "Warning: This game requires Rendering Mode to be set to Buffered."), 10.0f);
+		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("BufferedRenderingRequired", "Warning: This game requires Rendering Mode to be set to Buffered."), 10.0f, "bufreq");
+	} else {
+		g_OSD.CancelById("bufreq");
 	}
 
 	if (compat.flags().RequireBlockTransfer && g_Config.iSkipGPUReadbackMode != (int)SkipGPUReadbackMode::NO_SKIP && !PSP_CoreParameter().compat.flags().ForceEnableGPUReadback) {
 		auto gr = GetI18NCategory(I18NCat::GRAPHICS);
-		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("BlockTransferRequired", "Warning: This game requires Skip GPU Readbacks be set to No."), 10.0f);
+		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("BlockTransferRequired", "Warning: This game requires Skip GPU Readbacks be set to No."), 10.0f, "blockxfer");
+	} else {
+		g_OSD.CancelById("blockxfer");
 	}
 
 	if (compat.flags().RequireDefaultCPUClock && g_Config.iLockedCPUSpeed != 0) {
 		auto gr = GetI18NCategory(I18NCat::GRAPHICS);
-		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("DefaultCPUClockRequired", "Warning: This game requires the CPU clock to be set to default."), 10.0f);
+		g_OSD.Show(OSDType::MESSAGE_WARNING, gr->T("DefaultCPUClockRequired", "Warning: This game requires the CPU clock to be set to default."), 10.0f, "defaultclock");
+	} else {
+		g_OSD.CancelById("defaultclock");
 	}
 }
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1559,9 +1559,11 @@ bool FramebufferManagerCommon::DrawFramebufferToOutput(const DisplayLayoutConfig
 	constexpr float u0 = 0.0f, u1 = 480.0f / 512.0f;
 	constexpr float v0 = 0.0f, v1 = 1.0f;
 
-	presentation_->UpdateUniforms(textureCache_->VideoIsPlaying());
-	presentation_->SourceTexture(pixelsTex, 512, 272);
-	presentation_->RunPostshaderPasses(config, flags, uvRotation, u0, v0, u1, v1);
+	if (useBufferedRendering_) {
+		presentation_->UpdateUniforms(textureCache_->VideoIsPlaying());
+		presentation_->SourceTexture(pixelsTex, 512, 272);
+		presentation_->RunPostshaderPasses(config, flags, uvRotation, u0, v0, u1, v1);
+	}
 
 	// PresentationCommon sets all kinds of state, we can't rely on anything.
 	gstate_c.Dirty(DIRTY_ALL);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -3023,9 +3023,10 @@ bool FramebufferManagerCommon::GetFramebuffer(u32 fb_address, int fb_stride, GEB
 	}
 
 	if (!useBufferedRendering_) {
-		// Safety check.
-		w = std::min(w, PSP_CoreParameter().pixelWidth);
-		h = std::min(h, PSP_CoreParameter().pixelHeight);
+		// In this mode, we can only screenshot the backbuffer, and we can't resize with a simple blit (well technically we could, but complicated)
+		w = PSP_CoreParameter().pixelWidth;
+		h = PSP_CoreParameter().pixelHeight;
+		buffer.SetIsBackbuffer(true);
 	}
 
 	// TODO: Maybe should handle flipY inside CopyFramebufferToMemorySync somehow?

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1665,6 +1665,8 @@ void FramebufferManagerCommon::PrepareCopyDisplayToOutput(const DisplayLayoutCon
 			}
 		} else {
 			DEBUG_LOG(Log::FrameBuf, "Found no FBO to display! displayFBPtr = %08x", fbaddr);
+			// No framebuffer to display! Clear to black.
+			// TODO: Draw a black rectangle, will be important once we add backgrounds.
 			gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
 			// No framebuffer to display! Clear to black.
 			presentation_->SourceBlank();
@@ -3434,10 +3436,6 @@ void FramebufferManagerCommon::DrawActiveTexture(float x, float y, float w, floa
 void FramebufferManagerCommon::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, RasterChannel channel, const char *tag) {
 	if (!dst->fbo || !src->fbo || !useBufferedRendering_) {
 		// This can happen if they recently switched from non-buffered.
-		if (useBufferedRendering_) {
-			// Just bind the back buffer for rendering, forget about doing anything else as we're in a weird state.
-			draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "BlitFramebuffer");
-		}
 		return;
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -334,7 +334,8 @@ public:
 	void RebindFramebuffer(const char *tag);
 	std::vector<const VirtualFramebuffer *> GetFramebufferList() const;
 
-	void CopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty);
+	void PrepareCopyDisplayToOutput(const DisplayLayoutConfig &config, bool reallyDirty);
+	void CopyDisplayToOutput(const DisplayLayoutConfig &config);
 
 	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, GPUCopyFlag flags, u32 skipDrawReason);
 	void PerformWriteFormattedFromMemory(u32 addr, int size, int width, GEBufferFormat fmt);

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -182,6 +182,9 @@ struct GPUDebugBuffer {
 
 	u32 PixelSize() const;
 
+	void SetIsBackbuffer(bool isBackBuffer) { isBackBuffer_ = isBackBuffer; }
+	bool IsBackBuffer() const { return isBackBuffer_; }
+
 private:
 	bool alloc_ = false;
 	u8 *data_ = nullptr;
@@ -189,6 +192,7 @@ private:
 	u32 height_ = 0;
 	GPUDebugBufferFormat fmt_ = GPU_DBG_FORMAT_INVALID;
 	bool flipped_ = false;
+	bool isBackBuffer_ = false;
 };
 
 struct GPUDebugVertex {

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -898,7 +898,6 @@ void PresentationCommon::CopyToOutput(const DisplayLayoutConfig &config) {
 	int lastWidth = srcWidth_;
 	int lastHeight = srcHeight_;
 
-	draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "FinalBlit");
 	draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 
 	if (!srcFramebuffer_ && !srcTexture_) {

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -124,6 +124,9 @@ public:
 	void DeviceRestore(Draw::DrawContext *draw);
 
 	void UpdateUniforms(bool hasVideo);
+
+	// One of these must be called every frame.
+	void SourceBlank();
 	void SourceTexture(Draw::Texture *texture, int bufferWidth, int bufferHeight);
 	void SourceFramebuffer(Draw::Framebuffer *fb, int bufferWidth, int bufferHeight);
 

--- a/GPU/Common/VertexDecoderHandwritten.cpp
+++ b/GPU/Common/VertexDecoderHandwritten.cpp
@@ -163,7 +163,6 @@ void VtxDec_Tu8_C5551_Ps16(const u8 *srcp, u8 *dstp, int numVerts, const UVScale
 	__m128i lowbits = _mm_set1_epi32(0x00070707);
 
 	// Two vertices at a time, we can share some calculations.
-	// It's OK to accidentally decode an extra vertex.
 	while (count >= 2) {
 		__m128i pos0 = _mm_loadl_epi64((const __m128i *) & src[0].x);
 		__m128i pos1 = _mm_loadl_epi64((const __m128i *) & src[1].x);
@@ -181,7 +180,7 @@ void VtxDec_Tu8_C5551_Ps16(const u8 *srcp, u8 *dstp, int numVerts, const UVScale
 		__m128d uvf = _mm_castps_pd(_mm_add_ps(_mm_mul_ps(_mm_cvtepi32_ps(uv32), uvScale), uvOff));
 		alpha &= col0;
 
-		// Combined RGBA
+		// Combined 5551 -> 8888 RGBA. Nasty.
 		__m128i col = _mm_set1_epi64x(col0);
 		__m128i r = _mm_slli_epi32(_mm_and_si128(col, rmask), 8 - 5);
 		__m128i g = _mm_slli_epi32(_mm_and_si128(col, gmask), 16 - 10);
@@ -224,7 +223,6 @@ void VtxDec_Tu8_C5551_Ps16(const u8 *srcp, u8 *dstp, int numVerts, const UVScale
 	uint32x2_t lowbits = vdup_n_u32(0x00070707);
 
 	// Two vertices at a time, we can share some calculations.
-	// It's OK to accidentally decode an extra vertex.
 	// Doing four vertices at a time might be even better, can share more of the pesky color format conversion.
 	while (count >= 2) {
 		int16x4_t pos0 = vld1_s16(&src[0].x);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -125,6 +125,7 @@ public:
 
 	virtual void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) = 0;
 	virtual void SetCurFramebufferDirty(bool dirty) = 0;
+	virtual void PrepareCopyDisplayToOutput(const DisplayLayoutConfig &config) = 0;
 	virtual void CopyDisplayToOutput(const DisplayLayoutConfig &config) = 0;
 	virtual bool PresentedThisFrame() const = 0;
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -538,10 +538,9 @@ void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
 	shaderManager_->DirtyLastShader();
 
 	// after this, render pass is active.
-	framebufferManager_->CopyDisplayToOutput(config, curFramebufferDirty_);
+	framebufferManager_->PrepareCopyDisplayToOutput(config, curFramebufferDirty_);
+	framebufferManager_->CopyDisplayToOutput(config);
 	curFramebufferDirty_ = false;
-
-	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }
 
 bool GPUCommonHW::PresentedThisFrame() const {

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -530,7 +530,7 @@ void GPUCommonHW::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
 }
 
-void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
+void GPUCommonHW::PrepareCopyDisplayToOutput(const DisplayLayoutConfig &config) {
 	drawEngineCommon_->FlushQueuedDepth();
 	// Flush anything left over.
 	drawEngineCommon_->Flush();
@@ -539,6 +539,9 @@ void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
 
 	// after this, render pass is active.
 	framebufferManager_->PrepareCopyDisplayToOutput(config, curFramebufferDirty_);
+}
+
+void GPUCommonHW::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
 	framebufferManager_->CopyDisplayToOutput(config);
 	curFramebufferDirty_ = false;
 }

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -11,6 +11,7 @@ public:
 
 	// This can fail, and if so no render pass is active.
 	void SetCurFramebufferDirty(bool dirty) override { curFramebufferDirty_ = dirty; }
+	void PrepareCopyDisplayToOutput(const DisplayLayoutConfig &config) override;
 	void CopyDisplayToOutput(const DisplayLayoutConfig &config) override;
 	void DoState(PointerWrap &p) override;
 	void DeviceLost() override;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -624,7 +624,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(const DisplayLayoutConfig &config, 
 		u1 = 1.0f;
 	}
 	if (!hasImage) {
-		draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "CopyToCurrentFboFromDisplayRam");
+		presentation_->SourceBlank();
 		presentation_->NotifyPresent();
 		return;
 	}
@@ -644,13 +644,16 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(const DisplayLayoutConfig &config, 
 
 	presentation_->SourceTexture(fbTex, desc.width, desc.height);
 	presentation_->RunPostshaderPasses(config, outputFlags, config.iInternalScreenRotation, u0, v0, u1, v1);
-	presentation_->CopyToOutput(config);
 }
 
-void SoftGPU::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
+void SoftGPU::PrepareCopyDisplayToOutput(const DisplayLayoutConfig &config) {
 	drawEngine_->transformUnit.Flush(this, "output");
 	// The display always shows 480x272.
 	CopyToCurrentFboFromDisplayRam(config, FB_WIDTH, FB_HEIGHT);
+}
+
+void SoftGPU::CopyDisplayToOutput(const DisplayLayoutConfig &config) {
+	presentation_->CopyToOutput(config);
 	MarkDirty(displayFramebuf_, displayStride_, 272, displayFormat_, SoftGPUVRAMDirty::CLEAR);
 }
 

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -138,6 +138,7 @@ public:
 
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void SetCurFramebufferDirty(bool dirty) override {}
+	void PrepareCopyDisplayToOutput(const DisplayLayoutConfig &config) override;
 	void CopyDisplayToOutput(const DisplayLayoutConfig &config) override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	std::vector<const VirtualFramebuffer *> GetFramebufferList() const override { return std::vector<const VirtualFramebuffer *>(); }

--- a/UI/Background.cpp
+++ b/UI/Background.cpp
@@ -446,7 +446,7 @@ void DrawBackground(UIContext &dc, float alpha, Lin::Vec3 focus) {
 }
 
 uint32_t GetBackgroundColorWithAlpha(const UIContext &dc) {
-	return colorAlpha(colorBlend(dc.GetTheme().backgroundColor, 0, 0.5f), 0.65f);  // 0.65 = 166 = A6
+	return colorAlpha(colorBlend(dc.GetTheme().backgroundColor, 0, 0.5f), 0.72f);  // 0.72 = 183 = B7
 }
 
 enum class BackgroundFillMode {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1567,7 +1567,7 @@ bool EmuScreen::checkPowerDown() {
 
 ScreenRenderRole EmuScreen::renderRole(bool isTop) const {
 	auto CanBeBackground = [&]() -> bool {
-		if (g_Config.bSkipBufferEffects) {
+		if (skipBufferEffects_) {
 			return isTop || (g_Config.bTransparentBackground && ShouldRunBehind());
 		}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -286,7 +286,7 @@ void EmuScreen::ProcessGameBoot(const Path &filename) {
 		g_OSD.Show(OSDType::MESSAGE_WARNING, "Shader cache is disabled (developer)");
 	}
 
-	if (g_Config.bTiltInputEnabled && g_Config.iTiltInputType != 0) {
+	if (g_Config.bTiltInputEnabled && g_Config.iTiltInputType != 0 && System_GetPropertyBool(SYSPROP_HAS_ACCELEROMETER)) {
 		auto co = GetI18NCategory(I18NCat::CONTROLS);
 		auto di = GetI18NCategory(I18NCat::DIALOG);
 		g_OSD.Show(OSDType::MESSAGE_INFO, ApplySafeSubstitutions("%1: %2", co->T("Tilt control"), di->T("Enabled")), "", "I_CONTROLLER", 2.5f, "tilt");

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -70,10 +70,11 @@ public:
 protected:
 	void darken();
 	void focusChanged(ScreenFocusChange focusChange) override;
+	ScreenRenderFlags PreRender() override;
 
 private:
 	void CreateViews() override;
-	ScreenRenderFlags RunEmulation(ScreenRenderMode mode, bool framebufferBound, bool skipBufferEffects);
+	ScreenRenderFlags RunEmulation(bool skipBufferEffects);
 	void OnDevTools(UI::EventParams &params);
 	void OnChat(UI::EventParams &params);
 
@@ -159,6 +160,7 @@ private:
 #endif
 	bool autoLoadFailed_ = false;  // to prevent repeat reloads
 	bool readyToFinishBoot_ = false;
+	bool skipBufferEffects_ = false;  // cached state, fetched once per frame.
 };
 
 bool MustRunBehind();

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -70,7 +70,7 @@ public:
 protected:
 	void darken();
 	void focusChanged(ScreenFocusChange focusChange) override;
-	ScreenRenderFlags PreRender() override;
+	ScreenRenderFlags PreRender(ScreenRenderMode mode) override;
 
 private:
 	void CreateViews() override;
@@ -95,6 +95,8 @@ private:
 
 	void ProcessQueuedVKeys();
 	void ProcessVKey(VirtKey vkey);
+
+	bool ShouldRunEmulation(ScreenRenderMode mode) const;
 
 	UI::Event OnDevMenu;
 	UI::Event OnChatMenu;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -78,6 +78,7 @@
 #include "Core/HLE/sceUsbMic.h"
 #include "Core/HLE/sceUtility.h"
 #include "GPU/Common/PostShader.h"
+#include "GPU/GPU.h"
 
 #if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
 #include "UI/DarwinFileSystemServices.h"
@@ -499,6 +500,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 		if (g_Config.bSkipBufferEffects) {
 			g_Config.bAutoFrameSkip = false;
 		}
+
 		System_PostUIMessage(UIMessage::GPU_RENDER_RESIZED);
 	});
 	skipBufferEffects->SetDisabledPtr(&g_Config.bSoftwareRendering);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -98,12 +98,6 @@ void HandleCommonMessages(UIMessage message, const char *value, ScreenManager *m
 }
 
 ScreenRenderFlags BackgroundScreen::render(ScreenRenderMode mode) {
-	if (mode & ScreenRenderMode::FIRST) {
-		SetupViewport();
-	} else {
-		_dbg_assert_(false);
-	}
-
 	UIContext *uiContext = screenManager()->getUIContext();
 
 	uiContext->PushTransform({ translation_, scale_, alpha_ });

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -11,6 +11,7 @@
 #include "UI/GameInfoCache.h"
 #include "Common/UI/PopupScreens.h"
 #include "Core/Config.h"
+#include "GPU/Common/PresentationCommon.h"
 
 TextWithImage::TextWithImage(ImageID imageID, std::string_view text, UI::LinearLayoutParams *layoutParams) : UI::LinearLayout(ORIENT_HORIZONTAL, layoutParams) {
 	using namespace UI;
@@ -258,4 +259,33 @@ void AddRotationPicker(ScreenManager *screenManager, UI::ViewGroup *parent, bool
 		INFO_LOG(Log::System, "New display rotation: %d", g_Config.iScreenRotation);
 		System_Notify(SystemNotification::ROTATE_UPDATED);
 	});
+}
+
+void GameInfoBGView::Draw(UIContext &dc) {
+	// Should only be called when visible.
+	std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(dc.GetDrawContext(), gamePath_, GameInfoFlags::PIC1);
+	dc.Flush();
+
+	// PIC1 is the loading image, so let's only draw if it's available.
+	if (ginfo->Ready(GameInfoFlags::PIC1) && ginfo->pic1.texture) {
+		Draw::Texture *texture = ginfo->pic1.texture;
+		if (texture) {
+			const DisplayLayoutConfig &config = g_Config.GetDisplayLayoutConfig(g_display.GetDeviceOrientation());
+			// Similar to presentation, we want to put the game PIC1 in the same region of the screen.
+			FRect frame = GetScreenFrame(config.bIgnoreScreenInsets, g_display.pixel_xres, g_display.pixel_yres);
+			FRect rc;
+			CalculateDisplayOutputRect(config, &rc, texture->Width(), texture->Height(), frame, config.iInternalScreenRotation);
+
+			// Need to adjust for DPI here since we're still in the UI coordinate space here, not the pixel coordinate space used for in-game presentation.
+			Bounds bounds(rc.x * g_display.dpi_scale_x, rc.y * g_display.dpi_scale_y, rc.w * g_display.dpi_scale_x, rc.h * g_display.dpi_scale_y);
+
+			dc.GetDrawContext()->BindTexture(0, texture);
+
+			double loadTime = ginfo->pic1.timeLoaded;
+			uint32_t color = alphaMul(color_, ease((time_now_d() - loadTime) * 3));
+			dc.Draw()->DrawTexRect(bounds, 0, 0, 1, 1, color);
+			dc.Flush();
+			dc.RebindTexture();
+		}
+	}
 }

--- a/UI/MiscViews.h
+++ b/UI/MiscViews.h
@@ -78,4 +78,17 @@ private:
 	float scale_ = 1.0f;
 };
 
+class GameInfoBGView : public UI::InertView {
+public:
+	GameInfoBGView(const Path &gamePath, UI::LayoutParams *layoutParams) : InertView(layoutParams), gamePath_(gamePath) {}
+
+	void Draw(UIContext &dc) override;
+	std::string DescribeText() const override { return ""; }
+	void SetColor(uint32_t c) { color_ = c; }
+
+protected:
+	Path gamePath_;
+	uint32_t color_ = 0xFFC0C0C0;
+};
+
 void AddRotationPicker(ScreenManager *screenManager, UI::ViewGroup *parent, bool text);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1151,7 +1151,7 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 
 	g_screenManager->getUIContext()->SetTintSaturation(g_Config.fUITint, g_Config.fUISaturation);
 
-	// All actual rendering happen in here.
+	// All actual rendering (and also emulation) happens in here.
 	ScreenRenderFlags renderFlags = g_screenManager->render();
 	if (g_screenManager->getUIContext()->Text()) {
 		g_screenManager->getUIContext()->Text()->OncePerFrame();

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -266,10 +266,11 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 	}
 
 	if (draw) {
-		draw->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Headless");
+		draw->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Backbuffer");
 		// Vulkan may get angry if we don't do a final present.
 		if (gpu) {
 			gpu->SetCurFramebufferDirty(true);
+			gpu->PrepareCopyDisplayToOutput(g_Config.GetDisplayLayoutConfig(DeviceOrientation::Landscape));
 			gpu->CopyDisplayToOutput(g_Config.GetDisplayLayoutConfig(DeviceOrientation::Landscape));
 		}
 


### PR DESCRIPTION
Followup to #21218 

Reduces the number of wacky edge cases by a lot, no more chance to accidentally not bind the backbuffer in a frame (which was bad).

~~Needs more testing before merge.~~

Bugs found:

- [x] Need to fix screenshots in skip buffer mode
- [x] Check that switching skip buffer mode goes smoothly in-game
