### PR TITLE
GPU: Shader optimizations using inversesqrt and dead code removal

### DIFF
--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -34,7 +34,8 @@ const char * const hlsl_preamble_fs =
 "#define mediump\n"
 "#define highp\n"
 "#define fract frac\n"
-"#define mod(x, y) fmod(x, y)\n";
+"#define mod(x, y) fmod(x, y)\n"
+"#define inversesqrt rsqrt\n";
 
 static const char * const hlsl_d3d11_preamble_fs =
 "#define DISCARD discard\n"
@@ -61,6 +62,7 @@ static const char * const hlsl_preamble_gs =
 "#define lowp\n"
 "#define mediump\n"
 "#define highp\n"
+"#define inversesqrt rsqrt\n"
 "\n";
 
 static const char * const vulkan_glsl_preamble_gs =
@@ -84,6 +86,7 @@ static const char * const hlsl_preamble_vs =
 "#define lowp\n"
 "#define mediump\n"
 "#define highp\n"
+"#define inversesqrt rsqrt\n"
 "\n";
 
 static const char * const semanticNames[] = {

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -231,7 +231,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		}
 		if (enableColorTest && !colorTestAgainstZero) {
 			WRITE(p, "uint roundAndScaleTo8x4(in highp vec3 x) { uvec3 u = uvec3(floor(x * 255.0 + 0.5)); return u.r | (u.g << 8) | (u.b << 16); }\n");
-			WRITE(p, "uint packFloatsTo8x4(in vec3 x) { uvec3 u = uvec3(x); return u.r | (u.g << 8) | (u.b << 16); }\n");
 		}
 
 		WRITE(p, "layout (location = 0, index = 0) out vec4 fragColor0;\n");
@@ -271,7 +270,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		if (enableColorTest) {
 			if (compat.shaderLanguage == HLSL_D3D11) {
 				WRITE(p, "uint roundAndScaleTo8x4(float3 x) { uvec3 u = (floor(x * 255.0f + 0.5f)); return u.r | (u.g << 8) | (u.b << 16); }\n");
-				WRITE(p, "uint packFloatsTo8x4(in vec3 x) { uvec3 u = uvec3(x); return u.r | (u.g << 8) | (u.b << 16); }\n");
 			} else {
 				WRITE(p, "vec3 roundAndScaleTo255v(float3 x) { return floor(x * 255.0f + 0.5f); }\n");
 			}
@@ -418,7 +416,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 			if (enableColorTest && !colorTestAgainstZero) {
 				if (compat.bitwiseOps) {
 					WRITE(p, "uint roundAndScaleTo8x4(in vec3 x) { uvec3 u = uvec3(floor(x * 255.92)); return u.r | (u.g << 0x8u) | (u.b << 0x10u); }\n");
-					WRITE(p, "uint packFloatsTo8x4(in vec3 x) { uvec3 u = uvec3(x); return u.r | (u.g << 0x8u) | (u.b << 0x10u); }\n");
 				} else if (gl_extensions.gpuVendor == GPU_VENDOR_IMGTEC) {
 					WRITE(p, "vec3 roundTo255thv(in vec3 x) { vec3 y = x + (0.5/255.0); return y - fract(y * 255.0) * (1.0 / 255.0); }\n");
 				} else {
@@ -471,12 +468,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		WRITE(p, "  highp vec4 f = vec4(u);\n");
 		WRITE(p, "  return f * (1.0 / 255.0);\n");
 		WRITE(p, "}\n");
-	}
-
-	if (compat.bitwiseOps && enableColorTest) {
-		p.C("uvec3 unpackUVec3(highp uint x) {\n");
-		p.C("  return uvec3(x & 0xFFu, (x >> 0x8u) & 0xFFu, (x >> 0x10u) & 0xFFu);\n");
-		p.C("}\n");
 	}
 
 	// PowerVR needs a custom modulo function. For some reason, this has far higher precision than the builtin one.

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -923,6 +923,8 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			}
 			if (distanceNeeded) {
 				WRITE(p, "  float distance;\n");
+				WRITE(p, "  float distSq;\n");
+				WRITE(p, "  float invDist;\n");
 				WRITE(p, "  lowp float lightScale;\n");
 			}
 			WRITE(p, "  mediump float ldot;\n");
@@ -961,9 +963,11 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				p.F("    toLight = u_lightpos%s;\n", iStr);
 				p.C("    if (type != 0x0u) {\n");  // GE_LIGHTTYPE_DIRECTIONAL
 				p.F("      toLight -= worldpos;\n");
-				p.F("      distance = length(toLight);\n");
-				p.F("      toLight /= distance;\n");
-				p.F("      attenuation = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0);\n", iStr);
+				p.F("      float distSq = dot(toLight, toLight);\n");
+				p.F("      float invDist = inversesqrt(distSq);\n");
+				p.F("      distance = distSq * invDist;\n");
+				p.F("      toLight *= invDist;\n");
+				p.F("      attenuation = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distSq)), 0.0, 1.0);\n", iStr);
 				p.C("      if (type == 0x01u) {\n"); // GE_LIGHTTYPE_POINT
 				p.C("        lightScale = attenuation;\n");
 				p.C("      } else {\n");  // type must be 0x02 - GE_LIGHTTYPE_SPOT
@@ -984,8 +988,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				p.F("    diffuse = (u_lightdiffuse%s * diffuseColor) * max(ldot, 0.0);\n", iStr);
 				p.C("    if (comp == 0x1u && ldot >= 0.0) {\n");  // do specular. note - must allow for the >= case, since the u_matspecular.a <= 0.0 case relies on it.
 				p.C("      if (u_matspecular.a > 0.0) {\n");
-				p.C("        ldot = dot(normalize(toLight + vec3(0.0, 0.0, 1.0)), worldnormal);\n");
-				p.C("        ldot = pow(max(ldot, 0.0), u_matspecular.a);\n");
+				p.C("        vec3 halfVec = toLight + vec3(0.0, 0.0, 1.0);\n");
+				p.C("        float halfInvLen = inversesqrt(dot(halfVec, halfVec));\n");
+				p.C("        ldot = pow(max(dot(halfVec, worldnormal) * halfInvLen, 0.0), u_matspecular.a);\n");
 				p.C("      } else {\n");
 				p.C("        ldot = 1.0;\n");
 				p.C("      }\n");
@@ -1013,8 +1018,12 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 					p.F("  toLight = u_lightpos%s;\n", iStr);
 				} else {
 					p.F("  toLight = u_lightpos%s - worldpos;\n", iStr);
-					p.C("  distance = length(toLight);\n");
-					p.C("  toLight /= distance;\n");
+					// Use inversesqrt() for better performance on mobile GPUs.
+					// distance = sqrt(distSq), and toLight * inversesqrt(distSq) normalizes it.
+					p.C("  distSq = dot(toLight, toLight);\n");
+					p.C("  invDist = inversesqrt(distSq);\n");
+					p.C("  distance = distSq * invDist;\n");
+					p.C("  toLight *= invDist;\n");
 				}
 
 				bool doSpecular = comp == GE_LIGHTCOMP_BOTH;
