### PR TITLE
add missing null check during actOnDeathPacket

### DIFF
--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -1083,7 +1083,7 @@ void actOnDeathPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * se
 	// Find Peer
 	SceNetAdhocMatchingMemberInternal * deadkid = findPeer(context, &mac);
 
-	if (deadkid->state != PSP_ADHOC_MATCHING_PEER_CHILD) {
+	if (deadkid == NULL || deadkid->state != PSP_ADHOC_MATCHING_PEER_CHILD) {
 		// Invalid Sibling
 		return;
 	}


### PR DESCRIPTION
It is not impossible for deadkid to not be tracked, so we have to null check that