### PR TITLE
Adhoc relay server: Auto/Yes/No instead of checkbox

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -71,7 +71,7 @@ static const std::string_view logSectionName = "LogDebug";
 static const std::string_view logSectionName = "Log";
 #endif
 
-static const std::vector<std::string_view> defaultProAdhocServerList = {
+const std::vector<std::string_view> defaultProAdhocServerList = {
 	"socom.cc", "psp.gameplayer.club",  // TODO: Add some saved recent history too?
 };
 
@@ -1033,7 +1033,7 @@ static const ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", SETTING(g_Config, bEnableWlan), false, CfgFlag::PER_GAME),
 	ConfigSetting("EnableAdhocServer", SETTING(g_Config, bEnableAdhocServer), false, CfgFlag::PER_GAME),
 	ConfigSetting("proAdhocServer", SETTING(g_Config, sProAdhocServer), "socom.cc", CfgFlag::PER_GAME),
-	ConfigSetting("UseServerRelay", SETTING(g_Config, bUseServerRelay), false, CfgFlag::PER_GAME),
+	ConfigSetting("AdhocServerRelayMode", SETTING(g_Config, iAdhocServerRelayMode), (int)AdhocServerRelayMode::Auto, CfgFlag::PER_GAME),
 	ConfigSetting("proAdhocServerList", SETTING(g_Config, proAdhocServerList), &defaultProAdhocServerList, CfgFlag::DEFAULT),
 	ConfigSetting("PortOffset", SETTING(g_Config, iPortOffset), 10000, CfgFlag::PER_GAME),
 	ConfigSetting("PrimaryDNSServer", SETTING(g_Config, sInfrastructureDNSServer), "67.222.156.250", CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -552,7 +552,7 @@ public:
 	// Networking
 	bool bEnableAdhocServer;
 	std::string sProAdhocServer;
-	bool bUseServerRelay;
+	int iAdhocServerRelayMode;
 	std::vector<std::string> proAdhocServerList;
 	std::string sInfrastructureDNSServer;
 	std::string sInfrastructureUsername;  // Username used for Infrastructure play. Different restrictions.
@@ -764,4 +764,6 @@ std::string CreateRandMAC();
 // TODO: Find a better place for this.
 extern http::RequestManager g_DownloadManager;
 extern Config g_Config;
+
+extern const std::vector<std::string_view> defaultProAdhocServerList;
 

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -81,6 +81,12 @@ enum class CPUCore {
 	JIT_IR = 3,
 };
 
+enum class AdhocServerRelayMode {
+	Auto = 0,
+	AlwaysOn = 1,
+	AlwaysOff = 2,
+};
+
 enum {
 	ROTATION_AUTO = 0,
 	ROTATION_LOCKED_HORIZONTAL = 1,

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1648,7 +1648,25 @@ u32 sceNetAdhocInit() {
 		// Since we are deleting GameMode Master here, we should probably need to make sure GameMode resources all cleared too.
 		deleteAllGMB();
 
-		serverHasRelay = g_Config.bUseServerRelay;
+		// If a server is in our default list, we know it supports relay.
+		switch ((AdhocServerRelayMode)g_Config.iAdhocServerRelayMode) {
+		case AdhocServerRelayMode::Auto:
+			serverHasRelay = false;
+			// If it's in our default server list, we know it supports relay.
+			for (auto serverName : defaultProAdhocServerList) {
+				if (serverName == g_Config.sProAdhocServer) {
+					serverHasRelay = true;
+					break;
+				}
+			}
+			break;
+		case AdhocServerRelayMode::AlwaysOn:
+			serverHasRelay = true;
+			break;
+		default:
+			serverHasRelay = false;
+			break;
+		}
 
 		if (serverHasRelay) {
 			aemu_post_office_init();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1050,8 +1050,8 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 
 	networkingSettings->Add(new ItemHeader(n->T("Ad Hoc multiplayer")));
 
-	static const char *relayModes[] = {"Auto", "On", "Off"};
-	PopupMultiChoice *relayModePopup = networkingSettings->Add(new PopupMultiChoice(&g_Config.iAdhocServerRelayMode, n->T("Try to use server-provided packet relay"), relayModes, 0, ARRAY_SIZE(relayModes), I18NCat::NETWORKING, screenManager()));
+	static const char *relayModes[] = {"Auto", "Yes", "No"};
+	PopupMultiChoice *relayModePopup = networkingSettings->Add(new PopupMultiChoice(&g_Config.iAdhocServerRelayMode, n->T("Try to use server-provided packet relay"), relayModes, 0, ARRAY_SIZE(relayModes), I18NCat::DIALOG, screenManager()));
 	relayModePopup->SetEnabled(!PSP_IsInited());
 	networkingSettings->Add(new SettingHint(n->T("PacketRelayHint", "Available on servers that provide 'aemu_postoffice' packet relay, like socom.cc. Disable this for LAN or VPN play. Can be more reliable, but sometimes slower.")));
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1049,7 +1049,10 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 	}
 
 	networkingSettings->Add(new ItemHeader(n->T("Ad Hoc multiplayer")));
-	networkingSettings->Add(new CheckBox(&g_Config.bUseServerRelay, n->T("Try to use server-provided packet relay")))->SetEnabled(!PSP_IsInited());
+
+	static const char *relayModes[] = {"Auto", "On", "Off"};
+	PopupMultiChoice *relayModePopup = networkingSettings->Add(new PopupMultiChoice(&g_Config.iAdhocServerRelayMode, n->T("Try to use server-provided packet relay"), relayModes, 0, ARRAY_SIZE(relayModes), I18NCat::NETWORKING, screenManager()));
+	relayModePopup->SetEnabled(!PSP_IsInited());
 	networkingSettings->Add(new SettingHint(n->T("PacketRelayHint", "Available on servers that provide 'aemu_postoffice' packet relay, like socom.cc. Disable this for LAN or VPN play. Can be more reliable, but sometimes slower.")));
 
 	networkingSettings->Add(new ItemHeader(n->T("Ad Hoc server")));

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -396,6 +396,7 @@ VFPU = VFPU
 Active = نشط
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = تلقائي
 Back = ‎رجوع
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -392,6 +392,7 @@ VFPU = VFPU
 Active = Etkindir
 Are you sure you want to delete the file? = Faylı silmək istədiyinizdən əminsiz?
 Are you sure you want to exit? = Çıxmaq istədiyinizdən əminsiz?
+Auto = Özbaşına
 Back = Geri dön
 Bottom Center = Alt orta
 Bottom Left = Alt sol

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Аўта
 Back = Назад
 Bottom Center = Унізе па цэнтры
 Bottom Left = Унізе злева

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Активен
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Назад
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Actiu
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Enrere
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Zpět
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Tilbage
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -380,6 +380,7 @@ VFPU = VFPU
 Active = Aktiv
 Are you sure you want to delete the file? = Willst du die Datei wirklich löschen?
 Are you sure you want to exit? = Willst du wirklich beenden?
+Auto = Autom.
 Back = Zurück
 Bottom Center = Mitte unten
 Bottom Left = Links unten

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Poleboko'
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -412,6 +412,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Back
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -389,6 +389,7 @@ VFPU = VFPU
 Active = Activo
 Are you sure you want to delete the file? = ¿Estás seguro de que quieres eliminar el archivo?
 Are you sure you want to exit? = ¿Estás seguro de que quieres salir?
+Auto = Automático
 Back = Atrás
 Bottom Center = Inferior centrado
 Bottom Left = Inferior izquierda

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Activo
 Are you sure you want to delete the file? = ¿Estás seguro de que quieres borrar el archivo?
 Are you sure you want to exit? = ¿Estás seguro de que quieres salir?
+Auto = Auto
 Back = Atrás
 Bottom Center = Abajo centrado
 Bottom Left = Abajo izquierda

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = خودکار
 Back = ‎بازگشت
 Bottom Center = پایین وسط
 Bottom Left = پایین چپ

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Aktiivinen
 Are you sure you want to delete the file? = Haluatko varmasti poistaa tiedoston?
 Are you sure you want to exit? = Haluatko varmasti poistua?
+Auto = Automaattinen
 Back = Takaisin
 Bottom Center = Alhaalla keskellä
 Bottom Left = Alhaalla vasemmalla

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Actif
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Automatique
 Back = Retour
 Bottom Center = En bas au centre
 Bottom Left = En bas à gauche

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Atrás
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = ΕΝΕΡΓΟ
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = ΠΙΣΩ
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = <<
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = <<
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Aktivno
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Nazad
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Aktív
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Vissza
 Bottom Center = Alul középen
 Bottom Left = Alul bal old.

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Aktif
 Are you sure you want to delete the file? = Apakah Anda yakin untuk menghapus file?
 Are you sure you want to exit? = Apakah Anda yakin untuk keluar?
+Auto = Otomatis
 Back = Kembali
 Bottom Center = Tengah bawah
 Bottom Left = Kiri bawah

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Attiva
 Are you sure you want to delete the file? = Vuoi davvero eliminare il file?
 Are you sure you want to exit? = Vuoi davvero uscire?
+Auto = Auto
 Back = Indietro
 Bottom Center = In basso al centro
 Bottom Left = In basso a sinistra

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = アクティブ
 Are you sure you want to delete the file? = ファイルを削除してもよろしいですか？
 Are you sure you want to exit? = 本当に終了してもよろしいですか？
+Auto = 自動
 Back = 戻る
 Bottom Center = 下中央
 Bottom Left = 左下

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Bali
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = 활성화
 Are you sure you want to delete the file? = 파일을 삭제할까요?
 Are you sure you want to exit? = 정말 종료할까요?
+Auto = 자동
 Back = 뒤로가기
 Bottom Center = 하단 중앙
 Bottom Left = 하단 왼쪽

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -402,6 +402,7 @@ VFPU = VFPU
 Active = چالاک
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = گەڕانەوە
 Bottom Center = خوارەوە ناوەڕاست
 Bottom Left = خوارەوە چەپ

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = ຍ້ອນກັບ
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Atgal
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Balik
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Terug
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Aktiv
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Er du sikker på at du vil avslutte?
+Auto = Auto
 Back = Tilbake
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -387,6 +387,7 @@ VFPU = VFPU
 Active = Aktywny
 Are you sure you want to delete the file? = Na pewno chcesz usunąć ten plik?
 Are you sure you want to exit? = Na pewno chcesz wyjść?
+Auto = Automatycznie
 Back = Powrót
 Bottom Center = Dolny środek
 Bottom Left = Dolne lewo

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -412,6 +412,7 @@ VFPU = VFPU
 Active = Ativo
 Are you sure you want to delete the file? = Você tem certeza que você quer apagar o arquivo?
 Are you sure you want to exit? = Você tem certeza que você quer sair?
+Auto = Auto
 Back = Voltar
 Bottom Center = No centro do rodapé
 Bottom Left = A esquerda do rodapé

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -412,6 +412,7 @@ VFPU = VFPU
 Active = Ativo
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Automático
 Back = Voltar
 Bottom Center = Centro do rodapé
 Bottom Left = A esquerda do rodapé

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -389,6 +389,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Înapoi
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Активно
 Are you sure you want to delete the file? = Вы уверены, что хотите удалить файл?
 Are you sure you want to exit? = Вы уверены, что хотите выйти?
+Auto = Авто
 Back = Назад
 Bottom Center = Внизу в центре
 Bottom Left = Внизу слева

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Aktiv
 Are you sure you want to delete the file? = Är du säker på att du vill ta bort filen?
 Are you sure you want to exit? = Är du säker på att du vill avsluta?
+Auto = Automatisk
 Back = Tillbaka
 Bottom Center = Underkant centrerad
 Bottom Left = Underkant vänster

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -389,6 +389,7 @@ VFPU = VFPU
 Active = Active
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Awto
 Back = Bumalik
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -404,6 +404,7 @@ VFPU = VFPU
 Active = เปิดการทำงาน
 Are you sure you want to delete the file? = คุณแน่ใจนะ ว่าต้องการลบไฟล์นี้ทิ้ง?
 Are you sure you want to exit? = คุณแน่ใจนะว่าต้องการออกเกม?
+Auto = อัตโนมัติ
 Back = ย้อนกลับ
 Bottom Center = มุมล่างกลางจอ
 Bottom Left = มุมล่างซ้ายจอ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -390,6 +390,7 @@ VFPU = VFPU
 Active = Etkin
 Are you sure you want to delete the file? = Dosyayı silmek istediğinizden emin misiniz?
 Are you sure you want to exit? = Çıkmak istediğinden emin misin?
+Auto = Otomatik
 Back = Geri
 Bottom Center = Orta Alt
 Bottom Left = Sol Alt

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Активно
 Are you sure you want to delete the file? = Ви впевнені, що хочете видалити файл?
 Are you sure you want to exit? = Ви впевнені, що хочете вийти?
+Auto = Авто
 Back = Назад
 Bottom Center = Знизу центрально
 Bottom Left = Знизу ліворуч

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = Hoạt động
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
+Auto = Auto
 Back = Trở lại
 Bottom Center = Bottom center
 Bottom Left = Bottom left

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = 激活
 Are you sure you want to delete the file? = 确定要删除该文件吗?
 Are you sure you want to exit? = 确定要退出吗?
+Auto = 自动
 Back = 返回
 Bottom Center = 正下方
 Bottom Left = 左下方

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -388,6 +388,7 @@ VFPU = VFPU
 Active = 啟用
 Are you sure you want to delete the file? = 確定要刪除該檔案嗎？
 Are you sure you want to exit? = 確定要退出嗎？
+Auto = 自動
 Back = 返回
 Bottom Center = 正下
 Bottom Left = 左下


### PR DESCRIPTION
This is my proposal to implement #21134

Replaces the checkbox with Auto / Yes / No, where Auto means that all the servers we have in our default config list also are assumed to support server relay, so it's auto-enabled for those but not for others.

The current list is set in Config.cpp like this:

```c++
const std::vector<std::string_view> defaultProAdhocServerList = {
	"socom.cc", "psp.gameplayer.club",
};
```

Any additions?

* Fixes #21134

