### PR TITLE
Assorted prep

### DIFF
--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -11,17 +11,23 @@
 namespace File {
 
 struct FileInfo {
-	std::string name;
+	std::string name;  // local name in directory
 	Path fullName;
+
 	bool exists = false;
 	bool isDirectory = false;
 	bool isWritable = false;
-	uint64_t size = 0;
+	uint64_t size = 0;  // in bytes
 
-
+	// time_t
 	uint64_t atime = 0;
 	uint64_t mtime = 0;
 	uint64_t ctime = 0;
+	// Microseconds, addition to the time_t.
+	int atimeUs = 0;
+	int mtimeUs = 0;
+	int ctimeUs = 0;
+	// Access bitfield
 	uint32_t access = 0;  // st_mode & 0x1ff
 
 	bool operator <(const FileInfo &other) const;

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -317,7 +317,7 @@ int OpenFD(const Path &path, OpenFlag flags) {
 		return -1;
 	}
 
-	INFO_LOG(Log::IO, "Android_OpenContentUriFd: %s (%s)", path.c_str(), OpenFlagToString(flags).c_str());
+	DEBUG_LOG(Log::IO, "Android_OpenContentUriFd: %s (%s)", path.c_str(), OpenFlagToString(flags).c_str());
 	int descriptor = Android_OpenContentUriFd(path.ToString(), mode);
 	if (descriptor < 0) {
 		// File probably just doesn't exist. No biggie.

--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -143,6 +143,11 @@ const float friction = 0.92f;
 const float stop_threshold = 0.1f;
 
 bool ScrollView::Touch(const TouchInput &input) {
+	// Ignore buttons other than the left one.
+	if ((input.flags & TouchInputFlags::MOUSE) && (input.buttons & 1) == 0) {
+		return false;
+	}
+
 	if ((input.flags & TouchInputFlags::DOWN) && scrollTouchId_ == -1 && bounds_.Contains(input.x, input.y)) {
 		if (orientation_ == ORIENT_VERTICAL) {
 			Bob bob = ComputeBob();

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1236,14 +1236,16 @@ bool SavedataParam::GetList(SceUtilitySavedataParam *param)
 		{
 			entries[i].st_mode = 0x11FF;
 			if (sfoFiles[i].exists) {
-				__IoCopyDate(entries[i].st_ctime, sfoFiles[i].ctime);
-				__IoCopyDate(entries[i].st_atime, sfoFiles[i].atime);
-				__IoCopyDate(entries[i].st_mtime, sfoFiles[i].mtime);
+				ConvertTmToPspDateTime(entries[i].st_ctime, sfoFiles[i].ctime, sfoFiles[i].ctimeUs);
+				ConvertTmToPspDateTime(entries[i].st_atime, sfoFiles[i].atime, sfoFiles[i].atimeUs);
+				ConvertTmToPspDateTime(entries[i].st_mtime, sfoFiles[i].mtime, sfoFiles[i].mtimeUs);
 			} else {
-				__IoCopyDate(entries[i].st_ctime, validDir[i].ctime);
-				__IoCopyDate(entries[i].st_atime, validDir[i].atime);
-				__IoCopyDate(entries[i].st_mtime, validDir[i].mtime);
+				// What?
+				ConvertTmToPspDateTime(entries[i].st_ctime, validDir[i].ctime, validDir[i].ctimeUs);
+				ConvertTmToPspDateTime(entries[i].st_atime, validDir[i].atime, validDir[i].atimeUs);
+				ConvertTmToPspDateTime(entries[i].st_mtime, validDir[i].mtime, validDir[i].mtimeUs);
 			}
+
 			// folder name without gamename (max 20 u8)
 			std::string outName = validDir[i].name.substr(GetGameName(param).size());
 			memset(entries[i].name, 0, sizeof(entries[i].name));
@@ -1364,9 +1366,9 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param, u32 requestAddr)
 
 		entry->st_mode = 0x21FF;
 		entry->st_size = file->size + sizeOffset;
-		__IoCopyDate(entry->st_ctime, file->ctime);
-		__IoCopyDate(entry->st_atime, file->atime);
-		__IoCopyDate(entry->st_mtime, file->mtime);
+		ConvertTmToPspDateTime(entry->st_ctime, file->ctime, file->ctimeUs);
+		ConvertTmToPspDateTime(entry->st_atime, file->atime, file->atimeUs);
+		ConvertTmToPspDateTime(entry->st_mtime, file->mtime, file->mtimeUs);
 		// TODO: Probably actually 13 + 3 pad...
 		strncpy(entry->name, file->name.c_str(), 16);
 		entry->name[15] = '\0';
@@ -1467,14 +1469,12 @@ bool SavedataParam::GetSize(SceUtilitySavedataParam *param) {
 	return exists;
 }
 
-void SavedataParam::Clear()
-{
-	if (saveDataList)
-	{
-		for (int i = 0; i < saveNameListDataCount; i++)
-		{
-			if (saveDataList[i].texture != NULL && (!noSaveIcon || saveDataList[i].texture != noSaveIcon->texture))
+void SavedataParam::Clear() {
+	if (saveDataList) {
+		for (int i = 0; i < saveNameListDataCount; i++) {
+			if (saveDataList[i].texture && (!noSaveIcon || saveDataList[i].texture != noSaveIcon->texture)) {
 				delete saveDataList[i].texture;
+			}
 			saveDataList[i].texture = NULL;
 		}
 
@@ -1491,8 +1491,7 @@ void SavedataParam::Clear()
 	}
 }
 
-int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
-{
+int SavedataParam::SetPspParam(SceUtilitySavedataParam *param) {
 	pspParam = param;
 	if (!pspParam) {
 		Clear();

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -776,6 +776,10 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 	localtime_r((time_t*)&ctime, &x.ctime);
 	localtime_r((time_t*)&mtime, &x.mtime);
 
+	x.atimeUs = info.atimeUs;
+	x.ctimeUs = info.ctimeUs;
+	x.mtimeUs = info.mtimeUs;
+
 	return ReplayApplyDiskFileInfo(x, CoreTiming::GetGlobalTimeUs());
 }
 

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -118,9 +118,9 @@ struct PSPFileInfo {
 	bool exists = false;
 	FileType type = FILETYPE_NORMAL;
 
-	tm atime{};
-	tm ctime{};
-	tm mtime{};
+	tm atime{}; int atimeUs = 0;
+	tm ctime{}; int ctimeUs = 0;
+	tm mtime{}; int mtimeUs = 0;
 
 	bool isOnSectorSystem = false;
 	u32 startSector = 0;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -905,18 +905,17 @@ u64 __IoCompleteAsyncIO(FileNode *f) {
 	return 0;
 }
 
-void __IoCopyDate(ScePspDateTime& date_out, const tm& date_in)
-{
-	date_out.year = date_in.tm_year+1900;
-	date_out.month = date_in.tm_mon+1;
+void ConvertTmToPspDateTime(ScePspDateTime& date_out, const tm& date_in, int microSeconds) {
+	date_out.year = date_in.tm_year + 1900;
+	date_out.month = date_in.tm_mon + 1;
 	date_out.day = date_in.tm_mday;
 	date_out.hour = date_in.tm_hour;
 	date_out.minute = date_in.tm_min;
 	date_out.second = date_in.tm_sec;
-	date_out.microsecond = 0;
+	date_out.microsecond = microSeconds;
 }
 
-static void __IoGetStat(SceIoStat *stat, PSPFileInfo &info) {
+static void __IoGetStat(SceIoStat *stat, const PSPFileInfo &info) {
 	memset(stat, 0xfe, sizeof(SceIoStat));
 
 	int type, attr;
@@ -931,9 +930,9 @@ static void __IoGetStat(SceIoStat *stat, PSPFileInfo &info) {
 	stat->st_mode = type | info.access;
 	stat->st_attr = attr;
 	stat->st_size = info.size;
-	__IoCopyDate(stat->st_a_time, info.atime);
-	__IoCopyDate(stat->st_c_time, info.ctime);
-	__IoCopyDate(stat->st_m_time, info.mtime);
+	ConvertTmToPspDateTime(stat->st_a_time, info.atime, info.atimeUs);
+	ConvertTmToPspDateTime(stat->st_c_time, info.ctime, info.ctimeUs);
+	ConvertTmToPspDateTime(stat->st_m_time, info.mtime, info.mtimeUs);
 	stat->st_private[0] = info.startSector;
 }
 

--- a/Core/HLE/sceIo.h
+++ b/Core/HLE/sceIo.h
@@ -35,7 +35,7 @@ u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 ou
 int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec);
 
 u32 __IoGetFileHandleFromId(u32 id, u32 &outError);
-void __IoCopyDate(ScePspDateTime& date_out, const tm& date_in);
+void ConvertTmToPspDateTime(ScePspDateTime& date_out, const tm& date_in, int microSeconds);
 
 KernelObject *__KernelFileNodeObject();
 KernelObject *__KernelDirListingObject();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -569,16 +569,18 @@ void PSP_ForceDebugStats(bool enable) {
 	_assert_(coreCollectDebugStatsCounter >= 0);
 }
 
-static void InitGPU(GPUCore gpuCore, Draw::DrawContext *draw, std::string *error_string) {
-	_dbg_assert_(!gpu);
-
-	INFO_LOG(Log::Loader, "Starting graphics...");
-	// This set the `gpu` global.
-	bool success = GPU_Init(gpuCore, g_CoreParameter.graphicsContext, draw);
-	if (!success) {
-		*error_string = "Unable to initialize rendering engine.";
-		CPU_Shutdown(false);
-		g_bootState = BootState::Failed;
+static void InitGPU(std::string *error_string) {
+	if (!gpu) {  // should be!
+		INFO_LOG(Log::Loader, "Starting graphics...");
+		Draw::DrawContext *draw = g_CoreParameter.graphicsContext ? g_CoreParameter.graphicsContext->GetDrawContext() : nullptr;
+		// This set the `gpu` global.
+		GPUCore gpuCore = PSP_CoreParameter().gpuCore;
+		bool success = GPU_Init(gpuCore, g_CoreParameter.graphicsContext, draw);
+		if (!success) {
+			*error_string = "Unable to initialize rendering engine.";
+			CPU_Shutdown(false);
+			g_bootState = BootState::Failed;
+		}
 	}
 }
 
@@ -597,19 +599,6 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 	if (g_CoreParameter.graphicsContext == nullptr) {
 		g_CoreParameter.graphicsContext = temp;
 	}
-	Draw::DrawContext *draw = g_CoreParameter.graphicsContext ? g_CoreParameter.graphicsContext->GetDrawContext() : nullptr;
-
-	GPUCore gpuCore = g_CoreParameter.gpuCore;
-
-	// In libretro, the creation order is different, it's ok with a null draw context here.
-	// We do need to rework the whole init process.. ugh.
-#ifndef __LIBRETRO__
-	if (!draw && gpuCore != GPUCORE_SOFTWARE) {
-		ERROR_LOG(Log::Loader, "No drawing context provided.");
-		g_bootState = BootState::Failed;
-		return false;
-	}
-#endif
 
 	g_CoreParameter.errorString.clear();
 
@@ -621,7 +610,7 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 
 	Core_NotifyLifecycle(CoreLifecycle::STARTING);
 
-	g_loadingThread = std::thread([errorString, gpuCore, draw]() {
+	g_loadingThread = std::thread([errorString]() {
 		SetCurrentThreadName("ExecLoader");
 
 		AndroidJNIThreadContext jniContext;
@@ -663,8 +652,9 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 		}
 
 		// Initialize the GPU as far as we can here (do things like load cache files).
+		_dbg_assert_(!gpu);
 #ifndef __LIBRETRO__
-		InitGPU(gpuCore, draw, errorString);
+		InitGPU(errorString);
 #endif
 		g_bootState = BootState::Complete;
 	});
@@ -696,7 +686,7 @@ BootState PSP_InitUpdate(std::string *error_string) {
 	}
 
 #ifdef __LIBRETRO__
-	InitGPU(g_CoreParameter.gpuCore, g_CoreParameter.graphicsContext->GetDrawContext(), error_string);
+	InitGPU(error_string);
 #endif
 
 	// Ok, async part of the boot completed, let's finish up things on the main thread.

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -907,24 +907,30 @@ handleELF:
 			u64 saveDataSize = 0;
 			u64 installDataSize = 0;
 
+			std::lock_guard<std::mutex> lock(info_->lock);
+			info_->gameSizeOnDisk = gameSizeOnDisk;
+			info_->saveDataSize = saveDataSize;
+			info_->installDataSize = installDataSize;
+		}
+
+		if (flags_ & GameInfoFlags::SAVEDATA_SIZE) {
 			switch (info_->fileType) {
 			case IdentifiedFileType::PSP_ISO:
 			case IdentifiedFileType::PSP_ISO_NP:
 			case IdentifiedFileType::PSP_DISC_DIRECTORY:
 			case IdentifiedFileType::PSP_PBP:
 			case IdentifiedFileType::PSP_PBP_DIRECTORY:
-				saveDataSize = info_->GetGameSavedataSizeInBytes();
-				installDataSize = info_->GetInstallDataSizeInBytes();
+			{
+				std::lock_guard<std::mutex> lock(info_->lock);
+				info_->saveDataSize = info_->GetGameSavedataSizeInBytes();
+				info_->installDataSize = info_->GetInstallDataSizeInBytes();
 				break;
+			}
 			default:
 				break;
 			}
-
-			std::lock_guard<std::mutex> lock(info_->lock);
-			info_->gameSizeOnDisk = gameSizeOnDisk;
-			info_->saveDataSize = saveDataSize;
-			info_->installDataSize = installDataSize;
 		}
+
 		if (flags_ & GameInfoFlags::UNCOMPRESSED_SIZE) {
 			info_->gameSizeUncompressed = info_->GetSizeUncompressedInBytes();
 		}
@@ -1038,12 +1044,13 @@ void GameInfoCache::PurgeType(IdentifiedFileType fileType) {
 
 // Call on the main thread ONLY - that is from stuff called from NativeFrame.
 // Can also be called from the audio thread for menu background music, but that cannot request images!
-std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags, GameInfoFlags *outHasFlags) {
+std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags, GameInfoFlags *outHasFlags, GameInfoFlags refetchFlags) {
 	const std::string &pathStr = gamePath.ToString();
 
 	// _dbg_assert_(gamePath != GetSysDirectory(DIRECTORY_SAVEDATA));
 
 	// This is always needed to determine the method to get the other info, so make sure it's computed first.
+
 	wantFlags |= GameInfoFlags::FILE_TYPE;
 
 	mapLock_.lock();
@@ -1056,10 +1063,15 @@ std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const 
 
 		info->FinishPendingTextureLoads(draw);
 		info->lastAccessedTime = time_now_d();
+
 		GameInfoFlags wanted = (GameInfoFlags)0;
 		{
 			// Careful now!
 			std::unique_lock<std::mutex> lock(info->lock);
+			if (refetchFlags != GameInfoFlags::EMPTY) {
+				// Forget some flags!
+				info->hasFlags &= ~refetchFlags;
+			}
 			GameInfoFlags willHaveFlags = info->hasFlags | info->pendingFlags;  // We don't want to re-fetch data that we have, so or in pendingFlags.
 			wanted = (GameInfoFlags)((int)wantFlags & ~(int)willHaveFlags);  // & is reserved for testing so we have to cast to int. ugh.
 			info->pendingFlags |= wanted;
@@ -1067,6 +1079,7 @@ std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const 
 				*outHasFlags = info->hasFlags;
 			}
 		}
+
 		if (wanted != (GameInfoFlags)0) {
 			// We're missing info that we want. Go get it!
 			GameInfoWorkItem *item = new GameInfoWorkItem(gamePath, info, wanted);

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -48,6 +48,7 @@ enum class GameInfoFlags {
 	SND = 0x20,
 	SIZE = 0x40,
 	UNCOMPRESSED_SIZE = 0x80,
+	SAVEDATA_SIZE = 0x100,
 };
 ENUM_CLASS_BITOPS(GameInfoFlags);
 
@@ -200,7 +201,7 @@ public:
 	// because they're big. bgTextures and sound may be discarded over time as well.
 	// NOTE: This never returns null, so you don't need to check for that. Do check Ready() flags though.
 	// It's OK to pass in nullptr for draw if you don't need the actual texture right now.
-	std::shared_ptr<GameInfo> GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags, GameInfoFlags *outHasFlags = nullptr);
+	std::shared_ptr<GameInfo> GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags, GameInfoFlags *outHasFlags = nullptr, GameInfoFlags refetchFlags = GameInfoFlags::EMPTY);
 	void FlushBGs();  // Gets rid of all BG textures. Also gets rid of bg sounds.
 
 	void CancelAll();

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-	id("com.android.application") version "9.0.0" apply false
+	id("com.android.application") version "9.0.1" apply false
 	id("com.google.protobuf") version "0.9.6" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Fixes a bug where the software renderer wasn't activated anymore by reverting a misguided refactoring, thanks fcrwr in https://github.com/hrydgard/ppsspp/commit/045368656f86c25b9e1fb44d26490124990977be .

Also, plumbs through support for high precision file timestamps, and implements support on Windows. This is in preparation for various attempts at fixing the Silent Hill savedata issue.

Bumps gradle again.