### PR TITLE
ImMemView fixes

### DIFF
--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -1104,7 +1104,7 @@ void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &
 			ImGui::SetKeyboardFocusHere(0);
 			focusSearchValueInput_ = false;
 		}
-		if (ImGui::InputText("data", searchStr_, IM_ARRAYSIZE(searchStr_), ImGuiInputTextFlags_EnterReturnsTrue) || ImGui::Button("Search")) {
+		if (ImGui::InputText("data", searchStr_, IM_ARRAYSIZE(searchStr_), ImGuiInputTextFlags_EnterReturnsTrue) | ImGui::Button("Search")) {
 			memView_.initSearch(searchStr_, selectedSearchType_);
 			// TODO: transfer focus on the memview.
 		}

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -21,7 +21,7 @@
 #include "UI/ImDebugger/ImDebugger.h"
 #include "UI/ImDebugger/ImMemView.h"
 
-static const char* searchtypes[] = {"u8", "u16", "u32", "u64", "float", "string", "string16","bytesequence"};
+static const char* searchtypes[] = {"u8", "u16", "u32", "u64", "float", "string", "string16", "bytesequence"};
 
 ImMemView::ImMemView() {
 	windowStart_ = curAddress_;
@@ -156,7 +156,7 @@ void ImMemView::Draw(ImDrawList *drawList) {
 			const ImColor zeroColor = 0x888888ff;
 			const ImColor searchResBg = 0xFF108010;
 
-			if (address + j >= selectRangeStart_ && address + j < selectRangeEnd_ && !memSearch_.searching) {
+			if (address + j >= selectRangeStart_ && address + j < selectRangeEnd_) {
 				if (asciiSelected_) {
 					hexBGCol = secondarySelBg;
 					hexTextCol = secondarySelFg;
@@ -174,7 +174,7 @@ void ImMemView::Draw(ImDrawList *drawList) {
 					continueRect = true;
 				}
 			} else if (!tag.empty()) {
-				if (memSearch_.status == SEARCH_OK && address+j>= memSearch_.matchAddress && address +j < memSearch_.matchAddress + memSearch_.data.size() && !memSearch_.searching) {
+				if (memSearch_.status == SEARCH_OK && address+j >= memSearch_.matchAddress && address +j < memSearch_.matchAddress + memSearch_.data.size()) {
 					hexBGCol = searchResBg;
 				} else {
 					hexBGCol = pickTagColor(tag);
@@ -860,7 +860,6 @@ MemorySearchStatus ImMemView::search(bool continueSearch) {
 	memoryAreas.emplace_back(PSP_GetKernelMemoryBase(), PSP_GetUserMemoryEnd());
 	memoryAreas.emplace_back(PSP_GetScratchpadMemoryBase(), PSP_GetScratchpadMemoryEnd());
 
-	memSearch_.searching = true;
 	// NOTE:
 	// this currently stops at the first found value
 	// we could look for all matches
@@ -887,14 +886,8 @@ MemorySearchStatus ImMemView::search(bool continueSearch) {
 		int index = memSearch_.searchAddress - memSearch_.segmentStart;
 		int endIndex = memSearch_.segmentEnd - memSearch_.segmentStart - size;
 		while (index < endIndex) {
-			// cancel search
-			if ((index % 256) == 0 && ImGui::IsKeyDown(ImGuiKey_Escape)) {
-				memSearch_.searching = false;
-				return SEARCH_CANCEL;
-			}
 			if (memcmp(&dataPointer[index], data, size) == 0) {
 				memSearch_.matchAddress = index + memSearch_.segmentStart;
-				memSearch_.searching = false;
 				gotoAddr(memSearch_.matchAddress);
 				return SEARCH_OK;
 			}
@@ -903,7 +896,6 @@ MemorySearchStatus ImMemView::search(bool continueSearch) {
 	}
 
 	statusMessage_ = "Not found";
-	memSearch_.searching = false;
 	return SEARCH_NOTFOUND;
 }
 

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -1180,7 +1180,9 @@ void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &
 	StatusBar(memView_.StatusMessage());
 
 	ImGui::End();
-	ProcessKeyboardShortcuts();
+	if (!ImGui::GetIO().WantTextInput) {
+		ProcessKeyboardShortcuts();
+	}
 }
 
 const char *ImMemWindow::Title(int index) {

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -81,15 +81,13 @@ private:
 	struct MemorySearch{
 		// keep search related variables grouped
 		std::vector<u8> data;
-		uint8_t* fast_data;
-		size_t fast_size;
 		u32 searchAddress;
-		u32 matchAddress;
+		u32 matchAddress = 0xFFFFFFFF;
 		u32 segmentStart;
 		u32 segmentEnd;
 		bool searching;
-		MemorySearchStatus status;
-	} memSearch_;
+		MemorySearchStatus status = SEARCH_INITIAL;
+	} memSearch_{};
 
 	std::vector<u8> byteClipboard_;
 	void CopyToByteClipboard();
@@ -175,6 +173,9 @@ private:
 // Corresponds to the CMemView dialog
 class ImMemWindow {
 public:
+	ImMemWindow() {
+		searchStr_[0] = 0;
+	}
 	void Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &control, int index);
 	ImMemView &View() {
 		return memView_;

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -18,8 +18,9 @@ enum CommonToggles {
 	Off,
 };
 
-enum MemorySearchStatus {SEARCH_PSP_NOT_INIT=-1, SEARCH_INITIAL, SEARCH_OK, SEARCH_NOTFOUND, SEARCH_CANCEL};
-enum MemorySearchType {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT_32, STRING, STRING_16,  BYTE_SEQ};
+enum MemorySearchStatus {SEARCH_PSP_NOT_INIT=-1, SEARCH_INITIAL, SEARCH_OK, SEARCH_NOTFOUND};
+enum MemorySearchType {BITS_8, BITS_16, BITS_32, BITS_64, FLOAT_32, STRING, STRING_16, BYTE_SEQ};
+
 class ImMemView {
 public:
 	ImMemView();
@@ -85,7 +86,6 @@ private:
 		u32 matchAddress = 0xFFFFFFFF;
 		u32 segmentStart;
 		u32 segmentEnd;
-		bool searching;
 		MemorySearchStatus status = SEARCH_INITIAL;
 	} memSearch_{};
 
@@ -210,7 +210,6 @@ private:
 	char searchStr_[512];
 	// store the state of the search form
 	ImMemView memView_;
-	char searchTerm_[64]{};
 
 	u32 gotoAddr_ = 0x08800000;
 };


### PR DESCRIPTION
1. Open a memory window, focus another debugger window, press `n` => segfault from trying to read from uninitialized pointer `fast_data`
2. Open memory search, focus 'Go to address:' input field, try to type address containing `f` => as soon as `f` typed, active text input field loses focus, search input field gets focused instead.
3. Flickering when pressing enter in search input widget, because code short-circuits condition and never draws 'Search' button
4. `memSearch_.searching` is never true when its value is checked
5. Can't really cancel the search this way, search happens on the ui thread, blocking it, ImGui::IsKeyPressed just checks internal array.