### PR TITLE
Adds one more image size (128x128) option for DXT1 block skipping in texture replacement

### DIFF
--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -308,6 +308,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	options->Get("reduceHash", &reduceHash_);
 	options->Get("ignoreMipmap", &ignoreMipmap_);
 	options->Get("skipLastDXT1Blocks128x64", &skipLastDXT1Blocks128x64_);
+	options->Get("skipLastDXT1Blocks128x128", &skipLastDXT1Blocks128x128_);
 	if (reduceHash_ && hash_ == ReplacedTextureHash::QUICK) {
 		reduceHash_ = false;
 		ERROR_LOG(Log::TexReplacement, "Texture Replacement: reduceHash option requires safer hash, use xxh32 or xxh64 instead.");
@@ -539,6 +540,9 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 		if (skipLastDXT1Blocks128x64_ && fmt == GE_TFMT_DXT1 && w == 128 && h == 64) {
 			// Skip the last few blocks as specified.
 			sizeInRAM -= 8 * skipLastDXT1Blocks128x64_;
+		}
+		if (skipLastDXT1Blocks128x128_ && fmt == GE_TFMT_DXT1 && w == 128 && h == 128) {
+			sizeInRAM -= 8 * skipLastDXT1Blocks128x128_;
 		}
 
 		switch (hash_) {

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -150,6 +150,7 @@ protected:
 	bool reduceHash_ = false;
 	bool ignoreMipmap_ = false;
 	int skipLastDXT1Blocks128x64_ = 0;
+	int skipLastDXT1Blocks128x128_ = 0;
 
 	float reduceHashGlobalValue = 0.5f; // Global value for textures dump pngs of all sizes, 0.5 by default but can be set in textures.ini
 


### PR DESCRIPTION
Adds one more image size option (128x128) for the texture hashing problem in Tag Force.

Requesting this because I've made a mod for the game to render the entire Yu-Gi-Oh card from one large 128x128 image instead of building it from smaller images.

See #19714