### PR TITLE
Fix font rendering after window resizing on SDL(linux)

### DIFF
--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -431,6 +431,7 @@ void TextDrawerSDL::ClearFonts() {
 	// We wipe all the maps, including fontMap_.
 	fontMap_.clear();
 	fallbackFonts_.clear();
+	glyphFallbackFontIndex_.clear();
 }
 
 #endif


### PR DESCRIPTION
I'm using Xubuntu 24.04.4 LTS and building ppsspp with SDL (built via ./b.sh with default options).

NOTICE: This issue is fixed by Claude and tested by me.

Steps to reproduce:

1. Build and launch PPSSPP with the default SDL frontend
2. Observe that the UI font renders correctly at the default window size
3. Maximize the window
4. Restore the window back to its original size

Expected behavior: Font continues to render correctly after restore.

Actual behavior: All UI text that relies on fallback fonts (e.g. CJK characters or other non-ASCII glyphs) renders as squares/rectangles after the window is restored.

<img width="910" height="599" alt="image" src="https://github.com/user-attachments/assets/5cae7022-5c73-40cb-ac03-547fd000392c" />



Root Cause:
When the window is resized, the DPI scale changes, which triggers TextDrawer::OncePerFrame() to call ClearCache() and ClearFonts() to rebuild fonts at the new DPI.

In TextDrawerSDL::ClearFonts() (Common/Render/Text/draw_text_sdl.cpp), fontMap_ and fallbackFonts_ are both cleared, but glyphFallbackFontIndex_ is not cleared.

After the fonts are rebuilt, FindFallbackFonts() looks up glyphFallbackFontIndex_ first and finds stale cached indices from before the clear. Since fallbackFonts_ has been emptied and not yet fully repopulated, the stale index either points to nothing or fails the bounds check (fallbackFont < (int)fallbackFonts_.size()), causing the fallback font lookup to silently fail. Characters not covered by the primary font then render as squares.