### PR TITLE
iOS fixes

### DIFF
--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -212,6 +212,7 @@ Name=MMPX (2x)
 Author=Morgan McGuire and Mara Gagiu
 Compute=tex_mmpx.csh
 Scale=2
+VendorBlacklist=Apple
 [RedBlue]
 Type=StereoToMono
 Name=Red/Blue glasses (anaglyph)

--- a/copysym.sh
+++ b/copysym.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # === CONFIGURATION ===
 
 APP_NAME="PPSSPP"  # Name of your app bundle (no .app extension)
-DSYM_PATH="build-ios/Release-iphoneos/${APP_NAME}.app.dSYM"
+DSYM_PATH="build-ios/RelWithDebInfo-iphoneos/${APP_NAME}.app.dSYM"
 
 # === Find latest .xcarchive ===
 

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -113,6 +113,10 @@ __attribute__((used)) static Class _forceLinkSceneDelegate = [SceneDelegate clas
 		return UIInterfaceOrientationMaskLandscapeRight;
 	case ROTATION_LOCKED_VERTICAL:
 	case ROTATION_LOCKED_VERTICAL180:
+		if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+			// iPad supports both portrait orientations, so allow them.
+			return UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+		}
 		// We do not support reverse portrait on iOS.
 		return UIInterfaceOrientationMaskPortrait;
 	case ROTATION_LOCKED_HORIZONTAL180:

--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -65,13 +65,8 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
-	<key>UILaunchScreen</key>
-	<dict>
-		<key>UIColorName</key>
-		<string>black</string>
-		<key>UIImageName</key>
-		<string>LaunchIcon</string>
-	</dict>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UILaunchImageFile</key>
 	<string>Default.png</string>
 	<key>UIFileSharingEnabled</key>

--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -63,7 +63,15 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>black</string>
+		<key>UIImageName</key>
+		<string>LaunchIcon</string>
+	</dict>
 	<key>UILaunchImageFile</key>
 	<string>Default.png</string>
 	<key>UIFileSharingEnabled</key>

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,5 +1,8 @@
 Updating with a self-built MoltenVK
 ===================================
+
+Probably won't be needed again.
+
 cp -r ../dev/build-molten/MoltenVK/Package/Release/MoltenVK/static/MoltenVK.xcframework ios/MoltenVK
 
 The Old iOS Build Instructions

--- a/macOS/README.md
+++ b/macOS/README.md
@@ -1,3 +1,9 @@
+# MacOS notes
+
 Entitlements.plist is to be used for code signing on macOS.
 
 We enable "hardened runtime" in order to make notarization happy, but we need some exceptions.
+
+## MoltenVK on Mac
+
+To update MoltenVK, download the latest version and get the files from dylib/macOS and put them in ext/vulkan/macOS/Frameworks.


### PR DESCRIPTION
- Hide the mmpx shader (closes #21261 for now)
- Pass the app store validation again (some tweaks to the plist)