### PR TITLE
Assorted UI fixes

### DIFF
--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -55,6 +55,9 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 			if (layoutParams_->height == WRAP_CONTENT)
 				MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
 		}
+
+		// The below seems misguided and leads to wrong sized scrollviews. Need to investigate if it's needed somewhere...
+		/*
 		if (orientation_ == ORIENT_VERTICAL && vert.type != EXACTLY) {
 			float bestHeight = std::max(views_[0]->GetMeasuredHeight(), views_[0]->GetBounds().h);
 			if (vert.type == AT_MOST)
@@ -63,7 +66,7 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 			if (measuredHeight_ < bestHeight && layoutParams_->height < 0.0f) {
 				measuredHeight_ = bestHeight;
 			}
-		}
+		}*/
 	}
 }
 
@@ -276,8 +279,8 @@ void ScrollView::Draw(UIContext &dc) {
 	// If not anchored at the top of the screen exactly, and not scrolled to the top,
 	// draw a subtle drop shadow to indicate scrollability.
 
-	const float darkness = 0.4f;
-	if (bounds_.y > 0.0f && orientation_ == ORIENT_VERTICAL) {
+	constexpr float darkness = 0.4f;
+	if (shadows_ && bounds_.y > 0.0f && orientation_ == ORIENT_VERTICAL) {
 		float radius = 20.0f;
 
 		Bounds shadowBounds = bounds_;
@@ -292,8 +295,8 @@ void ScrollView::Draw(UIContext &dc) {
 	}
 
 	// Same at the bottom.
-	float y2 = dc.GetLayoutBounds().y2();
-	if (bounds_.y2() < y2 && orientation_ == ORIENT_VERTICAL) {
+	const float y2 = dc.GetLayoutBounds().y2();
+	if (shadows_ && bounds_.y2() < y2 && orientation_ == ORIENT_VERTICAL) {
 		float radius = 20.0f;
 
 		Bounds shadowBounds = bounds_;
@@ -483,10 +486,10 @@ float ScrollView::ClampedScrollPos(float pos) {
 		float maxPull = bounds_.h * 0.1f;
 		if (pos < 0.0f) {
 			float dist = std::min(-pos * (1.0f / bounds_.h), 1.0f);
-			pull_ = -(sqrt(dist) * maxPull);
+			pull_ = -(sqrtf(dist) * maxPull);
 		} else if (pos > scrollMax) {
 			float dist = std::min((pos - scrollMax) * (1.0f / bounds_.h), 1.0f);
-			pull_ = sqrt(dist) * maxPull;
+			pull_ = sqrtf(dist) * maxPull;
 		} else {
 			pull_ = 0.0f;
 		}

--- a/Common/UI/ScrollView.h
+++ b/Common/UI/ScrollView.h
@@ -44,6 +44,10 @@ public:
 		alignOpposite_ = alignOpposite;
 	}
 
+	void SetShadows(bool shadows) {
+		shadows_ = shadows;
+	}
+
 	NeighborResult FindScrollNeighbor(View *view, const Point2D &target, FocusDirection direction, NeighborResult best) override;
 
 private:
@@ -81,6 +85,7 @@ private:
 	bool alignOpposite_ = false;
 	bool draggingBob_ = false;
 	bool mouseHover_ = false;
+	bool shadows_ = true;
 
 	float barDragStart_ = 0.0f;
 	float barDragOffset_ = 0.0f;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -720,6 +720,10 @@ BootState PSP_Init(const CoreParameter &coreParam, std::string *error_string) {
 	}
 }
 
+BootState PollBootState() {
+	return g_bootState;
+}
+
 void PSP_Shutdown(bool success) {
 	// Reduce the risk for weird races with the Windows GE debugger.
 	gpuDebug = nullptr;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -636,6 +636,9 @@ bool PSP_InitStart(const CoreParameter &coreParam) {
 			}
 		}
 
+		// Use this to test exit-during-boot and other exceptional cases.
+		// sleep_ms(6000, "test");
+
 		g_CoreParameter.fileType = fileType;
 
 		// TODO: The reason we pass in g_CoreParameter.errorString here is that it's persistent -

--- a/Core/System.h
+++ b/Core/System.h
@@ -75,6 +75,9 @@ BootState PSP_InitUpdate(std::string *error_string);
 // Returns either BootState::Complete or BootState::Failed.
 BootState PSP_Init(const CoreParameter &coreParam, std::string *error_string);
 
+// The main thread needs to block on this in some situations, like losing the surface.
+BootState PollBootState();
+
 void PSP_Shutdown(bool success);
 
 FileLoader *PSP_LoadedFile();

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2874,7 +2874,7 @@ void FramebufferManagerCommon::NotifyRenderResized(const DisplayLayoutConfig &co
 	PSP_CoreParameter().renderHeight = h;
 	PSP_CoreParameter().renderScaleFactor = scaleFactor;
 
-	if (UpdateRenderSize(msaaLevel)) {
+	if (draw_ && UpdateRenderSize(msaaLevel)) {
 		draw_->StopThreads();
 		DestroyAllFBOs();
 		draw_->StartThreads();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1368,6 +1368,13 @@ void EmuScreen::CreateViews() {
 }
 
 void EmuScreen::deviceLost() {
+	// If we are currently in the middle of boot, we have to block here!
+	// Otherwise the boot thread will encounter draw_ == nullptr and weird stuff like that.
+	// We're doing this in a very ugly way for now.
+	while (PollBootState() == BootState::Booting) {
+		sleep_ms(100, "device-lost-during-boot");
+	}
+
 	UIScreen::deviceLost();
 
 	if (imguiInited_) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1648,11 +1648,15 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 
 	const DeviceOrientation orientation = GetDeviceOrientation();
 	const DisplayLayoutConfig &displayLayoutConfig = g_Config.GetDisplayLayoutConfig(orientation);
+	// We might have a bad viewport after RunEmulation, reset.
+	Viewport viewport{0.0f, 0.0f, (float)g_display.pixel_xres, (float)g_display.pixel_yres, 0.0f, 1.0f};
 
 	if (!skipBufferEffects_ && !ShouldRunEmulation(mode)) {
 		if (gpu) {
 			gpu->CopyDisplayToOutput(displayLayoutConfig);
 		}
+		draw->SetViewport(viewport);
+		draw->SetScissorRect(0, 0, g_display.pixel_xres, g_display.pixel_yres);
 		darken();
 		return screenRenderFlags;
 	}
@@ -1663,6 +1667,8 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		if (mode & ScreenRenderMode::TOP) {
 			checkPowerDown();
 		}
+		draw->SetViewport(viewport);
+		draw->SetScissorRect(0, 0, g_display.pixel_xres, g_display.pixel_yres);
 		renderUI();
 		return screenRenderFlags;
 	}
@@ -1672,8 +1678,6 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		screenRenderFlags = RunEmulation(true);
 	}
 
-	// We might have a bad viewport after RunEmulation, reset.
-	Viewport viewport{0.0f, 0.0f, (float)g_display.pixel_xres, (float)g_display.pixel_yres, 0.0f, 1.0f};
 	draw->SetViewport(viewport);
 
 	ProcessQueuedVKeys();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1744,9 +1744,19 @@ void TriggerRestart(const char *why, bool editThenRestore, const Path &gamePath)
 	System_RestartApp(param);
 }
 
+// From PauseScreen
+std::string GetConfirmExitMessage();
+
 void GameSettingsScreen::TriggerRestartOrDo(std::function<void()> callback) {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
-	screenManager()->push(new UI::MessagePopupScreen(di->T("Restart"), di->T("Changing this setting requires PPSSPP to restart."), di->T("Restart"), di->T("Cancel"), [=](bool yes) {
+
+	std::string confirmExitMessage = GetConfirmExitMessage();
+	if (!confirmExitMessage.empty()) {
+		confirmExitMessage = "\n\n" + confirmExitMessage;
+	}
+	confirmExitMessage = std::string(di->T("Changing this setting requires PPSSPP to restart.")) + confirmExitMessage;
+
+	screenManager()->push(new UI::MessagePopupScreen(di->T("Restart"), confirmExitMessage, di->T("Restart"), di->T("Cancel"), [=](bool yes) {
 		if (yes) {
 			TriggerRestart("GameSettingsScreen::RenderingBackendYes", editGameSpecificThenRestore_, gamePath_);
 		} else {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -782,6 +782,10 @@ int GetUnsavedProgressSeconds() {
 std::string GetConfirmExitMessage() {
 	std::string confirmMessage;
 
+	if (!PSP_IsInited()) {
+		return std::string();
+	}
+
 	int unsavedSeconds = GetUnsavedProgressSeconds();
 
 	// If RAIntegration has dirty info, ask for confirmation.

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -49,15 +49,11 @@ protected:
 	void OnVKey(VirtKey virtualKeyCode, bool down) override;
 
 private:
-	void CreateSavestateControls(UI::LinearLayout *viewGroup);
+	void CreateSavestateControls(UI::LinearLayout *viewGroup, UI::LinearLayout **extraRow);
 
 	void OnGameSettings(UI::EventParams &e);
 	void OnExit(UI::EventParams &e);
 	void OnReportFeedback(UI::EventParams &e);
-
-	void OnRewind(UI::EventParams &e);
-	void OnLoadUndo(UI::EventParams &e);
-	void OnLastSaveUndo(UI::EventParams &e);
 
 	void OnCreateConfig(UI::EventParams &e);
 	void OnDeleteConfig(UI::EventParams &e);

--- a/UI/Theme.cpp
+++ b/UI/Theme.cpp
@@ -88,29 +88,32 @@ static void LoadThemeInfo(const std::vector<Path> &directories) {
 		themeInfos.push_back(info);
 	};
 
-	for (size_t d = 0; d < directories.size(); d++) {
+	for (const auto &d : directories) {
 		std::vector<File::FileInfo> fileInfo;
-		g_VFS.GetFileListing(directories[d].c_str(), &fileInfo, "ini:");
+		g_VFS.GetFileListing(d.c_str(), &fileInfo, "ini:");
 
 		if (fileInfo.empty()) {
-			File::GetFilesInDir(directories[d], &fileInfo, "ini:");
+			File::GetFilesInDir(d, &fileInfo, "ini:");
 		}
 
-		for (size_t f = 0; f < fileInfo.size(); f++) {
+		for (const auto &f : fileInfo) {
 			IniFile ini;
 			bool success = false;
-			if (fileInfo[f].isDirectory)
+			if (f.isDirectory) {
 				continue;
+			}
 
-			Path name = fileInfo[f].fullName;
-			Path path = directories[d];
+			Path name(f.fullName);
+			Path path = d;
 			// Hack around Android VFS path bug. really need to redesign this.
-			if (name.ToString().substr(0, 7) == "assets/")
+			if (name.ToString().substr(0, 7) == "assets/") {
 				name = Path(name.ToString().substr(7));
-			if (path.ToString().substr(0, 7) == "assets/")
+			}
+			if (path.ToString().substr(0, 7) == "assets/") {
 				path = Path(path.ToString().substr(7));
+			}
 
-			if (ini.LoadFromVFS(g_VFS, name.ToString()) || ini.Load(fileInfo[f].fullName)) {
+			if (ini.LoadFromVFS(g_VFS, name.ToString()) || ini.Load(f.fullName)) {
 				success = true;
 			}
 
@@ -245,7 +248,7 @@ void UpdateTheme() {
 	ui_theme.popupSliderFocusedColor = themeInfo.uPopupSliderFocusedColor;
 }
 
-UI::Theme *GetTheme() {
+const UI::Theme *GetTheme() {
 	return &ui_theme;
 }
 

--- a/UI/Theme.h
+++ b/UI/Theme.h
@@ -27,4 +27,4 @@ void ReloadAllThemeInfo();
 
 std::vector<std::string> GetThemeInfoNames();
 void UpdateTheme();
-UI::Theme *GetTheme();
+const UI::Theme *GetTheme();


### PR DESCRIPTION
Another pile of UI fixes, including a window resize fix on the pause screen, positioning of the save state undo/redo buttons, and fix a crash if you tried to exit during loading.

Also improves the native text input popup.

Takes care of a few points from #21223.