### PR TITLE
Fix Driver 76 not creating adhoc sockets

### DIFF
--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -240,3 +240,4 @@ void Register_ModuleMgrForKernel();
 
 // Expose for use by KUBridge.
 u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr);
+u32 sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, u32 optionAddr);


### PR DESCRIPTION
Driver 76 uses `sceKernelGetModuleIdList` to get a module list after calling `sceUtilityLoadNetModule`, then go module by module with `sceKernelQueryModuleInfo` to check if at least `pspnet_adhoc.prx` was loaded.

Load modules during `sceUtilityLoadNetModule`, expand success lying modules to have real names, add adhoc modules to the success lying list, list lied modules during `sceKernelGetModuleIdList`.