### PR TITLE
UI fixes, add GPU "overclock" for Outrun

### DIFF
--- a/Common/Input/GestureDetector.cpp
+++ b/Common/Input/GestureDetector.cpp
@@ -46,10 +46,12 @@ TouchInput GestureDetector::Update(const TouchInput &touch, const Bounds &bounds
 		p.lastY = touch.y;
 	}
 
+	const float dragThreshold = 5.0f / g_display.dpi_scale_y;
+
 	if (p.distanceY > p.distanceX) {
 		if (p.down) {
 			double timeDown = time_now_d() - p.downTime;
-			if (!p.active && p.distanceY * timeDown > 3) {
+			if (!p.active && p.distanceY > dragThreshold) {
 				p.active |= GESTURE_DRAG_VERTICAL;
 				// Kill the drag. TODO: Only cancel the drag in one direction.
 				TouchInput inp2 = touch;
@@ -64,7 +66,7 @@ TouchInput GestureDetector::Update(const TouchInput &touch, const Bounds &bounds
 	if (p.distanceX > p.distanceY) {
 		if (p.down) {
 			double timeDown = time_now_d() - p.downTime;
-			if (!p.active && p.distanceX * timeDown > 3) {
+			if (!p.active && p.distanceX > dragThreshold) {
 				p.active |= GESTURE_DRAG_HORIZONTAL;
 				// Kill the drag. TODO: Only cancel the drag in one direction.
 				TouchInput inp2 = touch;

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -163,6 +163,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "BoostExactFramebufferMatch", &flags_.BoostExactFramebufferMatch);
 	CheckSetting(iniFile, gameID, "PersistentFramebuffers", &flags_.PersistentFramebuffers);
 	CheckSetting(iniFile, gameID, "FileCreatedTimeHack", &flags_.FileCreatedTimeHack);
+	CheckSetting(iniFile, gameID, "FastEmulatedGPU", &flags_.FastEmulatedGPU);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -122,6 +122,7 @@ struct CompatFlags {
 	bool BoostExactFramebufferMatch;
 	bool PersistentFramebuffers;
 	bool FileCreatedTimeHack;
+	bool FastEmulatedGPU;
 };
 
 struct VRCompat {

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -132,6 +132,10 @@ void SceKernelVplHeader::Init(u32 ptr, u32 size) {
 
 u32 SceKernelVplHeader::Allocate(u32 size) {
 	u32 allocBlocks = ((size + 7) / 8) + 1;
+	if (!nextFreeBlock_.IsValid()) {
+		ERROR_LOG(Log::sceKernel, "VPL: nextFreeBlock invalid.");
+		return (u32)-1;
+	}
 	auto prev = nextFreeBlock_;
 	do {
 		auto b = prev->next;

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -100,8 +100,7 @@ static u32 JitMemCheck(u32 pc) {
 	return coreState == CORE_RUNNING_CPU || coreState == CORE_NEXTFRAME ? 0 : 1;
 }
 
-namespace MIPSComp
-{
+namespace MIPSComp {
 using namespace ArmGen;
 using namespace ArmJitConstants;
 
@@ -244,7 +243,10 @@ void ArmJit::CompileDelaySlot(int flags) {
 void ArmJit::Compile(u32 em_address) {
 	PROFILE_THIS_SCOPE("jitc");
 
-	// INFO_LOG(Log::JIT, "Compiling at %08x", em_address);
+	if (!Memory::IsValid4AlignedAddress(em_address)) {
+		Core_ExecException(em_address, em_address, ExecExceptionType::JUMP);
+		return;
+	}
 
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
 		ClearCache();

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -242,13 +242,18 @@ void Arm64Jit::CompileDelaySlot(int flags) {
 
 void Arm64Jit::Compile(u32 em_address) {
 	PROFILE_THIS_SCOPE("jitc");
+
+	if (!Memory::IsValid4AlignedAddress(em_address)) {
+		Core_ExecException(em_address, em_address, ExecExceptionType::JUMP);
+		return;
+	}
+
 	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
 		INFO_LOG(Log::JIT, "Space left: %d", (int)GetSpaceLeft());
 		ClearCache();
 	}
 
 	BeginWrite(JitBlockCache::MAX_BLOCK_INSTRUCTIONS * 16);
-
 
 	// To debug really wacky JIT issues, it can be a good idea to bisect the block number,
 	// and disable parts of the jit using jo.disableFlags for certain ranges of blocks.

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -300,13 +300,14 @@ void Jit::EatInstruction(MIPSOpcode op) {
 
 void Jit::Compile(u32 em_address) {
 	PROFILE_THIS_SCOPE("jitc");
-	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
-		ClearCache();
-	}
 
-	if (!Memory::IsValidAddress(em_address) || (em_address & 3) != 0) {
+	if (!Memory::IsValid4AlignedAddress(em_address)) {
 		Core_ExecException(em_address, em_address, ExecExceptionType::JUMP);
 		return;
+	}
+
+	if (GetSpaceLeft() < 0x10000 || blocks.IsFull()) {
+		ClearCache();
 	}
 
 	// Sometimes we compile fairly large blocks, although it's uncommon.

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1290,7 +1290,10 @@ bail:
 
 	int cycles = vertexCost_ * totalVertCount;
 	gpuStats.vertexGPUCycles += cycles;
-	cyclesExecuted += cycles;
+
+	if (!PSP_CoreParameter().compat.flags().FastEmulatedGPU) {
+		cyclesExecuted += cycles;
+	}
 }
 
 void GPUCommonHW::Execute_Bezier(u32 op, u32 diff) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -311,7 +311,7 @@ static void EmuThreadFunc() {
 			ERROR_LOG(Log::System, "No activity, clearing commands");
 			while (!frameCommands.empty())
 				frameCommands.pop();
-			return;
+			break;
 		}
 		// Still under lock here.
 		ProcessFrameCommands(env);
@@ -1635,9 +1635,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_pushCameraImageAndroid(
 // Call this under frameCommandLock.
 static void ProcessFrameCommands(JNIEnv *env) {
 	while (!frameCommands.empty()) {
-		FrameCommand frameCmd;
-		frameCmd = frameCommands.front();
-		frameCommands.pop();
+		const FrameCommand &frameCmd = frameCommands.front();
 
 		DEBUG_LOG(Log::System, "frameCommand '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
 
@@ -1646,6 +1644,8 @@ static void ProcessFrameCommands(JNIEnv *env) {
 		env->CallVoidMethod(ppssppActivity, postCommand, cmd, param);
 		env->DeleteLocalRef(cmd);
 		env->DeleteLocalRef(param);
+
+		frameCommands.pop();
 	}
 }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -847,6 +847,7 @@ retry:
 			INFO_LOG(Log::System, "Failed to initialize Vulkan, switching to OpenGL");
 			g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
 			SetGPUBackend(GPUBackend::OPENGL);
+			delete ctx;
 			goto retry;
 		} else {
 			graphicsContext = ctx;
@@ -1693,6 +1694,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_PpssppActivity_requestExitVulkanR
 }
 
 // TODO: Merge with the Win32 EmuThread and so on, and the Java EmuThread?
+// This function must release the window reference.
 static void VulkanEmuThread(ANativeWindow *wnd) {
 	SetCurrentThreadName("EmuThread");
 
@@ -1703,6 +1705,7 @@ static void VulkanEmuThread(ANativeWindow *wnd) {
 		ERROR_LOG(Log::G3D, "runVulkanRenderLoop: Tried to enter without a created graphics context.");
 		renderLoopRunning = false;
 		exitRenderLoop = false;
+		ANativeWindow_release(wnd);
 		return;
 	}
 
@@ -1710,6 +1713,7 @@ static void VulkanEmuThread(ANativeWindow *wnd) {
 		WARN_LOG(Log::G3D, "runVulkanRenderLoop: ExitRenderLoop requested at start, skipping the whole thing.");
 		renderLoopRunning = false;
 		exitRenderLoop = false;
+		ANativeWindow_release(wnd);
 		return;
 	}
 
@@ -1729,6 +1733,7 @@ static void VulkanEmuThread(ANativeWindow *wnd) {
 		delete graphicsContext;
 		graphicsContext = nullptr;
 		renderLoopRunning = false;
+		ANativeWindow_release(wnd);
 		return;
 	}
 
@@ -1764,6 +1769,7 @@ static void VulkanEmuThread(ANativeWindow *wnd) {
 	graphicsContext->ShutdownFromRenderThread();
 	renderLoopRunning = false;
 	exitRenderLoop = false;
+	ANativeWindow_release(wnd);
 
 	WARN_LOG(Log::G3D, "Render loop function exited.");
 }
@@ -1798,15 +1804,15 @@ Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameInfo(JNIEnv * env, jclass, jobj
 	if (info) {
 		INFO_LOG(Log::System, "GetInfo successful, waiting");
 
-		// Wait for both name and icon
-		int attempts = 1000;
+		// Wait for both name and icon for a second.
+		int attempts = 100;
 		while ((!info->Ready(GameInfoFlags::PARAM_SFO) || !info->Ready(GameInfoFlags::ICON)) && attempts > 0) {
-			sleep_ms(1, "info-icon-poll");
+			sleep_ms(10, "info-icon-poll");
 			attempts--;
 		}
 		INFO_LOG(Log::System, "Done waiting");
 
-		if (info->fileType != IdentifiedFileType::UNKNOWN) {
+		if (attempts > 0 && info->fileType != IdentifiedFileType::UNKNOWN) {
 			// Get the game title
 			gameName = info->GetTitle();
 			if (gameName.length() > strlen("The ") && startsWithNoCase(gameName, "The ")) {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2140,3 +2140,10 @@ NPUZ00006 = true  # MJA 2
 # Silent Hill: Shattered Memories does some strange checks of the file-created time, which won't pass on some platforms. See issue #13781
 ULES01352 = true
 ULUS10450 = true
+
+[FastEmulatedGPU]
+# Crude hack that makes the emulated GPU appear a lot faster, removing internal slowdowns in games. This makes Outrun stick to 60fps.
+# Outrun 2006: Coast to Coast - issue #11358 (car reflections)
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true


### PR DESCRIPTION
Outrun 2006 slows down a bit on the real PSP, but there's not really much reason to keep this behavior under emulation (if a game is GPU limited on PSP, especially vertex count like this one, it's very likely not going to be under emulation..)

So let's pretend that our GPU can process vertices really fast.

Also, fix a bunch of various bugs, and make long-pressing stuff in scroll views a little less awkward.