### PR TITLE
Fix a bunch of memory problems found by valgrind

### DIFF
--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -125,11 +125,12 @@ public:
 		size_ += count;
 	}
 
+	// Adds this number of new T to the end, and returns the pointer to them.
 	T *extend_uninitialized(size_t count) {
-		size_t sz = size_;
+		const size_t prevSize = size_;
 		if (size_ + count <= capacity_) {
 			size_ += count;
-			return &data_[sz];
+			return data_ + prevSize;
 		} else {
 			size_t newCapacity = size_ + count * 2;  // Leave some extra room when growing in all cases
 			if (newCapacity < capacity_ * 2) {
@@ -138,7 +139,7 @@ public:
 			}
 			IncreaseCapacityTo(newCapacity);
 			size_ += count;
-			return &data_[sz];
+			return data_ + prevSize;
 		}
 	}
 

--- a/Common/Data/Format/ZIMLoad.cpp
+++ b/Common/Data/Format/ZIMLoad.cpp
@@ -59,7 +59,7 @@ int LoadZIMPtr(const uint8_t *zim, size_t datasize, int *width, int *height, int
 	memcpy(flags, zim + 12, 4);
 
 	int num_levels = 1;
-	int image_data_size[ZIM_MAX_MIP_LEVELS];
+	int image_data_size[ZIM_MAX_MIP_LEVELS]{};
 	if (*flags & ZIM_HAS_MIPS) {
 		num_levels = log2i(*width < *height ? *width : *height) + 1;
 	}

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -1156,8 +1156,7 @@ const Path GetCurDirectory() {
 	return Path(curDir);
 #else
 	char temp[4096]{};
-	getcwd(temp, 4096);
-	return Path(temp);
+	return Path(getcwd(temp, 4096));
 #endif
 }
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1960,7 +1960,7 @@ void VKRPipelineLayout::FlushDescSets(VulkanContext *vulkan, int frame, QueuePro
 				_dbg_assert_(data[i].buffer.buffer != VK_NULL_HANDLE);
 				bufferInfo[numBuffers].buffer = data[i].buffer.buffer;
 				bufferInfo[numBuffers].range = data[i].buffer.range;
-				bufferInfo[numBuffers].offset = 0;
+				bufferInfo[numBuffers].offset = 0;  // This is supplied by the dynamic offset.
 				writes[numWrites].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
 				writes[numWrites].pBufferInfo = &bufferInfo[numBuffers];
 				writes[numWrites].pImageInfo = nullptr;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -165,7 +165,7 @@ struct CompileQueueEntry {
 // Pending descriptor sets.
 // TODO: Sort these by VKRPipelineLayout to avoid storing it for each element.
 struct PendingDescSet {
-	int offset;  // probably enough with a u16.
+	int offset;  // This is in whole PackedDescriptors, not bytes. probably enough with a u16.
 	u8 count;
 	VkDescriptorSet set;
 };
@@ -189,6 +189,10 @@ struct PackedDescriptor {
 #endif
 	};
 };
+
+static_assert(sizeof(PackedDescriptor) == 16, "PackedDescriptor should be exactly 16 bytes");
+static_assert(sizeof(PackedDescriptor::image) == 16, "PackedDescriptor should be exactly 16 bytes");
+static_assert(sizeof(PackedDescriptor::buffer) == 16, "PackedDescriptor should be exactly 16 bytes");
 
 // Note that we only support a single descriptor set due to compatibility with some ancient devices.
 // We should probably eventually give that up eventually.

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -451,7 +451,7 @@ public:
 		PendingDescSet &descSet = data.descSets_.push_uninitialized();
 		descSet.offset = (uint32_t)offset;
 		descSet.count = count;
-		// descSet.set = VK_NULL_HANDLE;  // to be filled in
+		descSet.set = VK_NULL_HANDLE;  // to be filled in
 		*descSetIndex = setIndex;
 		return retval;
 	}

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -23,6 +23,7 @@
 #include "Common/File/VFS/VFS.h"
 #include "Common/StringUtils.h"
 #include "Common/System/OSD.h"
+#include "Common/System/System.h"
 #include "Core/Compatibility.h"
 #include "Core/Config.h"
 #include "Core/System.h"
@@ -59,20 +60,23 @@ void Compatibility::Load(const std::string &gameID) {
 		}
 	}
 
