### PR TITLE
libretro: fix ios/tvos builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2083,7 +2083,7 @@ if(LINUX OR ANDROID OR MACOSX OR IOS)
 	)
 endif()
 
-if(MACOSX OR IOS)
+if((MACOSX OR IOS) AND NOT LIBRETRO)
 	list(APPEND CoreExtra
 		Core/Util/DarwinFileSystemServices.mm
 		Core/Util/DarwinFileSystemServices.h)
@@ -2530,7 +2530,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 	${CMAKE_CURRENT_BINARY_DIR}/git-version.cpp
 )
 
-if(MACOSX OR IOS)
+if((MACOSX OR IOS) AND NOT LIBRETRO)
 	set_source_files_properties(Core/Util/DarwinFileSystemServices.mm
 		PROPERTIES COMPILE_FLAGS -fobjc-arc)
 endif()

--- a/Core/Util/PathUtil.cpp
+++ b/Core/Util/PathUtil.cpp
@@ -153,7 +153,7 @@ Path GetGameConfigFilePath(const Path &searchPath, std::string_view gameId, bool
 // /var/mobile/Containers/Data/Application/0E0E89DE-8D8E-485A-860C-700D8BC87B86/Documents/PSP/GAME/SuicideBarbie
 // The GUID part changes on each launch.
 bool TryUpdateSavedPath(Path *path) {
-#if PPSSPP_PLATFORM(IOS)
+#if PPSSPP_PLATFORM(IOS) && !defined(__LIBRETRO__)
 	// DEBUG_LOG(Log::Loader, "Original path: %s", path->c_str());
 	std::string pathStr = path->ToString();
 	if (startsWith(pathStr, "/private/var/mobile/Containers/Data/Application/")) {


### PR DESCRIPTION
These aren't necessary for libretro, it should be (despite not currently) handling bookmarks, etc., itself.