### PR TITLE
Add UI for adding and removing custom servers from the adhoc server screen

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -812,6 +812,10 @@ static int DefaultGamePreviewVolume() {
 	return g_Config.iUIVolume;
 }
 
+std::string DefaultProAdhocServer() {
+	return "socom.cc";
+}
+
 static const ConfigSetting soundSettings[] = {
 	ConfigSetting("Enable", SETTING(g_Config, bEnableSound), true, CfgFlag::PER_GAME),
 	ConfigSetting("ExtraAudioBuffering", SETTING(g_Config, bExtraAudioBuffering), false, CfgFlag::DEFAULT),
@@ -1032,7 +1036,7 @@ static const std::vector<std::string_view> emptyList;
 static const ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", SETTING(g_Config, bEnableWlan), false, CfgFlag::PER_GAME),
 	ConfigSetting("EnableAdhocServer", SETTING(g_Config, bEnableAdhocServer), false, CfgFlag::PER_GAME),
-	ConfigSetting("proAdhocServer", SETTING(g_Config, sProAdhocServer), "socom.cc", CfgFlag::PER_GAME),
+	ConfigSetting("proAdhocServer", SETTING(g_Config, sProAdhocServer), &DefaultProAdhocServer, CfgFlag::PER_GAME),
 	ConfigSetting("AdhocServerRelayMode", SETTING(g_Config, iAdhocServerRelayMode), (int)AdhocServerRelayMode::Auto, CfgFlag::PER_GAME),
 	ConfigSetting("PortOffset", SETTING(g_Config, iPortOffset), 10000, CfgFlag::PER_GAME),
 	ConfigSetting("PrimaryDNSServer", SETTING(g_Config, sInfrastructureDNSServer), "67.222.156.250", CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -778,6 +778,7 @@ private:
 };
 
 std::string CreateRandMAC();
+std::string DefaultProAdhocServer();
 
 // TODO: Find a better place for this.
 extern http::RequestManager g_DownloadManager;

--- a/UI/AdhocServerScreen.cpp
+++ b/UI/AdhocServerScreen.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "AdhocServerScreen.h"
 
 #include "Common/Net/Resolve.h"
@@ -28,6 +29,7 @@ public:
 			}
 		}
 	}
+	virtual bool CanComplete(DialogResult result) { return result == DR_OK ? !editValue_.empty() : true; }
 
 	const char *tag() const override { return "AdhocAddServerPopup"; }
 

--- a/UI/AdhocServerScreen.cpp
+++ b/UI/AdhocServerScreen.cpp
@@ -5,6 +5,37 @@
 #include "Common/StringUtils.h"
 #include "Core/HLE/sceNetAdhoc.h"
 
+class AdhocAddServerPopupScreen : public UI::PopupScreen {
+public:
+	AdhocAddServerPopupScreen() : PopupScreen(T(I18NCat::NETWORKING, "Add server"), T(I18NCat::DIALOG, "Add"), T(I18NCat::DIALOG, "Cancel")) {
+	}
+
+	void CreatePopupContents(UI::ViewGroup *parent) override {
+		using namespace UI;
+		auto ni = GetI18NCategory(I18NCat::NETWORKING);
+
+		PopupTextInputChoice *textInputChoice = parent->Add(new PopupTextInputChoice(GetRequesterToken(), &editValue_, ni->T("Hostname"), "", 450, screenManager()));
+		parent->Add(new CheckBox(&hasRelay_, ni->T("Use relay server")));
+	}
+
+	virtual void OnCompleted(DialogResult result) {
+		if (result == DialogResult::DR_OK) {
+			if (hasRelay_) {
+				// Insert at the start of the vector.
+				g_Config.vCustomAdhocServerListWithRelay.insert(g_Config.vCustomAdhocServerListWithRelay.begin(), editValue_);
+			} else {
+				g_Config.vCustomAdhocServerList.insert(g_Config.vCustomAdhocServerList.begin(), editValue_);
+			}
+		}
+	}
+
+	const char *tag() const override { return "AdhocAddServerPopup"; }
+
+private:
+	std::string editValue_;
+	bool hasRelay_ = true;
+};
+
 static UI::View *CreateLinkButton(std::string url) {
 	using namespace UI;
 
@@ -73,13 +104,14 @@ protected:
 		scroll->Add(content);
 		parent->Add(scroll);
 	}
