### PR TITLE
Add compat flag to freeze reported file creation times. Helps Silent Hill: Shattered Memories

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -162,6 +162,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DetectDestBlendSquared", &flags_.DetectDestBlendSquared);
 	CheckSetting(iniFile, gameID, "BoostExactFramebufferMatch", &flags_.BoostExactFramebufferMatch);
 	CheckSetting(iniFile, gameID, "PersistentFramebuffers", &flags_.PersistentFramebuffers);
+	CheckSetting(iniFile, gameID, "FileCreatedTimeHack", &flags_.FileCreatedTimeHack);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -121,6 +121,7 @@ struct CompatFlags {
 	bool DetectDestBlendSquared;
 	bool BoostExactFramebufferMatch;
 	bool PersistentFramebuffers;
+	bool FileCreatedTimeHack;
 };
 
 struct VRCompat {

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -1220,14 +1220,18 @@ void ImGeDebuggerWindow::Draw(ImConfig &cfg, ImControl &control, GPUDebugInterfa
 			ImGui::Text("Total bytes to transfer: %d", gstate.getTransferWidth() * gstate.getTransferHeight() * gstate.getTransferBpp());
 		} else {
 			// Visualize prim by default (even if we're not directly on a prim instruction).
-			VirtualFramebuffer *vfb = rbViewer_.GetVFB(gpuDebug->GetFramebufferManagerCommon());
-			if (vfb) {
-				if (vfb->fbo) {
-					ImGui::Text("Framebuffer: %s", vfb->fbo->Tag());
-				} else {
-					ImGui::Text("Framebuffer");
+			FramebufferManagerCommon *fbMan = gpuDebug->GetFramebufferManagerCommon();
+			VirtualFramebuffer *vfb = nullptr;
+			if (fbMan) {
+				vfb = rbViewer_.GetVFB(fbMan);
+				if (vfb) {
+					if (vfb->fbo) {
+						ImGui::Text("Framebuffer: %s", vfb->fbo->Tag());
+					} else {
+						ImGui::Text("Framebuffer");
+					}
+					ImGui::SameLine();
 				}
-				ImGui::SameLine();
 			}
 			ImGui::SetNextItemWidth(200.0f);
 			ImGui::SliderFloat("Zoom", &previewZoom_, 0.125f, 2.f, "%.3f", ImGuiSliderFlags_Logarithmic);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2135,3 +2135,8 @@ NPUZ00062 = true  # Mahjong Artifacts (MJA)
 NPEZ00194 = true  # Mahjong Artifacts (MJA)
 NPEZ00003 = true  # MJA 2
 NPUZ00006 = true  # MJA 2
+
+[FileCreatedTimeHack]
+# Silent Hill: Shattered Memories does some strange checks of the file-created time, which won't pass on some platforms. See issue #13781
+ULES01352 = true
+ULUS10450 = true


### PR DESCRIPTION
Fixes the old issue #13781  . Thanks @fcrwr. 

The game does some very strange checks on file creation dates of savegames, which are not compatible with how Android Scoped Storage and some other platforms report these times. @fcrwr discovered that simply forcing creation times to zero passes these checks, so here we go, yet another compat flag.

(I've been thinking that maybe we should implement our own 100% PSP-compatible filesystem inside a big opaque file instead of using the host file system, but the drawbacks seem to outweigh the advantages...)