### PR TITLE
Show ffmpeg version in sysinfo, add back "Show PSP" button

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -63,7 +63,7 @@ namespace
 
 	bool ReadPSPFile(const std::string &filename, u8 **data, s64 dataSize, s64 *readSize)
 	{
-		int handle = pspFileSystem.OpenFile(filename, FILEACCESS_READ);
+		int handle = pspFileSystem.OpenFile(filename, (FileAccess)((int)FILEACCESS_READ | (int)FILEACCESS_PPSSPP_QUIET));
 		if (handle < 0)
 			return false;
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -1128,3 +1128,19 @@ s64 MediaEngine::getLastTimeStamp() {
 		return 0;
 	return m_lastTimeStamp - m_firstTimeStamp;
 }
+
+std::string GetFFMPEGVersion() {
+#ifdef USE_FFMPEG
+	std::string comment = "";
+	if (LIBAVFORMAT_VERSION_MAJOR == 57 && LIBAVFORMAT_VERSION_MINOR == 25 && LIBAVFORMAT_VERSION_MICRO == 100) {
+		// This is the bundled version.
+		comment = " (bundled)";
+	} else {
+		comment = " (system)";
+	}
+	return StringFromFormat("%d.%d.%d (%s)%s",
+		LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO, av_version_info(), comment.c_str());
+#else
+	return "N/A";
+#endif
+}

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -155,3 +155,5 @@ private:
 	int m_mpegheaderReadPos = 0;
 	int m_mpegheaderSize = 0;
 };
+
+std::string GetFFMPEGVersion();

