### PR TITLE
Windows fullscreen mode: Don't forget to set the WS_POPUP flag, Mahjongg Artifacts fix

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -161,6 +161,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "NullPageValid", &flags_.NullPageValid);
 	CheckSetting(iniFile, gameID, "DetectDestBlendSquared", &flags_.DetectDestBlendSquared);
 	CheckSetting(iniFile, gameID, "BoostExactFramebufferMatch", &flags_.BoostExactFramebufferMatch);
+	CheckSetting(iniFile, gameID, "PersistentFramebuffers", &flags_.PersistentFramebuffers);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -120,6 +120,7 @@ struct CompatFlags {
 	bool NullPageValid;
 	bool DetectDestBlendSquared;
 	bool BoostExactFramebufferMatch;
+	bool PersistentFramebuffers;
 };
 
 struct VRCompat {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1747,6 +1747,8 @@ void FramebufferManagerCommon::DecimateFBOs() {
 	}
 	fbosToDelete_.clear();
 
+	const bool persistentFramebuffers = PSP_CoreParameter().compat.flags().PersistentFramebuffers;
+
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *vfb = vfbs_[i];
 		int age = frameLastFramebufUsed_ - std::max(vfb->last_frame_render, vfb->last_frame_used);
@@ -1760,7 +1762,7 @@ void FramebufferManagerCommon::DecimateFBOs() {
 		UpdateFramebufUsage(vfb);
 
 		if (vfb != displayFramebuf_ && vfb != prevDisplayFramebuf_ && vfb != prevPrevDisplayFramebuf_) {
-			if (age > FBO_OLD_AGE) {
+			if (age > FBO_OLD_AGE && !persistentFramebuffers) {
 				INFO_LOG(Log::FrameBuf, "Decimating FBO for %08x (%ix%i %s), age %i", vfb->fb_address, vfb->width, vfb->height, GeBufferFormatToString(vfb->fb_format), age);
 				DestroyFramebuf(vfb);
 				vfbs_.erase(vfbs_.begin() + i--);
@@ -1770,7 +1772,7 @@ void FramebufferManagerCommon::DecimateFBOs() {
 
 	for (auto it = tempFBOs_.begin(); it != tempFBOs_.end(); ) {
 		int age = frameLastFramebufUsed_ - it->second.last_frame_used;
-		if (age > FBO_OLD_AGE) {
+		if (age > FBO_OLD_AGE && !persistentFramebuffers) {
 			it->second.fbo->Release();
 			it = tempFBOs_.erase(it);
 		} else {
@@ -1782,7 +1784,7 @@ void FramebufferManagerCommon::DecimateFBOs() {
 	for (size_t i = 0; i < bvfbs_.size(); ++i) {
 		VirtualFramebuffer *vfb = bvfbs_[i];
 		int age = frameLastFramebufUsed_ - vfb->last_frame_render;
-		if (age > FBO_OLD_AGE) {
+		if (age > FBO_OLD_AGE && !persistentFramebuffers) {
 			INFO_LOG(Log::FrameBuf, "Decimating FBO for %08x (%dx%d %s), age %i", vfb->fb_address, vfb->width, vfb->height, GeBufferFormatToString(vfb->fb_format), age);
 			DestroyFramebuf(vfb);
 			bvfbs_.erase(bvfbs_.begin() + i--);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -341,7 +341,7 @@ namespace MainWindow {
 			if (g_Config.bFullScreenMulti) {
 				SetMenu(hWnd, NULL);
 				// Strip all decorations
-				SetWindowLong(hWnd, GWL_STYLE, prevStyle & ~WS_OVERLAPPEDWINDOW);
+				SetWindowLong(hWnd, GWL_STYLE, (prevStyle & ~WS_OVERLAPPEDWINDOW) | WS_POPUP);
 				// Maximize isn't enough to display on all monitors.
 				// Remember that negative coordinates may be valid.
 				const int totalX = GetSystemMetrics(SM_XVIRTUALSCREEN);
@@ -357,7 +357,7 @@ namespace MainWindow {
 				if (GetMonitorInfo(MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST), &mi)) {
 					SetMenu(hWnd, NULL);
 					// Strip all decorations
-					SetWindowLong(hWnd, GWL_STYLE, prevStyle & ~WS_OVERLAPPEDWINDOW);
+					SetWindowLong(hWnd, GWL_STYLE, (prevStyle & ~WS_OVERLAPPEDWINDOW) | WS_POPUP);
 
 					SetWindowPos(hWnd, HWND_TOP,
 						mi.rcMonitor.left, mi.rcMonitor.top,
@@ -373,7 +373,7 @@ namespace MainWindow {
 				g_Config.iWindowX, g_Config.iWindowY);
 
 			// Transitioning to Windowed
-			SetWindowLong(hWnd, GWL_STYLE, prevStyle | WS_OVERLAPPEDWINDOW);
+			SetWindowLong(hWnd, GWL_STYLE, (prevStyle & ~WS_POPUP) | WS_OVERLAPPEDWINDOW);
 			SetMenu(hWnd, g_hMenu);
 
 			WINDOWPLACEMENT wp = {sizeof(WINDOWPLACEMENT)};
@@ -902,8 +902,8 @@ namespace MainWindow {
 				if (g_Config.bFullScreen && !g_inForcedResize) {
 					MONITORINFO mi = {sizeof(mi)};
 					if (GetMonitorInfo(MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST), &mi)) {
-						int monWidth = mi.rcMonitor.right - mi.rcMonitor.left;
-						int monHeight = mi.rcMonitor.bottom - mi.rcMonitor.top;
+						const int monWidth = mi.rcMonitor.right - mi.rcMonitor.left;
+						const int monHeight = mi.rcMonitor.bottom - mi.rcMonitor.top;
 
 						// If the new size is no longer the full monitor size, drop FS state (put back the menu
 						// and recalculate window decorations without actually changing the size of the window).
@@ -912,9 +912,9 @@ namespace MainWindow {
 							if (GetMenu(hWnd) == NULL) {
 								SetMenu(hWnd, g_hMenu);
 							}
-							DWORD style = GetWindowLong(hWnd, GWL_STYLE);
+							const DWORD style = GetWindowLong(hWnd, GWL_STYLE);
 							if (!(style & WS_CAPTION)) {
-								SetWindowLong(hWnd, GWL_STYLE, style | WS_OVERLAPPEDWINDOW);
+								SetWindowLong(hWnd, GWL_STYLE, (style & ~WS_POPUP) | WS_OVERLAPPEDWINDOW);
 								SetWindowPos(hWnd, NULL, 0, 0, 0, 0,
 									SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED | SWP_NOACTIVATE);
 							}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2128,3 +2128,10 @@ ULJS00293 = true
 ULKS46257 = true
 ULJS19073 = true
 NPJH50848 = true
+
+[PersistentFramebuffers]
+# A few games render to framebuffers and count on them sticking around "forever", like Mahjong Artifacts.
+NPUZ00062 = true  # Mahjong Artifacts (MJA)
+NPEZ00194 = true  # Mahjong Artifacts (MJA)
+NPEZ00003 = true  # MJA 2
+NPUZ00006 = true  # MJA 2


### PR DESCRIPTION
According to various sources, some drivers rely on this flag to detect fullscreen windows to apply some optimizations to.

Also sneaks in a quick workaround for the latest problem from the Mahjongg Artifacts issue, #15828.