-	{
-		IniFile compat;
-		// This loads from assets.
-		if (compat.LoadFromVFS(g_VFS, "compatvr.ini")) {
-			CheckVRSettings(compat, gameID);
+	const int deviceType = System_GetPropertyInt(SYSPROP_DEVICE_TYPE);
+	if ((deviceType == DEVICE_TYPE_VR) || g_Config.bForceVR) {
+		{
+			IniFile compat;
+			// This loads from assets.
+			if (compat.LoadFromVFS(g_VFS, "compatvr.ini")) {
+				CheckVRSettings(compat, gameID);
+			}
 		}
-	}
 
-	{
-		IniFile compat2;
-		// This one is user-editable. Need to load it after the system one.
-		Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compatvr.ini";
-		if (compat2.Load(path)) {
-			CheckVRSettings(compat2, gameID);
+		{
+			IniFile compat2;
+			// This one is user-editable. Need to load it after the system one.
+			Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compatvr.ini";
+			if (compat2.Load(path)) {
+				CheckVRSettings(compat2, gameID);
+			}
 		}
 	}
 }

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -283,7 +283,7 @@ float ControlMapper::MapAxisValue(float value, int vkId, const InputMapping &map
 		// If a signed axis is mapped to an unsigned mapping,
 		// convert it. This happens when mapping DirectInput triggers to analog speed,
 		// for example.
-		int direction;
+		int direction = 0;
 		if (IsSignedAxis(mapping.Axis(&direction))) {
 			// The value has been split up into two curInput values, so we need to go fetch the other
 			// and put them back together again. Kind of awkward, but at least makes the regular case simple...

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -457,7 +457,7 @@ u32 SymbolMap::GetNextSymbolAddress(u32 address, SymbolType symmask) {
 
 std::string SymbolMap::GetDescription(unsigned int address) {
 	std::lock_guard<std::recursive_mutex> guard(lock_);
-	const char *labelName = nullptr;
+	std::string labelName;
 
 	u32 funcStart = GetFunctionStart(address);
 	if (funcStart != INVALID_ADDRESS) {
@@ -468,7 +468,7 @@ std::string SymbolMap::GetDescription(unsigned int address) {
 			labelName = GetLabelName(dataStart);
 	}
 
-	if (labelName)
+	if (!labelName.empty())
 		return labelName;
 
 	char descriptionTemp[32];

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -61,7 +61,7 @@ private:
 	void WriteSfoFile();
 
 	SceUtilityGamedataInstallParam request{};
-	PSPPointer<SceUtilityGamedataInstallParam> param;
+	PSPPointer<SceUtilityGamedataInstallParam> param{};
 	std::vector<std::string> inFileNames;
 	int numFiles = 0;
 	int readFiles = 0;

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -53,7 +53,7 @@ private:
 	void DrawBanner();
 	void DrawIndicator();
 
-	SceUtilityNetconfParam request = {};
+	SceUtilityNetconfParam request{};
 	u32 requestAddr = 0;
 	int connResult = -1;
 

--- a/Core/Dialog/PSPScreenshotDialog.h
+++ b/Core/Dialog/PSPScreenshotDialog.h
@@ -39,6 +39,6 @@ protected:
 		return true;
 	}
 
-	int mode;
-	PSPPointer<SceUtilityScreenshotParams> params_;
+	int mode = 0;
+	PSPPointer<SceUtilityScreenshotParams> params_{};
 };

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1350,7 +1350,7 @@ skip:
 			for (auto iter = range.first; iter != range.second; ++iter) {
 				AnalyzedFunction &f = *iter->second;
 				if (f.hash == mf->hash && f.size == mf->size) {
-					strncpy(f.name, mf->name, sizeof(mf->name) - 1);
+					truncate_cpy(f.name, mf->name);
 
 					std::string existingLabel = g_symbolMap->GetLabelString(f.start);
 					char defaultLabel[256];

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1196,7 +1196,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 	float u0 = 0.0f, u1 = 1.0f;
 	float v0 = 0.0f, v1 = 1.0f;
 
-	DrawTextureFlags flags;
+	DrawTextureFlags flags = DrawTextureFlags::DRAWTEX_DEFAULT;
 	if (useBufferedRendering_ && vfb) {
 		_dbg_assert_(vfb->fbo);
 		if (vfb->fbo) {
@@ -2102,10 +2102,10 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 	// For now fill in these old variables from the candidates to reduce the initial diff.
 	VirtualFramebuffer *dstBuffer = nullptr;
 	VirtualFramebuffer *srcBuffer = nullptr;
-	int srcY;
-	int srcH;
-	int dstY;
-	int dstH;
+	int srcY = 0;
+	int srcH = 0;
+	int dstY = 0;
+	int dstH = 0;
 
 	const CopyCandidate *bestSrc = GetBestCopyCandidate(srcCandidates, src, channel);
 	if (bestSrc) {

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -211,13 +211,14 @@ enum BindFramebufferColorFlags {
 };
 
 enum DrawTextureFlags {
+	DRAWTEX_DEFAULT = 0,
 	DRAWTEX_NEAREST = 0,
 	DRAWTEX_LINEAR = 1,
 	DRAWTEX_TO_BACKBUFFER = 8,
 	DRAWTEX_DEPTH = 16,
 };
 
-inline DrawTextureFlags operator | (const DrawTextureFlags &lhs, const DrawTextureFlags &rhs) {
+inline DrawTextureFlags operator | (DrawTextureFlags lhs, DrawTextureFlags rhs) {
 	return DrawTextureFlags((u32)lhs | (u32)rhs);
 }
 

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -389,8 +389,11 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 	dirtyUniforms = 0;
 
 	// Analyze scene
-	bool is2D, flatScreen;
-	if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
+	bool is2D = false, flatScreen = false;
+
+	const bool useVR = gstate_c.Use(GPU_USE_VIRTUAL_REALITY);
+
+	if (useVR) {
 		is2D = Is2DVRObject(gstate.projMatrix, gstate.isModeThrough());
 		flatScreen = IsFlatVRScene();
 	}
@@ -410,7 +413,7 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 	}
 
 	// Set HUD mode
-	if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
+	if (useVR) {
 		if (GuessVRDrawingHUD(is2D, flatScreen)) {
 			float aspect = 480.0f / 272.0f * (IsImmersiveVRMode() ? 0.5f : 1.0f);
 			render_->SetUniformF1(&u_scaleX, g_Config.fHeadUpDisplayScale * aspect);
@@ -423,7 +426,7 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 
 	// Update any dirty uniforms before we draw
 	if (dirty & DIRTY_PROJMATRIX) {
-		if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
+		if (useVR) {
 			Matrix4x4 vrProjection;
 			if (flatScreen || is2D) {
 				memcpy(&vrProjection, gstate.projMatrix, 16 * sizeof(float));
@@ -482,7 +485,7 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 	}
 	if (dirty & DIRTY_FOGCOLOR) {
 		SetColorUniform3(render_, &u_fogcolor, gstate.fogcolor);
-		if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
+		if (useVR) {
 			SetVRCompat(VR_COMPAT_FOG_COLOR, gstate.fogcolor);
 		}
 	}
@@ -567,7 +570,7 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 		SetMatrix4x3(render_, &u_world, gstate.worldMatrix);
 	}
 	if (dirty & DIRTY_VIEWMATRIX) {
-		if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
+		if (useVR) {
 			float leftEyeView[16];
 			float rightEyeView[16];
 			ConvertMatrix4x3To4x4Transposed(leftEyeView, gstate.viewMatrix);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -537,10 +537,13 @@ void DrawEngineVulkan::Flush() {
 			descriptors[2].image.sampler = (boundDepal_ && boundDepalSmoothed_) ? samplerSecondaryLinear_ : samplerSecondaryNearest_;
 			descriptors[3].buffer.buffer = baseBuf;
 			descriptors[3].buffer.range = sizeof(UB_VS_FS_Base);
+			descriptors[3].buffer.offset = 0;
 			descriptors[4].buffer.buffer = lightBuf;
 			descriptors[4].buffer.range = sizeof(UB_VS_Lights);
+			descriptors[4].buffer.offset = 0;
 			descriptors[5].buffer.buffer = boneBuf;
 			descriptors[5].buffer.range = sizeof(UB_VS_Bones);
+			descriptors[5].buffer.offset = 0;
 
 			const uint32_t dynamicUBOOffsets[3] = {
 				baseUBOOffset, lightUBOOffset, boneUBOOffset,

--- a/ext/libkirk/AES.h
+++ b/ext/libkirk/AES.h
@@ -44,9 +44,8 @@ void AES_cbc_encrypt(AES_ctx *ctx, const u8 *src, u8 *dst, int size);
 void AES_cbc_decrypt(AES_ctx *ctx, const u8 *src, u8 *dst, int size);
 void AES_CMAC(AES_ctx *ctx, const unsigned char *input, int length, unsigned char *mac);
 
-int	rijndaelKeySetupEnc(unsigned int [], const unsigned char [], int);
-int	rijndaelKeySetupDec(unsigned int [], const unsigned char [], int);
-void rijndaelEncrypt(const unsigned int [], int, const unsigned char [],
-	    unsigned char []);
+int	rijndaelKeySetupEnc(u32 [], const u8 [], int);
+int	rijndaelKeySetupDec(u32 [], const u8 [], int);
+void rijndaelEncrypt(const u32 [], int, const u8 pt[16], u8 ct[16]);
 
 #endif /* __RIJNDAEL_H */


### PR DESCRIPTION
As usual, it pays off to run valgrind before a release. Found a couple use-after-free and uninitialized data. Now savestates are valgrind-clean :)

Also a few regular compiler warning fixes.