+
 private:
 	AdhocServerListEntry entry_;
 };
 
 class AdhocServerRow : public UI::LinearLayout {
 public:
-	AdhocServerRow(std::string *value, const AdhocServerListEntry &entry, ScreenManager *screenManager, UI::LayoutParams *layoutParams = nullptr);
+	AdhocServerRow(std::string *value, const AdhocServerListEntry &entry, bool showDeleteButton, ScreenManager *screenManager, UI::LayoutParams *layoutParams = nullptr);
 
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override {
 		w = 500; h = 90;
@@ -125,7 +157,7 @@ private:
 	AdhocServerListEntry entry_;
 };
 
-AdhocServerRow::AdhocServerRow(std::string *value, const AdhocServerListEntry &entry, ScreenManager *screenManager, UI::LayoutParams *layoutParams)
+AdhocServerRow::AdhocServerRow(std::string *value, const AdhocServerListEntry &entry, bool showDeleteButton, ScreenManager *screenManager, UI::LayoutParams *layoutParams)
 	: UI::LinearLayout(ORIENT_HORIZONTAL, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::WRAP_CONTENT, UI::Margins(5.0f, 0.0f))), value_(value), entry_(entry) {
 	using namespace UI;
 
@@ -146,6 +178,29 @@ AdhocServerRow::AdhocServerRow(std::string *value, const AdhocServerListEntry &e
 
 	if (entry.mode == AdhocDataMode::AemuPostoffice) {
 		TextView *relay = Add(new TextView("Relay", new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity::G_VCENTER, Margins(10.0))));
+	}
+	if (showDeleteButton) {
+		Choice *deleteButton = Add(new Choice(ImageID("I_TRASHCAN"), new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, Gravity::G_VCENTER, Margins(0, 0, 10, 0))));
+		deleteButton->OnClick.Add([host = entry.host, screenManager](UI::EventParams &e) {
+			auto di = GetI18NCategory(I18NCat::DIALOG);
+			std::string message = ApplySafeSubstitutions(di->T("Are you sure you want to delete %1"), host);
+			screenManager->push(new UI::MessagePopupScreen(di->T("Delete"), message, di->T("Delete"), di->T("Cancel"), [host](bool confirmed) {
+				if (confirmed) {
+					auto f = std::find(g_Config.vCustomAdhocServerList.begin(), g_Config.vCustomAdhocServerList.end(), host);
+					if (f != g_Config.vCustomAdhocServerList.end()) {
+						g_Config.vCustomAdhocServerList.erase(f);
+					}
+					f = std::find(g_Config.vCustomAdhocServerListWithRelay.begin(), g_Config.vCustomAdhocServerListWithRelay.end(), host);
+					if (f != g_Config.vCustomAdhocServerListWithRelay.end()) {
+						g_Config.vCustomAdhocServerListWithRelay.erase(f);
+					}
+					if (g_Config.sProAdhocServer == host) {
+						// Reset to socom.cc, which will always be in a list.
+						g_Config.sProAdhocServer = DefaultProAdhocServer();
+					}
+				}
+			}));
+		});
 	}
 
 	if (!entry.description.empty()) {
@@ -190,9 +245,14 @@ void AdhocServerScreen::CreatePopupContents(UI::ViewGroup *parent) {
 
 	// We already kicked off loading the server list in the constructor, so by now it should be either loaded or in the process of loading.
 	// We can get the cached list immediately, and then update it when the async load finishes.
-	auto listItems = AdhocGetServerList(AdhocLoadListMode::CacheOnlySync);
+	std::vector<AdhocServerListEntry> listItems = AdhocGetServerList(AdhocLoadListMode::CacheOnlySync);
 
-	PopupTextInputChoice *textInputChoice = parent->Add(new PopupTextInputChoice(GetRequesterToken(), &editValue_, n->T("Hostname"), "", 450, screenManager()));
+	Choice *addServer = parent->Add(new Choice(n->T("Add server"), ImageID("I_PLUS")));
+	addServer->OnClick.Add([this](UI::EventParams &e) {
+		AdhocAddServerPopupScreen *addScreen = new AdhocAddServerPopupScreen();
+		screenManager()->push(addScreen);
+	});
+
 	parent->Add(new Spacer(5.0f));
 
 	// editValue_ has the currently selected server. On closing the dialog, we copy that to settings.
@@ -201,6 +261,14 @@ void AdhocServerScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	std::vector<AdhocServerListEntry> entries = listItems;
 	std::vector<AdhocServerListEntry> localEntries;
 	std::vector<AdhocServerListEntry> customEntries;
+
+	bool currentServerFound = false;  // If the current server is not found, we'll have to add it to one of the lists.
+
+	for (const auto &iter : entries) {
+		if (iter.host == editValue_) {
+			currentServerFound = true;
+		}
+	}
 
 	// Add localhost and local IPs, since those are common ones to connect to.
 	{
@@ -220,6 +288,10 @@ void AdhocServerScreen::CreatePopupContents(UI::ViewGroup *parent) {
 			entry.name = ipAddress;
 			entry.host = ipAddress;
 			localEntries.push_back(entry);
+
+			if (ipAddress == editValue_) {
+				currentServerFound = true;
+			}
 		}
 	}
 
@@ -242,6 +314,10 @@ void AdhocServerScreen::CreatePopupContents(UI::ViewGroup *parent) {
 		entry.host = host;
 		entry.mode = AdhocDataMode::AemuPostoffice;
 		customEntries.push_back(entry);
+
+		if (host == editValue_) {
+			currentServerFound = true;
+		}
 	}
 
 	for (const auto &host : g_Config.vCustomAdhocServerList) {
@@ -254,14 +330,18 @@ void AdhocServerScreen::CreatePopupContents(UI::ViewGroup *parent) {
 		entry.host = host;
 		entry.mode = AdhocDataMode::P2P;
 		customEntries.push_back(entry);
+
+		if (host == editValue_) {
+			currentServerFound = true;
+		}
 	}
 
 	ScrollView *scrollView = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
 	LinearLayout *innerView = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	innerView->SetSpacing(5.0f);
 
-	auto AddButtonFromEntry = [this](UI::ViewGroup *parent, const AdhocServerListEntry &entry) {
-		AdhocServerRow *row = new AdhocServerRow(&editValue_, entry, screenManager());
+	auto AddButtonFromEntry = [this](UI::ViewGroup *parent, const AdhocServerListEntry &entry, bool showDeleteButton) {
+		AdhocServerRow *row = new AdhocServerRow(&editValue_, entry, showDeleteButton, screenManager());
 		parent->Add(row);
 		row->OnSelected.Add([this](UI::EventParams &e) {
 			std::string value = e.v->Tag();
@@ -276,19 +356,30 @@ void AdhocServerScreen::CreatePopupContents(UI::ViewGroup *parent) {
 
 	if (!customEntries.empty()) {
 		CollapsibleSection *customSection = innerView->Add(new CollapsibleSection(n->T("Custom server list"), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+
+		if (!currentServerFound) {
+			// Add a virtual entry.
+			AdhocServerListEntry entry;
+			entry.name = editValue_;
+			entry.host = editValue_;
+			// Let's do a heuristic, we don't have a good value here..
+			entry.mode = (AdhocServerRelayMode)g_Config.iAdhocServerRelayMode == AdhocServerRelayMode::AlwaysOn ? AdhocDataMode::AemuPostoffice : AdhocDataMode::P2P;
+			AddButtonFromEntry(customSection, entry, true);
+		}
+
 		for (const auto &entry : customEntries) {
-			AddButtonFromEntry(customSection, entry);
+			AddButtonFromEntry(customSection, entry, true);
 		}
 	}
 
 	CollapsibleSection *publicSection = innerView->Add(new CollapsibleSection(n->T("Public server list"), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	for (const auto &entry : entries) {
-		AddButtonFromEntry(publicSection, entry);
+		AddButtonFromEntry(publicSection, entry, false);
 	}
 
 	CollapsibleSection *localSection = innerView->Add(new CollapsibleSection(n->T("Local network addresses"), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	for (const auto &entry : localEntries) {
-		AddButtonFromEntry(localSection, entry);
+		AddButtonFromEntry(localSection, entry, false);
 	}
 
 	scrollView->Add(innerView);

--- a/UI/AdhocServerScreen.h
+++ b/UI/AdhocServerScreen.h
@@ -26,6 +26,9 @@ protected:
 
 	void sendMessage(UIMessage message, const char *value) override;
 
+	void dialogFinished(const Screen *screen, DialogResult result) override {
+		RecreateViews();
+	}
 private:
 	void ResolverThread();
 

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -399,6 +399,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = ‎* PSP حجم
 Active = نشط
+Are you sure you want to delete %1? = هل أنت متأكد أنك تريد حذف %1؟ # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = تلقائي

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d saniyə
 * PSP res = * PSP çöz
 Active = Etkindir
+Are you sure you want to delete %1? = Əminsiniz, %1-i silmək istəyirsiniz? # AI translated
 Are you sure you want to delete the file? = Faylı silmək istədiyinizdən əminsiz?
 Are you sure you want to exit? = Çıxmaq istədiyinizdən əminsiz?
 Auto = Özbaşına

--- a/assets/lang/be_BY.ini
+++ b/assets/lang/be_BY.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d сек
 * PSP res = * Разр. PSP
 Active = Active
+Are you sure you want to delete %1? = Ці вы ўпэўнены, што хочаце выдаліць %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Аўта

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d секунди
 * PSP res = * PSP res
 Active = Активен
+Are you sure you want to delete %1? = Сигурни ли сте, че искате да изтриете %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d segons
 * PSP res = * resolució PSP
 Active = Actiu
+Are you sure you want to delete %1? = Estàs segur que vols eliminar %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d vteřin
 * PSP res = * PSP rozlišení
 Active = Active
+Are you sure you want to delete %1? = Jste si jisti, že chcete smazat %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekunder
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Er du sikker på, at du vil slette %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -390,6 +390,7 @@ VFPU = VFPU
 %d seconds = %d Sekunden
 * PSP res = * PSP-Auflösung
 Active = Aktiv
+Are you sure you want to delete %1? = Sind Sie sicher, dass Sie %1 löschen möchten? # AI translated
 Are you sure you want to delete the file? = Willst du die Datei wirklich löschen?
 Are you sure you want to exit? = Willst du wirklich beenden?
 Auto = Autom.

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Apakah Anda yakin ingin menghapus %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -415,6 +415,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Are you sure you want to delete %1?
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -392,6 +392,7 @@ VFPU = VFPU
 %d seconds = %d segundos
 * PSP res = * resolución PSP
 Active = Activo
+Are you sure you want to delete %1? = ¿Estás seguro de que quieres eliminar %1? # AI translated
 Are you sure you want to delete the file? = ¿Estás seguro de que quieres eliminar el archivo?
 Are you sure you want to exit? = ¿Estás seguro de que quieres salir?
 Auto = Automático

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d segundos
 * PSP res = * resolución PSP
 Active = Activo
+Are you sure you want to delete %1? = ¿Estás seguro que deseas eliminar %1? # AI translated
 Are you sure you want to delete the file? = ¿Estás seguro de que quieres borrar el archivo?
 Are you sure you want to exit? = ¿Estás seguro de que quieres salir?
 Auto = Auto

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d ثانیه
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = آیا مطمئن هستید که می‌خواهید %1 را حذف کنید؟ # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = خودکار

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekuntia
 * PSP res = * PSP-resoluutio
 Active = Aktiivinen
+Are you sure you want to delete %1? = Oletko varma, että haluat poistaa %1? # AI translated
 Are you sure you want to delete the file? = Haluatko varmasti poistaa tiedoston?
 Are you sure you want to exit? = Haluatko varmasti poistua?
 Auto = Automaattinen

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d secondes
 * PSP res = × définition PSP
 Active = Actif
+Are you sure you want to delete %1? = Êtes-vous sûr de vouloir supprimer %1 ? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Automatique

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Estás seguro de que queres eliminar %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d δευτερόλεπτα
 * PSP res = * ανάλυση PSP
 Active = ΕΝΕΡΓΟ
+Are you sure you want to delete %1? = Είσαι σίγουρος ότι θέλεις να διαγράψεις το %1; # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = האם אתה בטוח שברצונך למחוק את %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = האם אתה בטוח שברצונך למחוק את %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekundi
 * PSP res = * PSP res
 Active = Aktivno
+Are you sure you want to delete %1? = Jeste li sigurni da želite izbrisati %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d másodpercig
 * PSP res = * PSP felbontás
 Active = Aktív
+Are you sure you want to delete %1? = Biztos, hogy törölni szeretné %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d detik
 * PSP res = * PSP res
 Active = Aktif
+Are you sure you want to delete %1? = Apakah Anda yakin ingin menghapus %1? # AI translated
 Are you sure you want to delete the file? = Apakah Anda yakin untuk menghapus file?
 Are you sure you want to exit? = Apakah Anda yakin untuk keluar?
 Auto = Otomatis

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d secondi
 * PSP res = * definizione PSP
 Active = Attiva
+Are you sure you want to delete %1? = Sei sicuro di voler eliminare %1? # AI translated
 Are you sure you want to delete the file? = Vuoi davvero eliminare il file?
 Are you sure you want to exit? = Vuoi davvero uscire?
 Auto = Auto

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d 秒
 * PSP res = * PSP 解像度
 Active = アクティブ
+Are you sure you want to delete %1? = %1を削除してもよろしいですか？ # AI translated
 Are you sure you want to delete the file? = ファイルを削除してもよろしいですか？
 Are you sure you want to exit? = 本当に終了してもよろしいですか？
 Auto = 自動

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d detik
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Apa sampeyan yakin pengin mbusak %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d 초
 * PSP res = * PSP 리소스
 Active = 활성화
+Are you sure you want to delete %1? = %1을(를) 삭제하시겠습니까? # AI translated
 Are you sure you want to delete the file? = 파일을 삭제할까요?
 Are you sure you want to exit? = 정말 종료할까요?
 Auto = 자동

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -405,6 +405,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = چالاک
+Are you sure you want to delete %1? = Ma hûn qaset in ku hûn dixwazin %1 jê bînin? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d ວິນາທີ
 * PSP res = * ຂະໜາດຈໍ PSP
 Active = Active
+Are you sure you want to delete %1? = ທ່ານແน່ໃຈບໍ່ວ່າຈະລົບ %1 ຫຼື? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekundžių
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Ar tikrai norite ištrinti %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Adakah anda pasti mahu memadam %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d seconds
 * PSP res = * PSP-resolutie
 Active = Active
+Are you sure you want to delete %1? = Weet je zeker dat je %1 wilt verwijderen? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekunder
 * PSP res = * PSP-oppløsning
 Active = Aktiv
+Are you sure you want to delete %1? = Er du sikker på at du vil slette %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Er du sikker på at du vil avslutte?
 Auto = Auto

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekund
 * PSP res = * rozdz. PSP
 Active = Aktywny
+Are you sure you want to delete %1? = Czy na pewno chcesz usunąć %1? # AI translated
 Are you sure you want to delete the file? = Na pewno chcesz usunąć ten plik?
 Are you sure you want to exit? = Na pewno chcesz wyjść?
 Auto = Automatycznie

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -415,6 +415,7 @@ VFPU = VFPU
 %d seconds = %d segundos
 * PSP res = * Resolução do PSP
 Active = Ativo
+Are you sure you want to delete %1? = Tem certeza de que deseja excluir %1? # AI translated
 Are you sure you want to delete the file? = Você tem certeza que você quer apagar o arquivo?
 Are you sure you want to exit? = Você tem certeza que você quer sair?
 Auto = Auto

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -415,6 +415,7 @@ VFPU = VFPU
 %d seconds = %d segundos
 * PSP res = * Resolução da PSP
 Active = Ativo
+Are you sure you want to delete %1? = Tem certeza de que quer apagar %1? # AI translated
 Are you sure you want to delete the file? = Tens a certeza que queres eliminar o ficheiro?
 Are you sure you want to exit? = Tens a certeza que queres sair?
 Auto = Automático

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -392,6 +392,7 @@ VFPU = VFPU
 %d seconds = %d secunde
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Ești sigur că vrei să ștergi %1? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d сек
 * PSP res = * разр. PSP
 Active = Активно
+Are you sure you want to delete %1? = Вы уверены, что хотите удалить %1? # AI translated
 Are you sure you want to delete the file? = Вы уверены, что хотите удалить файл?
 Are you sure you want to exit? = Вы уверены, что хотите выйти?
 Auto = Авто

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d sekunder
 * PSP res = * PSP upplösning
 Active = Aktiv
+Are you sure you want to delete %1? = Är du säker på att du vill ta bort %1? # AI translated
 Are you sure you want to delete the file? = Är du säker på att du vill ta bort filen?
 Are you sure you want to exit? = Är du säker på att du vill avsluta?
 Auto = Automatisk

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -392,6 +392,7 @@ VFPU = VFPU
 %d seconds = %d na segundo
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to delete %1? = Шумо сӯҳбат мекунед, ки мехоҳед %1 - ро нест кунед? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Awto

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -406,6 +406,7 @@ VFPU = VFPU
 %d seconds = %d วินาที
 * PSP res = * ขนาดจอ PSP
 Active = เปิดการทำงาน
+Are you sure you want to delete %1? = คุณแน่ใจหรือว่าต้องการลบ %1? # AI translated
 Are you sure you want to delete the file? = คุณแน่ใจนะ ว่าต้องการลบไฟล์นี้ทิ้ง?
 Are you sure you want to exit? = คุณแน่ใจนะว่าต้องการออกเกม?
 Auto = อัตโนมัติ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -393,6 +393,7 @@ VFPU = VFPU
 %d seconds = %d saniye
 * PSP res = * PSP Çözünürlüğü
 Active = Etkin
+Are you sure you want to delete %1? = %1’i silmek istediğinizden emin misiniz? # AI translated
 Are you sure you want to delete the file? = Dosyayı silmek istediğinizden emin misiniz?
 Are you sure you want to exit? = Çıkmak istediğinden emin misin?
 Auto = Otomatik

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d сек
 * PSP res = * розш. PSP
 Active = Активно
+Are you sure you want to delete %1? = Ви впевнені, що хочете видалити %1? # AI translated
 Are you sure you want to delete the file? = Ви впевнені, що хочете видалити файл?
 Are you sure you want to exit? = Ви впевнені, що хочете вийти?
 Auto = Авто

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d giây
 * PSP res = * PSP như thật
 Active = Hoạt động
+Are you sure you want to delete %1? = Bạn có chắc chắn muốn xóa %1 không? # AI translated
 Are you sure you want to delete the file? = Are you sure you want to delete the file?
 Are you sure you want to exit? = Are you sure you want to exit?
 Auto = Auto

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d 秒
 * PSP res = * PSP分辨率
 Active = 激活
+Are you sure you want to delete %1? = 您确定要删除 %1 吗？ # AI translated
 Are you sure you want to delete the file? = 确定要删除该文件吗?
 Are you sure you want to exit? = 确定要退出吗?
 Auto = 自动

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -391,6 +391,7 @@ VFPU = VFPU
 %d seconds = %d 秒
 * PSP res = * PSP 解析度
 Active = 啟用
+Are you sure you want to delete %1? = 您確定要刪除 %1 嗎？ # AI translated
 Are you sure you want to delete the file? = 確定要刪除該檔案嗎？
 Are you sure you want to exit? = 確定要退出嗎？
 Auto = 自動


### PR DESCRIPTION
As it says on the tin.

If the user has previously set an adhoc server that's not in any list, we'll display it as if it's in the custom list and guess the relay status based on the setting.