### PR TITLE
Avoid error log in android by Gemini

### DIFF
--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -667,7 +667,7 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 			}
 
 			// We don't call super.onCreate, we just bail in an ugly way.
-			System.exit(-1);
+			finish();
 			return;
 		}
 


### PR DESCRIPTION
Avoid "Ops! Invalid eventType for aggregate. pkgName=org.ppsspp.ppssppgold, eventType=23,start=0" letting the system kill the task instead of System.exit() is the best way to mitigate it.