### PR TITLE
Adding StartupWMClass

### DIFF
--- a/SDL/PPSSPPSDL.desktop
+++ b/SDL/PPSSPPSDL.desktop
@@ -6,3 +6,4 @@ Type=Application
 Keywords=Sony;PlayStation;Portable;PSP;handheld;console;
 Categories=Game;Emulator;
 MimeType=application/x-cd-image;application/x-iso9660-image;application/x-compressed-iso;application/zip;
+StartupWMClass=org.ppsspp.PPSSPP


### PR DESCRIPTION
Yo! I was testing the Snap version on KDE and I ran into this problem:

<img width="55" height="168" alt="Captura de imagem_20260209_183759" src="https://github.com/user-attachments/assets/10479a74-fc05-4a2f-b89d-cef6c6ea1727" />


Adding StartupWMClass is to avoid this kind of problem.