### PR TITLE
iOS: Preserve permissions to access files across runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1386,8 +1386,6 @@ elseif(IOS AND NOT LIBRETRO)
 		ios/iCade/iCadeReaderView.h
 		ios/iCade/iCadeReaderView.m
 		ios/iCade/iCadeState.h
-		UI/DarwinFileSystemServices.mm
-		UI/DarwinFileSystemServices.h
 		Common/Battery/AppleBatteryClient.m
 	)
 
@@ -1412,7 +1410,7 @@ elseif(IOS AND NOT LIBRETRO)
 		ios/AudioEngine.mm
 		ios/LocationHelper.mm
 		ios/Controls.mm
-		UI/DarwinFileSystemServices.mm
+		Core/Util/DarwinFileSystemServices.mm
 		Common/Battery/AppleBatteryClient.m
 		Common/Render/Text/draw_text_cocoa.mm
 		PROPERTIES COMPILE_FLAGS -fobjc-arc)
@@ -1435,11 +1433,8 @@ elseif(USING_QT_UI)
 	endif()
 	if(APPLE)
 		list(APPEND NativeAppSource
-			UI/DarwinFileSystemServices.mm
-			UI/DarwinFileSystemServices.h
 			Common/Battery/AppleBatteryClient.m)
 		set_source_files_properties(Common/Battery/AppleBatteryClient.m
-			UI/DarwinFileSystemServices.mm
 			Common/Render/Text/draw_text_cocoa.mm
 			PROPERTIES COMPILE_FLAGS -fobjc-arc)
 		list(APPEND nativeExtraLibs ${COCOA_LIBRARY} ${QUARTZ_CORE_LIBRARY} ${IOKIT_LIBRARY})
@@ -1509,8 +1504,6 @@ else()
 		SDL/PPSSPPAboutViewController.m
 		SDL/PPSSPPAboutViewController.h
 		SDL/MacCameraHelper.mm
-		UI/DarwinFileSystemServices.mm
-		UI/DarwinFileSystemServices.h
 		Common/Battery/AppleBatteryClient.m
 		UI/PSPNSApplicationDelegate.mm
 		UI/PSPNSApplicationDelegate.h)
@@ -1518,7 +1511,7 @@ else()
 		# TODO
 		# set_source_files_properties(SDL/SDLMain.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
 
-		set_source_files_properties(UI/DarwinFileSystemServices.mm
+		set_source_files_properties(Core/Util/DarwinFileSystemServices.mm
 			UI/PSPNSApplicationDelegate.mm
 			SDL/CocoaMetalLayer.mm
 			SDL/CocoaBarItems.mm
@@ -2090,6 +2083,12 @@ if(LINUX OR ANDROID OR MACOSX OR IOS)
 	)
 endif()
 
+if(MACOSX OR IOS)
+	list(APPEND CoreExtra
+		Core/Util/DarwinFileSystemServices.mm
+		Core/Util/DarwinFileSystemServices.h)
+endif()
+
 # 'ppsspp_jni' on ANDROID, 'Core' everywhere else
 # SHARED on ANDROID, STATIC everywhere else
 add_library(${CoreLibName} ${CoreLinkType}
@@ -2530,6 +2529,11 @@ add_library(${CoreLibName} ${CoreLinkType}
 	ext/loongarch-disasm.h
 	${CMAKE_CURRENT_BINARY_DIR}/git-version.cpp
 )
+
+if(MACOSX OR IOS)
+	set_source_files_properties(Core/Util/DarwinFileSystemServices.mm
+		PROPERTIES COMPILE_FLAGS -fobjc-arc)
+endif()
 
 if(LIBRETRO)
 	target_include_directories(${CoreLibName} PRIVATE libretro/libretro-common/include)

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -30,6 +30,7 @@
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/FileSystems/BlockDevices.h"
 #include "Core/FileSystems/ISOFileSystem.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 #include "Core/PSPLoaders.h"
 #include "Core/MemMap.h"
 #include "Core/Loaders.h"
@@ -57,6 +58,15 @@ FileLoader *ConstructFileLoader(const Path &filename) {
 		}
 		return new CachingFileLoader(baseLoader);
 	}
+	#if PPSSPP_PLATFORM(IOS)
+	if (!File::Exists(filename)) {
+		// Try to "unlock" the path before the file loader hits it
+		Path newFilename = DarwinFileSystemServices::reauthorizeBookmarkByPath(filename);
+		if (!newFilename.empty()) {
+			return new LocalFileLoader(newFilename);
+		}
+	}
+	#endif
 	return new LocalFileLoader(filename);
 }
 

