### PR TITLE
Fix crashes in the ImGeDebugger 

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2472,6 +2472,10 @@ int sceKernelWakeupThread(SceUID uid) {
 			return hleLogVerbose(Log::sceKernel, 0, "woke thread at %i", t->nt.wakeupCount);
 		}
 	} else {
+		if (uid == (SceUID)-1) {
+			// Common error (for example in Power Stone). Let's log at debug level.
+			return hleLogDebug(Log::sceKernel, error, "bad thread id");
+		}
 		return hleLogError(Log::sceKernel, error, "bad thread id");
 	}
 }

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -332,11 +332,12 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	}
 
 	std::string badFilenames;
+	constexpr int MaxBadFilenameCount = 5;  // How many to list in the popup
 
 	if (ini.HasSection("hashes")) {
 		const Section *hashesSection = ini.GetOrCreateSection("hashes");
 		// Format: hashname = filename.png
-		bool checkFilenames = saveEnabled_ && !g_Config.bIgnoreTextureFilenames && !vfsIsZip_;
+		const bool checkFilenames = saveEnabled_ && !g_Config.bIgnoreTextureFilenames && !vfsIsZip_;
 
 		for (const auto &line : hashesSection->Lines()) {
 			if (line.Key().empty())
@@ -362,9 +363,9 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 #endif
 					if (bad) {
 						badFileNameCount++;
-						if (badFileNameCount == 10) {
+						if (badFileNameCount == MaxBadFilenameCount) {
 							badFilenames.append("...");
-						} else if (badFileNameCount < 10) {
+						} else if (badFileNameCount < MaxBadFilenameCount) {
 							badFilenames.append(v);
 							badFilenames.push_back('\n');
 						}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1670,8 +1670,6 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 	// Reset the viewport. Needed in case Cardboard or something similar was enabled.
 	draw->SetViewport(viewport);
 
-	runImDebugger();
-
 	Draw::BackendState state = draw->GetCurrentBackendState();
 
 	if (!(mode & ScreenRenderMode::TOP)) {
@@ -1814,6 +1812,8 @@ ScreenRenderFlags EmuScreen::RunEmulation(bool skipBufferEffects) {
 			Core_Break(BreakReason::FrameAdvance, 0);
 		}
 	}
+
+	runImDebugger();
 
 	return flags;
 }

--- a/UI/ImDebugger/ImGe.h
+++ b/UI/ImDebugger/ImGe.h
@@ -100,9 +100,12 @@ struct ImGeReadbackViewer : public PixelLookup {
 	bool FormatValueAt(char *buf, size_t bufSize, int x, int y) const override;
 	void DeviceLost();
 
-	// TODO: This is unsafe! If you load state for example with the debugger open...
-	// We need to re-fetch this each frame from the parameters.
-	VirtualFramebuffer *vfb = nullptr;
+	VirtualFramebuffer *GetVFB(FramebufferManagerCommon *fbMan) const;
+
+	// We need to re-fetch the vfb each frame from these parameters.
+	u32 fbAddr = 0;
+	u32 fbStride = 0;
+	GEBufferFormat fbFormat = GE_FORMAT_INVALID;
 
 	// This specifies what to show
 	Draw::Aspect aspect;


### PR DESCRIPTION
Must call RunImDebugger before the final render pass for readbacks to work.

Also fixes a long standing ImGeDebugger bug causing crashes whenever framebuffers were recreated (screen rotation, some kinds of resize etc).