### PR TITLE
Control mapper refactor, allow unpausing using analog triggers if mapped

### DIFF
--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -18,6 +18,7 @@ using KeyMap::MultiInputMapping;
 const float AXIS_BIND_THRESHOLD = 0.75f;
 const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
 
+ControlMapper g_controlMapper;
 
 // We reduce the threshold of some axes when another axis on the same stick is active.
 // This makes it easier to hit diagonals if you bind an analog stick to four face buttons or D-Pad.

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -112,3 +112,5 @@ private:
 
 void ConvertAnalogStick(float x, float y, float *outX, float *outY);
 float GetDeviceAxisThreshold(int device, const InputMapping &mapping);
+
+extern ControlMapper g_controlMapper;

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -8,6 +8,18 @@
 #include <mutex>
 
 struct DisplayLayoutConfig;
+
+// Pure interface.
+class ControlListener {
+public:
+	virtual ~ControlListener() = default;
+	virtual void OnVKey(VirtKey vkey, bool down) {}
+	virtual void OnVKeyAnalog(VirtKey vkey, float value) {}
+	virtual void UpdatePSPButtons(uint32_t buttonMask, uint32_t changedMask) {}
+	virtual void SetPSPAnalog(int rotation, int stick, float x, float y) {}
+	virtual void SetRawAnalog(int stick, float x, float y) {}
+};
+
 // Utilities for mapping input events to PSP inputs and virtual keys.
 // Main use is of course from EmuScreen.cpp, but also useful from control settings etc.
 class ControlMapper {
@@ -21,12 +33,9 @@ public:
 
 	// Required callbacks.
 	// TODO: These are so many now that a virtual interface might be more appropriate..
-	void SetCallbacks(
-		std::function<void(VirtKey, bool)> onVKey,
-		std::function<void(VirtKey, float)> onVKeyAnalog,
-		std::function<void(uint32_t, uint32_t)> updatePSPButtons,
-		std::function<void(int, int, float, float)> setPSPAnalog,
-		std::function<void(int, float, float)> setRawAnalog);
+	void SetListener(ControlListener *listener) {
+		listener_ = listener;
+	}
 
 	// Inject raw PSP key input directly, such as from touch screen controls.
 	// Combined with the mapped input. Unlike __Ctrl APIs, this supports
@@ -96,11 +105,7 @@ private:
 	std::map<InputMapping, InputSample> curInput_;
 
 	// Callbacks
-	std::function<void(VirtKey, bool)> onVKey_;
-	std::function<void(VirtKey, float)> onVKeyAnalog_;
-	std::function<void(uint32_t, uint32_t)> updatePSPButtons_;
-	std::function<void(int, int, float, float)> setPSPAnalog_;
-	std::function<void(int, float, float)> setRawAnalog_;
+	ControlListener *listener_ = nullptr;
 };
 
 void ConvertAnalogStick(float x, float y, float *outX, float *outY);

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <cstring>
 #include <mutex>
+#include <vector>
 
 struct DisplayLayoutConfig;
 
@@ -33,9 +34,10 @@ public:
 
 	// Required callbacks.
 	// TODO: These are so many now that a virtual interface might be more appropriate..