--- a/Core/Util/DarwinFileSystemServices.h
+++ b/Core/Util/DarwinFileSystemServices.h
@@ -11,6 +11,8 @@
 #include "Common/File/Path.h"
 #include "Common/System/Request.h"
 
+#if PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(MAC)
+
 #define PreferredMemoryStickUserDefaultsKey "UserPreferredMemoryStickDirectoryPath"
 
 typedef std::function<void (bool, Path)> DarwinDirectoryPanelCallback;
@@ -39,3 +41,5 @@ private:
 };
 
 void RestartMacApp();
+
+#endif

--- a/Core/Util/DarwinFileSystemServices.h
+++ b/Core/Util/DarwinFileSystemServices.h
@@ -31,8 +31,11 @@ public:
 	static Path appropriateMemoryStickDirectoryToUse();
 	static void setUserPreferredMemoryStickDirectory(Path);
 	static Path defaultMemoryStickPath();
-
 	static void ClearDelegate();
+
+	static Path reauthorizeBookmarkByPath(const Path &pathStr);
+	static void stopAccessingPath(const Path &pathStr);
+	static void terminate();
 private:
 #if PPSSPP_PLATFORM(IOS)
 	// iOS only, needed for UIDocumentPickerViewController

--- a/Core/Util/DarwinFileSystemServices.mm
+++ b/Core/Util/DarwinFileSystemServices.mm
@@ -14,6 +14,7 @@
 
 #include <dispatch/dispatch.h>
 #include <CoreServices/CoreServices.h>
+#include <map>
 
 #include "ppsspp_config.h"
 
@@ -36,6 +37,8 @@
 @property DarwinDirectoryPanelCallback panelCallback;
 @end
 