--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ What's new in 1.20
     - Assorted improvements ([#20778], [#20774])
   - Android
     - The minimum Android version has been raised for technical reasons, KitKat is no longer supported ([#19658])
+    - Support for Android devices with 16KB page size. This is a technical change, required by Google Play, that unfortunately forced us to drop compatibility with the very oldest devices (Android < 5). ([#20788])
     - Shortcut widgets can now be created even if the app isn't running ([#20798])
-    - Support for Android devices with 16K page size. This is a technical change, required by Google Play, that unfortunately forced us to drop compatibility with the very oldest devices. ([#20788])
     - Removed support for classic Moga controllers, these were only a thing on early Android ([#20762])
   - iOS
-    - Support for portrait screen rotation (wasn't available previously).
+    - Add support for screen rotation
   - Linux
     - Loongarch improvements by KatyushaScarlet ([#20683], [#20644], [#20599], [#20594]), text rendering improvements ([#21163])
     - SDL fullscreen problems fixed ([#21300], more)

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -240,6 +240,9 @@ void ControlMappingScreen::CreateSettingsViews(UI::ViewGroup *parent) {
 	if (!KeyMap::HasBuiltinController(sysName) && KeyMap::GetSeenPads().size()) {
 		parent->Add(new Choice(km->T("Autoconfigure")))->OnClick.Handle(this, &ControlMappingScreen::OnAutoConfigure);
 	}
+	parent->Add(new Choice(km->T("Show PSP")))->OnClick.Add([this](UI::EventParams &params) {
+		screenManager()->push(new VisualMappingScreen(gamePath_));
+	});
 	parent->Add(new CheckBox(&g_Config.bAllowMappingCombos, km->T("Allow combo mappings")));
 	parent->Add(new CheckBox(&g_Config.bStrictComboOrder, km->T("Strict combo input order")));
 }

--- a/UI/SystemInfoScreen.cpp
+++ b/UI/SystemInfoScreen.cpp
@@ -331,6 +331,9 @@ void SystemInfoScreen::CreateDeviceInfoTab(UI::LinearLayout *deviceSpecs) {
 	}
 }
 
+// From MediaEngine.cpp.
+std::string GetFFMPEGVersion();
+
 void SystemInfoScreen::CreateStorageTab(UI::LinearLayout *storage) {
 	using namespace UI;
 
@@ -361,39 +364,56 @@ void SystemInfoScreen::CreateBuildConfigTab(UI::LinearLayout *buildConfig) {
 	auto si = GetI18NCategory(I18NCat::SYSINFO);
 
 	buildConfig->Add(new ItemHeader(si->T("Build Configuration")));
+	std::string installerName = System_GetProperty(SYSPROP_INSTALLER_NAME);
+	if (installerName.empty()) {
+		installerName = "N/A";
+	}
+	std::vector<std::pair<std::string, std::string>> buildConfigItems = {
+		{"GIT_VERSION", PPSSPP_GIT_VERSION},
 #ifdef ANDROID_LEGACY
-	buildConfig->Add(new InfoItem("ANDROID_LEGACY", ""));
+		{"ANDROID_LEGACY", ""},
 #endif
 #ifdef _DEBUG
-	buildConfig->Add(new InfoItem("_DEBUG", ""));
+		{"_DEBUG", ""},
 #else
-	buildConfig->Add(new InfoItem("NDEBUG", ""));
+		{"NDEBUG", ""},
 #endif
 #ifdef USE_ASAN
-	buildConfig->Add(new InfoItem("USE_ASAN", ""));
+		{"USE_ASAN", ""},
 #endif
 #ifdef USING_GLES2
-	buildConfig->Add(new InfoItem("USING_GLES2", ""));
+		{"USING_GLES2", ""},
 #endif
 #ifdef MOBILE_DEVICE
-	buildConfig->Add(new InfoItem("MOBILE_DEVICE", ""));
+		{"MOBILE_DEVICE", ""},
 #endif
 #if PPSSPP_ARCH(ARMV7S)
-	buildConfig->Add(new InfoItem("ARMV7S", ""));
+		{"ARMV7S", ""},
 #endif
+		{std::string(si->T("ABI")), GetCompilerABI()},
 #if PPSSPP_ARCH(ARM_NEON)
-	buildConfig->Add(new InfoItem("ARM_NEON", ""));
+		{"ARM_NEON", ""},
 #endif
 #ifdef _M_SSE
-	buildConfig->Add(new InfoItem("_M_SSE", StringFromFormat("0x%x", _M_SSE)));
+		{"_M_SSE", StringFromFormat("0x%x", _M_SSE)},
 #endif
-	if (System_GetPropertyBool(SYSPROP_APP_GOLD)) {
-		buildConfig->Add(new InfoItem("GOLD", ""));
-	}
+		{"FFMPEG", GetFFMPEGVersion()},
+		{std::string(si->T("Installer")), installerName},
+	};
 
-	// Not really build config, but similar.
-	std::string installerName = System_GetProperty(SYSPROP_INSTALLER_NAME);
-	buildConfig->Add(new InfoItem(si->T("Installer"), installerName));
+	buildConfig->Add(new Choice(si->T("Copy summary to clipboard"), ImageID("I_FILE_COPY")))->OnClick.Add([buildConfigItems](UI::EventParams &e) {
+		std::string buildConfigStr;
+		for (auto &item : buildConfigItems) {
+			buildConfigStr += item.first + ": " + item.second + "\n";
+		}
+		System_CopyStringToClipboard(buildConfigStr.c_str());
+		auto di = GetI18NCategory(I18NCat::DIALOG);
+		g_OSD.Show(OSDType::MESSAGE_INFO, ApplySafeSubstitutions(di->T("Copied to clipboard: %1"), di->T("Build Configuration")), 0.0f, "copyToClip");
+	});
+
+	for (auto &item : buildConfigItems) {
+		buildConfig->Add(new InfoItem(item.first, item.second));
+	}
 }
 
 void SystemInfoScreen::CreateCPUExtensionsTab(UI::LinearLayout *cpuExtensions) {


### PR DESCRIPTION
The "Show PSP" screen in control mapping is not the most useful screen, but let's not remove stuff by mistake, I don't remember deliberatly deleting the button....