### PR TITLE
Change versionString on MainScreen to use infoStyle color

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1239,7 +1239,7 @@ public:
 		dc.DrawText(versionString,
 			bounds_.x + iconImg->w + 8,
 			bounds_.y + logoImg->h + (tiny ? 8 : 6),
-			dc.GetTheme().itemStyle.fgColor);
+			dc.GetTheme().infoStyle.fgColor);
 		dc.SetFontStyle(dc.GetTheme().uiFont);
 	}
 


### PR DESCRIPTION
Improves #18802 `22.`

This was easy to find, but I'm not sure how to go about `23.` (Why there are two types of screen titles? 😕 )