@@ -1039,13 +1048,13 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 					timesLightScale = "";
 					break;
 				case GE_LIGHTTYPE_POINT:
-					p.F("  lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0);\n", iStr);
+					p.F("  lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distSq)), 0.0, 1.0);\n", iStr);
 					break;
 				case GE_LIGHTTYPE_SPOT:
 				case GE_LIGHTTYPE_UNKNOWN:
 					p.F("  angle = dot(u_lightdir%s, toLight);\n", iStr, iStr);
 					p.F("  if (angle >= u_lightangle_spotCoef%s.x) {\n", iStr);
-					p.F("    lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0) * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(max(angle, 0.0), u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
+					p.F("    lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distSq)), 0.0, 1.0) * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(max(angle, 0.0), u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
 					p.C("  } else {\n");
 					p.C("    lightScale = 0.0;\n");
 					p.C("  }\n");
@@ -1059,8 +1068,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				if (doSpecular) {
 					p.C("  if (ldot >= 0.0) {\n");
 					p.C("    if (u_matspecular.a > 0.0) {\n");
-					p.C("      ldot = dot(normalize(toLight + vec3(0.0, 0.0, 1.0)), worldnormal);\n");
-					p.C("      ldot = pow(max(ldot, 0.0), u_matspecular.a);\n");
+					p.C("      vec3 halfVec = toLight + vec3(0.0, 0.0, 1.0);\n");
+					p.C("      float halfInvLen = inversesqrt(dot(halfVec, halfVec));\n");
+					p.C("      ldot = pow(max(dot(halfVec, worldnormal) * halfInvLen, 0.0), u_matspecular.a);\n");
 					p.C("    } else {\n");
 					p.C("      ldot = 1.0;\n");
 					p.C("    }\n");


### PR DESCRIPTION
## Summary

Two small shader generator optimizations:

1. **Use `inversesqrt()` for lighting calculations** - Replace `length()`/`normalize()` patterns with explicit `inversesqrt()` for better performance on mobile GPUs. The `inversesqrt` instruction is a single hardware operation, while `length()` requires `sqrt(dot())` and `normalize()` requires `inversesqrt` internally plus a multiply.

2. **Remove dead helper functions** - Clean up `unpackUVec3()` and `packFloatsTo8x4()` which were left unused after earlier refactoring (4329aaa31c and aec22491fe).

## Performance

Offline shader compiler results for the inversesqrt optimization (vertex shader with 4-light ubershader):

| GPU | Before | After | Change |
|-----|--------|-------|--------|
| Mali G31 (Bifrost) | 44.90 cycles | 40.50 cycles | -9.8% |
| Mali G52 (Bifrost) | 14.97 cycles | 13.50 cycles | -9.8% |
| Mali G310 (Valhall) | 13.88 cycles | 12.88 cycles | -7.2% |
| Mali G57 (Valhall) | 7.60 cycles | 6.97 cycles | -8.3% |
| PowerVR GE8300 | 322 ALU | 302 ALU | -6.2% |
| PowerVR GM9445 | 296 ALU | 280 ALU | -5.4% |
| PowerVR BXM | 560 instr | 540 instr | -3.6% |

## Testing

- Compiled cleanly with no warnings on Linux (GCC 15.2.1)
- Verified generated shader code produces mathematically equivalent results