### PR TITLE
OpenGL: Fix GLES3 detection for Mesa/Panfrost Mali drivers

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -192,6 +192,8 @@ bool CheckGLExtensions() {
 			gl_extensions.gpuVendor = GPU_VENDOR_VIVANTE;
 		} else if (vendor == "Apple Inc." || vendor == "Apple") {
 			gl_extensions.gpuVendor = GPU_VENDOR_APPLE;
+		} else if (vendor == "Mesa") {
+			gl_extensions.gpuVendor = GPU_VENDOR_MESA;
 		} else {
 			WARN_LOG(Log::G3D, "Unknown GL vendor: '%s'", vendor.c_str());
 			gl_extensions.gpuVendor = GPU_VENDOR_UNKNOWN;
@@ -291,9 +293,13 @@ bool CheckGLExtensions() {
 				}
 				gl_extensions.GLES3 = true;
 				// Though, let's ban Mali from the GLES 3 path for now, see #4078
-				if (strstr(renderer, "Mali") != 0) {
-					INFO_LOG(Log::G3D, "Forcing GLES3 off for Mali driver version: %s\n", versionStr ? versionStr : "N/A");
+				// Only apply to ARM's proprietary driver (GL_VENDOR="ARM"), not Mesa/Panfrost (GL_VENDOR="Mesa")
+				if (cvendor && strcmp(cvendor, "ARM") == 0 && strstr(renderer, "Mali") != 0) {
+					INFO_LOG(Log::G3D, "Forcing GLES3 off for ARM Mali proprietary driver version: %s\n", versionStr ? versionStr : "N/A");
 					gl_extensions.GLES3 = false;
+				} else if (strstr(renderer, "Mali") != 0) {
+					// Mali detected but not ARM vendor (likely Mesa/Panfrost) - allow GLES3
+					INFO_LOG(Log::G3D, "Mali GPU with non-ARM vendor '%s' detected, allowing GLES3\n", cvendor ? cvendor : "N/A");
 				}
 			} else {
 				// Just to be safe.


### PR DESCRIPTION
## Summary

- Fix incorrect GLES3 suppression that was being applied to Mesa/Panfrost drivers
- Add `GPU_VENDOR_MESA` for identifying Mesa drivers via GL_VENDOR
- Change the GLES3 ban to only apply when GL_VENDOR="ARM" (proprietary driver)

The original code checked for "Mali" in GL_RENDERER and disabled GLES3 for all Mali GPUs. This was a workaround for bugs in ARM's proprietary Mali driver (#4078). However, Mesa/Panfrost (open-source Mali driver) does not have these bugs and should be allowed to use GLES3 features like dual-source blending.

## Expected Behavior

| Driver | GL_VENDOR | GL_RENDERER | GLES3 |
|--------|-----------|-------------|-------|
| ARM blob | `ARM` | `Mali-G52` | Disabled (preserved) |
| Panfrost | `Mesa` | `Mali-G52 (Panfrost)` | **Enabled** |
| Lima | `Mesa` | `Mali-400 (Lima)` | N/A (ES 2.0 only) |
| Other Mesa | `Mesa` | `AMD Radeon...` | Unchanged |

## Test Plan

- [x] Builds successfully with GLES2 and Vulkan backends
- [x] Runtime test on desktop (no regressions)
- [x] Logic verified with 17 test cases covering ARM blob, Panfrost, Lima, and edge cases

Related issues: #4078, #15413

Signed-off-by: Chris Healy <cphealy@gmail.com>