+static std::map<std::string, void*> activeAccessTokens;
+
 void *DarwinFileSystemServices::__pickerDelegate = nullptr;
 
 void DarwinFileSystemServices::ClearDelegate() {
@@ -52,12 +55,16 @@ void DarwinFileSystemServices::ClearDelegate() {
 	return self;
 }
 
+static void addBookmark(NSURL *url);
+
 - (void)documentPicker:(UIDocumentPickerViewController *)controller didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
 	NSURL *url = urls.firstObject;
 	if (!url) {
 		self.panelCallback(false, Path());
 		return;
 	}
+
+	addBookmark(url);
 
 	// 1. Start accessing the resource
 	BOOL success = [url startAccessingSecurityScopedResource];
@@ -82,8 +89,135 @@ void DarwinFileSystemServices::ClearDelegate() {
 	INFO_LOG(Log::System, "Picker cancelled, pre-emptively hide keyboard");
 	[sharedViewController hideKeyboard];
 }
-
 @end
+
+// Internal helper to generate and store a bookmark for a given URL.
+// Also activates the security scope for the current session.
+static void addBookmark(NSURL *url) {
+	if (!url) return;
+
+	// IMPORTANT: You must start accessing BEFORE creating the bookmark,
+	// otherwise the OS denies the 'read' required to seal the bookmark.
+	BOOL accessStarted = [url startAccessingSecurityScopedResource];
+
+	INFO_LOG(Log::System, "Darwin: Creating bookmark (Access: %s) for: %s",
+			 accessStarted ? "YES" : "NO", url.path.UTF8String);
+
+	NSError *error = nil;
+	#if PPSSPP_PLATFORM(IOS)
+		NSURLBookmarkCreationOptions options = 0;
+	#else
+		NSURLBookmarkCreationOptions options = NSURLBookmarkCreationWithSecurityScope;
+	#endif
+
+	NSData *bookmark = [url bookmarkDataWithOptions:options
+					  includingResourceValuesForKeys:nil
+									   relativeToURL:nil
+											   error:&error];
+
+	if (bookmark) {
+		NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+		NSMutableDictionary *dict = [[defaults dictionaryForKey:@"SecureBookmarks"] mutableCopy] ?: [NSMutableDictionary dictionary];
+
+		[dict setObject:bookmark forKey:url.path];
+		[defaults setObject:dict forKey:@"SecureBookmarks"];
+		[defaults synchronize];
+
+		// If we started access specifically for this function, we keep the token.
+		// If we didn't have it in our map yet, store this URL.
+		std::string pathKey = url.path.UTF8String;
+		if (accessStarted && activeAccessTokens.find(pathKey) == activeAccessTokens.end()) {
+			activeAccessTokens[pathKey] = (void *)CFBridgingRetain(url);
+		} else if (accessStarted) {
+			// If it's already in the map, we don't need a second retain.
+			[url stopAccessingSecurityScopedResource];
+		}
+	} else {
+		ERROR_LOG(Log::System, "Darwin: Bookmark failed. Error 260 often means the file isn't 'coordinated' yet. Detail: %s",
+				  error.localizedDescription.UTF8String);
+
+		if (accessStarted) [url stopAccessingSecurityScopedResource];
+	}
+}
+Path DarwinFileSystemServices::reauthorizeBookmarkByPath(const Path &pathStr) {
+    INFO_LOG(Log::System, "Darwin: Reauthorizing [%s]", pathStr.c_str());
+
+    // 1. Return immediately if already active
+    if (activeAccessTokens.count(pathStr.ToString())) {
+        return pathStr;
+    }
+
+    // 2. Retrieve bookmark from disk
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSDictionary *dict = [defaults dictionaryForKey:@"SecureBookmarks"];
+    NSData *bookmarkData = dict[@(pathStr.c_str())];
+
+    if (!bookmarkData) {
+        WARN_LOG(Log::System, "Darwin: No bookmark data found for path (%s)", pathStr.c_str());
+        return Path();
+    }
+
+    // 3. Resolve
+    BOOL isStale = NO;
+    NSError *error = nil;
+#if PPSSPP_PLATFORM(IOS)
+    NSURLBookmarkResolutionOptions resOptions = 0;
+#else
+    NSURLBookmarkResolutionOptions resOptions = NSURLBookmarkResolutionWithSecurityScope;
+#endif
+
+    NSURL *url = [NSURL URLByResolvingBookmarkData:bookmarkData
+                                           options:resOptions
+                                     relativeToURL:nil
+                               bookmarkDataIsStale:&isStale
+                                             error:&error];
+
+    if (url && [url startAccessingSecurityScopedResource]) {
+        Path resolvedPath(url.path.UTF8String);
+
+        // 4. Handle stale/moved files
+        if (isStale || resolvedPath != pathStr) {
+            INFO_LOG(Log::System, "Darwin: File moved! Updating [%s] -> [%s]", pathStr.c_str(), resolvedPath.c_str());
+
+            // Clean up the old key from defaults
+            NSMutableDictionary *mutableDict = [dict mutableCopy];
+            [mutableDict removeObjectForKey:@(pathStr.c_str())];
+            [defaults setObject:mutableDict forKey:@"SecureBookmarks"];
+
+            // Re-save under the new path
+            addBookmark(url);
+        } else {
+            // Path is the same, just cache the token
+            activeAccessTokens[resolvedPath.ToString()] = (void *)CFBridgingRetain(url);
+        }
+
+        return resolvedPath;
+    }
+
+    ERROR_LOG(Log::System, "Darwin: Resolution failed for %s", pathStr.c_str());
+    return Path();
+}
+
+void DarwinFileSystemServices::stopAccessingPath(const Path &pathStr) {
+    auto it = activeAccessTokens.find(pathStr.ToString());
+    if (it != activeAccessTokens.end()) {
+        INFO_LOG(Log::System, "Darwin: Stopping access for: %s", pathStr.c_str());
+
+        NSURL *url = (__bridge_transfer NSURL *)it->second;
+        [url stopAccessingSecurityScopedResource];
+
+        activeAccessTokens.erase(it);
+    }
+}
+
+void DarwinFileSystemServices::terminate() {
+    INFO_LOG(Log::System, "Darwin: Terminating all security-scoped access.");
+    for (auto const& [path, token] : activeAccessTokens) {
+        NSURL *url = (__bridge_transfer NSURL *)token;
+        [url stopAccessingSecurityScopedResource];
+    }
+    activeAccessTokens.clear();
+}
 
 #else
 #include <AppKit/AppKit.h>

--- a/Core/Util/DarwinFileSystemServices.mm
+++ b/Core/Util/DarwinFileSystemServices.mm
@@ -12,7 +12,6 @@
 // /var/mobile/Containers/Data/Application/<UUID>/Documents
 // The /private prefix seems to be optional, so we strip it off before returning it.
 
-
 #include <dispatch/dispatch.h>
 #include <CoreServices/CoreServices.h>
 

--- a/Core/Util/PathUtil.cpp
+++ b/Core/Util/PathUtil.cpp
@@ -6,6 +6,7 @@
 #include "Common/System/System.h"
 #include "Common/Log.h"
 #include "Core/Util/PathUtil.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 #include "Core/Config.h"
 #include "Common/VR/PPSSPPVR.h"
 
@@ -169,14 +170,24 @@ bool TryUpdateSavedPath(Path *path) {
 		std::string memstick = g_Config.memStickDirectory.ToString();
 		size_t memstickDocumentsPos = memstick.find("/Documents");  // Note: No trailing slash, or we won't find it.
 		*path = Path(memstick.substr(0, memstickDocumentsPos) + pathStr.substr(documentsPos));
-		return true;
-	} else {
-		// Path can't be auto-updated.
-		return false;
 	}
-#else
-	return false;
+
+	if (File::Exists(*path)) {
+		return true;
+	}
+
+	// Still doesn't exist? Maybe got de-authorized
+	// Try to "unlock" the path before the file loader hits it
+	Path newFilename = DarwinFileSystemServices::reauthorizeBookmarkByPath(*path);
+	if (!newFilename.empty()) {
+		INFO_LOG(Log::UI, "Bookmark rename: %s -> %s", path->c_str(), newFilename.c_str());
+		*path = newFilename;
+		return true;
+	}
+	
+	// Path can't be auto-updated.
 #endif
+	return false;
 }
 
 Path GetFailedBackendsDir() {

--- a/Core/Util/RecentFiles.cpp
+++ b/Core/Util/RecentFiles.cpp
@@ -10,6 +10,7 @@
 #include "Core/Loaders.h"
 #include "Core/Util/RecentFiles.h"
 #include "Core/Util/PathUtil.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 #include "Core/Config.h"
 
 RecentFilesManager g_recentFiles;

--- a/Core/Util/VulkanEmuThread.cpp
+++ b/Core/Util/VulkanEmuThread.cpp
@@ -1,2 +1,0 @@
-#include "Core/Util/VulkanEmuThread.h"
-

--- a/SDL/CocoaBarItems.mm
+++ b/SDL/CocoaBarItems.mm
@@ -8,7 +8,7 @@
 #import <Cocoa/Cocoa.h>
 #import "PPSSPPAboutViewController.h"
 
-#include "UI/DarwinFileSystemServices.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 #include "UI/PSPNSApplicationDelegate.h"
 
 #include "Core/Debugger/SymbolMap.h"

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -76,7 +76,7 @@ SDLJoystick *joystick = NULL;
 #endif
 
 #if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-#include "UI/DarwinFileSystemServices.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 #endif
 
 #if PPSSPP_PLATFORM(MAC)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -82,7 +82,7 @@
 #include "GPU/GPU.h"
 
 #if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-#include "UI/DarwinFileSystemServices.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 #endif
 
 #if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1455,11 +1455,11 @@ void MainScreen::CreateViews() {
 		auto gr = GetI18NCategory(I18NCat::GRAPHICS);
 		Button *fullscreenButton = logo->Add(new Button("", ImageID(), new AnchorLayoutParams(48, 48, NONE, 0, 0, NONE, Centering::None)));
 		fullscreenButton->SetIgnoreText(true);
-		fullscreenButton->OnClick.Add([this](UI::EventParams &e) {
+		fullscreenButton->OnClick.Add([](UI::EventParams &e) {
 			g_Config.bFullScreen = !g_Config.bFullScreen;
 			System_ApplyFullscreenState();
 		});
-		fullscreenButton->SetImageIDFunc([this]() {
+		fullscreenButton->SetImageIDFunc([]() {
 			return g_Config.bFullScreen ? ImageID("I_RESTORE") : ImageID("I_FULLSCREEN");
 		});
 #endif

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -68,10 +68,7 @@
 #include "Core/Config.h"
 #include "Core/Loaders.h"
 #include "Common/Data/Text/I18n.h"
-
-#if PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(MAC)
-#include "UI/DarwinFileSystemServices.h" // For the browser
-#endif
+#include "Core/Util/DarwinFileSystemServices.h" // For the browser
 
 #include "Core/HLE/sceUmd.h"
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -155,9 +155,7 @@
 #include <mach-o/dyld.h>
 #endif
 
-#if PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(MAC)
-#include "UI/DarwinFileSystemServices.h"
-#endif
+#include "Core/Util/DarwinFileSystemServices.h"
 
 #if !defined(__LIBRETRO__)
 #include "Core/Util/GameDB.h"

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -930,6 +930,10 @@ void NativeShutdownGraphics() {
 	}
 #endif
 
+#if PPSSPP_PLATFORM(IOS)
+	DarwinFileSystemServices::terminate();
+#endif
+
 	if (g_audioBackend) {
 		delete g_audioBackend;
 		g_audioBackend = nullptr;

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -1046,7 +1046,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
-    <ClInclude Include="..\UI\DarwinFileSystemServices.h" />
+    <ClInclude Include="..\Core\Util\DarwinFileSystemServices.h" />
     <ClInclude Include="..\UI\PSPNSApplicationDelegate.h" />
     <ClInclude Include="..\UWP\App.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -1349,7 +1349,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </None>
     <None Include="..\settings.gradle" />
-    <None Include="..\UI\DarwinFileSystemServices.mm" />
+    <None Include="..\Core\Util\DarwinFileSystemServices.mm" />
     <None Include="..\UI\PSPNSApplicationDelegate.mm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -568,7 +568,7 @@
     <ClInclude Include="..\UI\PSPNSApplicationDelegate.h">
       <Filter>Other Platforms\Mac</Filter>
     </ClInclude>
-    <ClInclude Include="..\UI\DarwinFileSystemServices.h">
+    <ClInclude Include="..\Core\Util\DarwinFileSystemServices.h">
       <Filter>Other Platforms\iOS</Filter>
     </ClInclude>
     <ClInclude Include="..\ios\ViewControllerCommon.h">
@@ -821,7 +821,7 @@
     <None Include="..\UI\PSPNSApplicationDelegate.mm">
       <Filter>Other Platforms\Mac</Filter>
     </None>
-    <None Include="..\UI\DarwinFileSystemServices.mm">
+    <None Include="..\Core\Util\DarwinFileSystemServices.mm">
       <Filter>Other Platforms\iOS</Filter>
     </None>
     <None Include="..\ios\ViewControllerMetal.mm">

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -40,7 +40,7 @@
 #include "Core/Config.h"
 #include "Common/Log.h"
 #include "Common/Log/LogManager.h"
-#include "UI/DarwinFileSystemServices.h"
+#include "Core/Util/DarwinFileSystemServices.h"
 
 // Compile out all the hackery in app store builds.
 #if !PPSSPP_PLATFORM(IOS_APP_STORE)


### PR DESCRIPTION
We still do it our own way for files inside the app dir, but for everything else, create "bookmarks". 

This makes Recent work with files opened from iCloud for example.

Based on some example code from Gemini for this, much faster than trying to parse Apple's docs...