-	void SetListener(ControlListener *listener) {
-		listener_ = listener;
+	void AddListener(ControlListener *listener) {
+		listeners_.push_back(listener);
 	}
+	void RemoveListener(ControlListener *listener);
 
 	// Inject raw PSP key input directly, such as from touch screen controls.
 	// Combined with the mapped input. Unlike __Ctrl APIs, this supports
@@ -105,7 +107,7 @@ private:
 	std::map<InputMapping, InputSample> curInput_;
 
 	// Callbacks
-	ControlListener *listener_ = nullptr;
+	std::vector<ControlListener *> listeners_;
 };
 
 void ConvertAnalogStick(float x, float y, float *outX, float *outY);

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -480,11 +480,11 @@ void KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 }
 
 AnalogCalibrationScreen::AnalogCalibrationScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath, TwoPaneFlags::SettingsCanScroll) {
-	mapper_.AddListener(this);
+	g_controlMapper.AddListener(this);
 }
 
 AnalogCalibrationScreen::~AnalogCalibrationScreen() {
-	mapper_.RemoveListener(this);
+	g_controlMapper.RemoveListener(this);
 }
 
 void AnalogCalibrationScreen::SetPSPAnalog(int rotation, int stick, float x, float y) {
@@ -498,7 +498,7 @@ void AnalogCalibrationScreen::SetRawAnalog(int stick, float x, float y) {
 }
 
 void AnalogCalibrationScreen::update() {
-	mapper_.Update(g_Config.GetDisplayLayoutConfig(GetDeviceOrientation()), time_now_d());
+	g_controlMapper.Update(g_Config.GetDisplayLayoutConfig(GetDeviceOrientation()), time_now_d());
 	// We ignore the secondary stick for now and just use the two views
 	// for raw and psp input.
 	if (stickView_[0]) {
@@ -515,7 +515,7 @@ bool AnalogCalibrationScreen::key(const KeyInput &key) {
 
 	// Allow testing auto-rotation. If it collides with UI keys, too bad.
 	bool pauseTrigger = false;
-	mapper_.Key(key, &pauseTrigger);
+	g_controlMapper.Key(key, &pauseTrigger);
 
 	if (UI::IsEscapeKey(key)) {
 		TriggerFinish(DR_BACK);
@@ -529,7 +529,7 @@ void AnalogCalibrationScreen::axis(const AxisInput &axis) {
 	// UIScreen::axis(axis);
 
 	// Instead we just send the input directly to the mapper, that we'll visualize.
-	mapper_.Axis(&axis, 1);
+	g_controlMapper.Axis(&axis, 1);
 }
 
 std::string_view AnalogCalibrationScreen::GetTitle() const {

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -480,18 +480,21 @@ void KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 }
 
 AnalogCalibrationScreen::AnalogCalibrationScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath, TwoPaneFlags::SettingsCanScroll) {
-	mapper_.SetCallbacks(
-		[](int vkey, bool down) {},
-		[](int vkey, float analogValue) {},
-		[&](uint32_t bitsToSet, uint32_t bitsToClear) {},
-		[&](int iInternalRotation, int stick, float x, float y) {
-			analogX_[stick] = x;
-			analogY_[stick] = y;
-		},
-		[&](int stick, float x, float y) {
-			rawX_[stick] = x;
-			rawY_[stick] = y;
-		});
+	mapper_.SetListener(this);
+}
+
+AnalogCalibrationScreen::~AnalogCalibrationScreen() {
+	mapper_.SetListener(nullptr);
+}
+
+void AnalogCalibrationScreen::SetPSPAnalog(int rotation, int stick, float x, float y) {
+	analogX_[stick] = x;
+	analogY_[stick] = y;
+}
+
+void AnalogCalibrationScreen::SetRawAnalog(int stick, float x, float y) {
+	rawX_[stick] = x;
+	rawY_[stick] = y;
 }
 
 void AnalogCalibrationScreen::update() {

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -480,11 +480,11 @@ void KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 }
 
 AnalogCalibrationScreen::AnalogCalibrationScreen(const Path &gamePath) : UITwoPaneBaseDialogScreen(gamePath, TwoPaneFlags::SettingsCanScroll) {
-	mapper_.SetListener(this);
+	mapper_.AddListener(this);
 }
 
 AnalogCalibrationScreen::~AnalogCalibrationScreen() {
-	mapper_.SetListener(nullptr);
+	mapper_.RemoveListener(this);
 }
 
 void AnalogCalibrationScreen::SetPSPAnalog(int rotation, int stick, float x, float y) {

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -125,9 +125,10 @@ private:
 
 class JoystickHistoryView;
 
-class AnalogCalibrationScreen : public UITwoPaneBaseDialogScreen {
+class AnalogCalibrationScreen : public UITwoPaneBaseDialogScreen, protected ControlListener {
 public:
 	AnalogCalibrationScreen(const Path &gamePath);
+	~AnalogCalibrationScreen();
 
 	bool key(const KeyInput &key) override;
 	void axis(const AxisInput &axis) override;
@@ -139,6 +140,9 @@ public:
 protected:
 	void CreateSettingsViews(UI::ViewGroup *parent) override;
 	void CreateContentViews(UI::ViewGroup *parent) override;
+
+	void SetPSPAnalog(int rotation, int stick, float x, float y) override;
+	void SetRawAnalog(int stick, float x, float y) override;
 
 	std::string_view GetTitle() const override;
 private:

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -148,8 +148,6 @@ protected:
 private:
 	void OnResetToDefaults(UI::EventParams &e);
 
-	ControlMapper mapper_;
-
 	float analogX_[2]{};
 	float analogY_[2]{};
 	float rawX_[2]{};

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -162,7 +162,7 @@ void EmuScreen::SetPSPAnalog(int iInternalScreenRotation, int stick, float x, fl
 EmuScreen::EmuScreen(const Path &filename)
 	: gamePath_(filename) {
 	saveStateSlot_ = SaveState::GetCurrentSlot();
-	controlMapper_.SetListener(this);
+	controlMapper_.AddListener(this);
 
 	_dbg_assert_(coreState == CORE_POWERDOWN);
 
@@ -446,7 +446,7 @@ void EmuScreen::bootComplete() {
 }
 
 EmuScreen::~EmuScreen() {
-	controlMapper_.SetListener(nullptr);
+	controlMapper_.RemoveListener(this);
 
 	if (imguiInited_) {
 		ImGui_ImplThin3d_Shutdown();

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -36,7 +36,7 @@ struct AxisInput;
 class AsyncImageFileView;
 class ChatMenu;
 
-class EmuScreen : public UIScreen {
+class EmuScreen : public UIScreen, public ControlListener {
 public:
 	EmuScreen(const Path &filename);
 	~EmuScreen();
@@ -72,6 +72,13 @@ protected:
 	void focusChanged(ScreenFocusChange focusChange) override;
 	ScreenRenderFlags PreRender(ScreenRenderMode mode) override;
 
+	// ControlListener implementations
+	void OnVKey(VirtKey virtualKeyCode, bool down);
+	void OnVKeyAnalog(VirtKey virtualKeyCode, float value);
+	void UpdatePSPButtons(uint32_t buttonMask, uint32_t changedMask) override;
+	void SetPSPAnalog(int rotation, int stick, float x, float y);
+	void SetRawAnalog(int deviceId, float x, float y) {}
+
 private:
 	void CreateViews() override;
 	ScreenRenderFlags RunEmulation(bool skipBufferEffects);
@@ -87,8 +94,6 @@ private:
 	void runImDebugger();
 	void renderImDebugger();
 
-	void onVKey(VirtKey virtualKeyCode, bool down);
-	void onVKeyAnalog(VirtKey virtualKeyCode, float value);
 
 	void AutoLoadSaveState();
 	bool checkPowerDown();

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -141,8 +141,6 @@ private:
 
 	std::string extraAssertInfoStr_;
 
-	ControlMapper controlMapper_;
-
 	std::unique_ptr<ImDebugger> imDebugger_ = nullptr;
 	ImCommand imCmd_{};  // needed to buffer commands in case imgui wasn't created yet.
 

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -166,6 +166,8 @@ private:
 	bool autoLoadFailed_ = false;  // to prevent repeat reloads
 	bool readyToFinishBoot_ = false;
 	bool skipBufferEffects_ = false;  // cached state, fetched once per frame.
+
+	bool isOnTop_ = true;
 };
 
 bool MustRunBehind();

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1432,7 +1432,7 @@ void MainScreen::CreateViews() {
 #if !defined(MOBILE_DEVICE)
 		auto gr = GetI18NCategory(I18NCat::GRAPHICS);
 		ImageID icon(g_Config.bFullScreen ? "I_RESTORE" : "I_FULLSCREEN");
-		fullscreenButton_ = logo->Add(new Button(gr->T("FullScreen", "Full Screen"), icon, new AnchorLayoutParams(48, 48, NONE, 0, 0, NONE, Centering::None)));
+		fullscreenButton_ = logo->Add(new Button("", icon, new AnchorLayoutParams(48, 48, NONE, 0, 0, NONE, Centering::None)));
 		fullscreenButton_->SetIgnoreText(true);
 		fullscreenButton_->OnClick.Add([this](UI::EventParams &e) {
 			if (fullscreenButton_) {

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -23,17 +23,17 @@
 #include "Common/File/Path.h"
 #include "Common/UI/UIScreen.h"
 #include "Common/UI/ViewGroup.h"
+#include "Core/ControlMapper.h"
 #include "UI/BaseScreens.h"
 #include "UI/Screen.h"
 #include "UI/GameInfoCache.h"
 
-class GamePauseScreen : public UIBaseDialogScreen {
+class GamePauseScreen : public UIBaseDialogScreen, protected ControlListener {
 public:
 	GamePauseScreen(const Path &filename, bool bootPending);
 	~GamePauseScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult dr) override;
-	bool key(const KeyInput &key) override;
 
 	const char *tag() const override { return "GamePause"; }
 
@@ -41,6 +41,12 @@ protected:
 	void CreateViews() override;
 	void update() override;
 	UI::Margins RootMargins() const override;
+
+	// For processing of certain mapped keys.
+	bool UnsyncKey(const KeyInput &key) override;
+	void UnsyncAxis(const AxisInput *axes, size_t count) override;
+
+	void OnVKey(VirtKey virtualKeyCode, bool down);
 
 private:
 	void CreateSavestateControls(UI::LinearLayout *viewGroup);
@@ -77,6 +83,7 @@ private:
 	bool bootPending_ = false;
 
 	std::string saveStatePrefix_;
+	double createdTime_ = 0.0;
 };
 
 std::string GetConfirmExitMessage();


### PR DESCRIPTION
- Fixes #20852

This is also a first step towards unifying the input mapping between hardcoded desktop mappings (F10 etc) and the in-game mapper. Switches to a global control mapper instead of having it owned by EmuScreen.
