### PR TITLE
Windows input optimizations

### DIFF
--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -417,7 +417,7 @@ DInputMetaDevice::DInputMetaDevice() {
 }
 
 int DInputMetaDevice::UpdateState() {
-	static const int CHECK_FREQUENCY = 71;  // Just an arbitrary prime to try to not collide with other periodic checks.
+	constexpr int CHECK_FREQUENCY = 787;  // Just an arbitrary prime to try to not collide with other periodic checks.
 	if (checkCounter_++ > CHECK_FREQUENCY) {
 		const size_t newCount = DinputDevice::getNumPads();
 		if (newCount > numDinputDevices_) {

--- a/Windows/Hid/HidInputDevice.h
+++ b/Windows/Hid/HidInputDevice.h
@@ -68,6 +68,6 @@ private:
 	int inReportSize_ = 0;
 	int outReportSize_ = 0;
 	enum {
-		POLL_FREQ = 283,  // a prime number.
+		POLL_FREQ = 709,  // a prime number.
 	};
 };

--- a/Windows/InputDevice.cpp
+++ b/Windows/InputDevice.cpp
@@ -42,12 +42,12 @@ void InputManager::InputThread() {
 
 	// NOTE: The keyboard and mouse buttons are handled via raw input, not here.
 	// This is mainly for controllers which need to be polled, instead of generating events.
-	bool noSleep = false;
 	while (runThread_.load(std::memory_order_relaxed)) {
+		bool noSleep = false;
 		if (focused_.load(std::memory_order_relaxed) || !g_Config.bGamepadOnlyFocused) {
 			System_Notify(SystemNotification::POLL_CONTROLLERS);
 			for (const auto &device : devices_) {
-				int state = device->UpdateState();
+				const int state = device->UpdateState();
 				if (state == InputDevice::UPDATESTATE_SKIP_PAD)
 					break;
 				if (state == InputDevice::UPDATESTATE_NO_SLEEP) {

--- a/Windows/InputDevice.h
+++ b/Windows/InputDevice.h
@@ -32,7 +32,7 @@ public:
 	virtual void Shutdown() {}
 	virtual bool HasAccelerometer() const { return false; }
 
-	enum { UPDATESTATE_SKIP_PAD = 0x1234, UPDATESTATE_NO_SLEEP = 0x2345};
+	enum { UPDATESTATE_NORMAL = 0, UPDATESTATE_SKIP_PAD = 0x1234, UPDATESTATE_NO_SLEEP = 0x2345};
 	virtual int UpdateState() = 0;
 };
 

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -201,9 +201,8 @@ int XinputDevice::UpdateState() {
 		}
 	}
 
-	// If we get XInput, skip the others. This might not actually be a good idea,
-	// and was done to avoid conflicts between DirectInput and XInput.
-	return 0; // anySuccess ? UPDATESTATE_SKIP_PAD : 0;
+	// Previously we returned SKIP_PAD here but it wasn't a good idea.
+	return UPDATESTATE_NORMAL;
 }
 
 void XinputDevice::ReleaseAllKeys(int pad) {


### PR DESCRIPTION
Fixes a bug where the thread wouldn't sleep when it should in some configurations.

Also increases the time between polls for new controllers.

Will hopefully improve #21387 