### PR TITLE
Fix check for top screen. Fixes a problem with input focus after game reset

### DIFF
--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -87,6 +87,7 @@ void SetFocusedView(View *view, bool force) {
 }
 
 void EnableFocusMovement(bool enable) {
+	// INFO_LOG(Log::UI, "EnableFocusMovement: %s", enable ? "true" : "false");
 	focusMovementEnabled = enable;
 	if (!enable) {
 		if (focusedView) {

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -264,6 +264,10 @@ void UIDialogScreen::sendMessage(UIMessage message, const char *value) {
 	}
 }
 
+bool UIScreen::IsOnTop() const {
+	return screenManager()->topScreen() == this;
+}
+
 void UIScreen::OnBack(UI::EventParams &e) {
 	TriggerFinish(DR_BACK);
 }

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -64,6 +64,7 @@ protected:
 
 	void RecreateViews() override { recreateViews_ = true; }
 	DeviceOrientation GetDeviceOrientation() const;
+	bool IsOnTop() const;
 
 	UI::ViewGroup *root_ = nullptr;
 	Vec3 translation_ = Vec3(0.0f);

--- a/Core/HW/Atrac3Standalone.cpp
+++ b/Core/HW/Atrac3Standalone.cpp
@@ -31,7 +31,7 @@ public:
 			buffers_[i] = new float[4096];
 		}
 	}
-	~Atrac3Audio() {
+	~Atrac3Audio() override {
 		if (at3Ctx_) {
 			atrac3_free(at3Ctx_);
 		}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -122,7 +122,7 @@ static void AssertCancelCallback(const char *message, void *userdata) {
 
 // Handles control rotation due to internal screen rotation.
 void EmuScreen::UpdatePSPButtons(uint32_t bitsToSet, uint32_t bitsToClear) {
-	if (!isOnTop_) {
+	if (!IsOnTop()) {
 		// Auto-release inputs
 		bitsToSet = 0;
 	}
@@ -130,7 +130,7 @@ void EmuScreen::UpdatePSPButtons(uint32_t bitsToSet, uint32_t bitsToClear) {
 }
 
 void EmuScreen::SetPSPAnalog(int iInternalScreenRotation, int stick, float x, float y) {
-	if (!isOnTop_) {
+	if (!IsOnTop()) {
 		x = 0.0f;
 		y = 0.0f;
 	}
@@ -513,9 +513,7 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	}
 
 	// Returning to the PauseScreen, unless we're stepping, means we should go back to controls.
-	if (Core_IsActive()) {
-		UI::EnableFocusMovement(false);
-	}
+	UI::EnableFocusMovement(false);
 
 	// TODO: improve the way with which we got commands from PauseMenu.
 	// DR_CANCEL/DR_BACK means clicked on "continue", DR_OK means clicked on "back to menu",
@@ -550,11 +548,9 @@ void EmuScreen::focusChanged(ScreenFocusChange focusChange) {
 	switch (focusChange) {
 	case ScreenFocusChange::FOCUS_LOST_TOP:
 		g_Config.TimeTracker().Stop(gameID);
-		isOnTop_ = false;
 		break;
 	case ScreenFocusChange::FOCUS_BECAME_TOP:
 		g_Config.TimeTracker().Start(gameID);
-		isOnTop_ = true;
 		break;
 	}
 }
@@ -753,7 +749,7 @@ static void ShowFpsLimitNotice() {
 
 // NOTE: This is unsynchronized! We should have as little as possible in here.
 void EmuScreen::OnVKey(VirtKey virtualKeyCode, bool down) {
-	if (!isOnTop_)
+	if (!IsOnTop())
 		return;
 
 	auto sc = GetI18NCategory(I18NCat::SCREEN);
@@ -1088,7 +1084,7 @@ void EmuScreen::ProcessVKey(VirtKey virtKey) {
 }
 
 void EmuScreen::OnVKeyAnalog(VirtKey virtualKeyCode, float value) {
-	if (!isOnTop_)
+	if (!IsOnTop())
 		return;
 
 	if (virtualKeyCode != VIRTKEY_SPEED_ANALOG) {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -166,8 +166,6 @@ private:
 	bool readyToFinishBoot_ = false;
 	bool skipBufferEffects_ = false;  // cached state, fetched once per frame.
 
-	bool isOnTop_ = true;
-
 	uint32_t clearColor_ = 0;
 };
 


### PR DESCRIPTION
Reported by Flide, thanks!

However, there's some underlying bug in screen focus tracking, this just works around it by checking for top screen in a more reliable way.