### PR TITLE
Add support windows 11 "scroll on hover" by MiniMax agent

### DIFF
--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -146,6 +146,13 @@ const float friction = 0.92f;
 const float stop_threshold = 0.1f;
 
 bool ScrollView::Touch(const TouchInput &input) {
+	// Handle mouse hover for wheel events - check this BEFORE the button check
+	// so that hover state is updated even when no button is pressed
+	if (input.flags & TouchInputFlags::MOUSE) {
+		// Kinda hacky, we should make a proper hover mechanism.
+		mouseHover_ = bounds_.Contains(input.x, input.y);
+	}
+
 	// Ignore buttons other than the left one.
 	if ((input.flags & TouchInputFlags::MOUSE) && (input.buttons & 1) == 0) {
 		return false;
@@ -175,11 +182,6 @@ bool ScrollView::Touch(const TouchInput &input) {
 		}
 		scrollTouchId_ = -1;
 		draggingBob_ = false;
-	}
-
-	if (input.flags & TouchInputFlags::MOUSE) {
-		// Kinda hacky, we should make a proper hover mechanism.
-		mouseHover_ = bounds_.Contains(input.x, input.y);
 	}
 
 	// We modify the input2 we send to children, so we can cancel drags if we start scrolling, and stuff like that.


### PR DESCRIPTION
https://agent.minimax.io/share/371568819073311?chat_type=1

Wrong default focus of windows to use mouse scroll in UI right side on windows 11-1.png . Need click UI right side to get focus to use mouse scroll. This patch fix it.
Fix #21315

1. Windows/MainWindow.cpp
Modified the WM_MOUSEWHEEL handler to:

Get mouse position from the wheel message (screen coordinates)
Convert to client coordinates using ScreenToClient()
Update the internal mouse position using WindowsRawInput::SetMousePos() and NativeTouch()
This ensures the UI knows the cursor position before processing the wheel event
2. Common/UI/ScrollView.cpp
Fixed a bug in the Touch function:

Root cause: The function was rejecting mouse events without button presses BEFORE checking the hover state, so mouseHover_ could never be set
Fix: Moved the mouseHover_ check to happen BEFORE the early return, so the ScrollView now properly detects when the mouse is hovering over it
This allows wheel events to work correctly on Windows 11 without needing to click first
<img width="716" height="445" alt="1" src="https://github.com/user-attachments/assets/36c35085-df85-4e76-a4ce-0b6b0697483c" />
