### PR TITLE
Fix flickery background when navigating game lists with the keyboard/gamepad

### DIFF
--- a/UI/Background.cpp
+++ b/UI/Background.cpp
@@ -455,6 +455,54 @@ enum class BackgroundFillMode {
 	FitToScreen = 2,
 };
 
+void DrawBackgroundTexture(UIContext &dc, Draw::Texture *texture, Lin::Vec3 focus, float alpha) {
+	dc.GetDrawContext()->BindTexture(0, texture);
+	uint32_t color = whiteAlpha(std::clamp(alpha, 0.0f, 1.0f)) & 0xFFc0c0c0;
+
+	// TODO: Make this configurable?
+	const BackgroundFillMode mode = BackgroundFillMode::AdaptiveCropToScreen;
+
+	const Bounds screenBounds = dc.GetBounds();
+	float imageW = screenBounds.w;
+	float imageH = screenBounds.h;
+	float imageAspect = (float)texture->Width() / (float)texture->Height();
+
+	float squash = imageAspect / screenBounds.AspectRatio();
+
+	// Allow a lot of leeway for the image aspect - let it stretch a bit, and only then start cropping.
+	const float aspectLeeway = 0.5f;
+	if (mode == BackgroundFillMode::AdaptiveCropToScreen && squash >= 0.6f && squash < 1.7f) {
+		imageAspect = screenBounds.AspectRatio();
+	}
+
+	// Fit the image into the screen bounds according to the fill mode.
+	if (imageAspect > screenBounds.AspectRatio()) {
+		// Image is wider than screen.
+		if (mode == BackgroundFillMode::AdaptiveCropToScreen) {
+			// Crop width.
+			imageW = screenBounds.h * imageAspect;
+		} else if (mode == BackgroundFillMode::FitToScreen) {
+			// Fit height.
+			imageH = screenBounds.w / imageAspect;
+		}
+	} else {
+		// Image is taller than screen.
+		if (mode == BackgroundFillMode::AdaptiveCropToScreen) {
+			// Crop height.
+			imageH = screenBounds.w / imageAspect;
+		} else if (mode == BackgroundFillMode::FitToScreen) {
+			// Fit width.
+			imageW = screenBounds.h / imageAspect;
+		}
+	}
+
+	Bounds finalImageBounds = Bounds::FromCenterWH(screenBounds.centerX(), screenBounds.centerY(), imageW, imageH);
+
+	dc.Draw()->DrawTexRect(finalImageBounds, 0, 0, 1, 1, color);
+	dc.Flush();
+	dc.RebindTexture();
+}
+
 void DrawGameBackground(UIContext &dc, const Path &gamePath, Lin::Vec3 focus, float alpha) {
 	using namespace Draw;
 	using namespace UI;
@@ -467,51 +515,8 @@ void DrawGameBackground(UIContext &dc, const Path &gamePath, Lin::Vec3 focus, fl
 
 	GameInfoTex *pic = (ginfo && ginfo->Ready(GameInfoFlags::PIC1)) ? ginfo->GetPIC1() : nullptr;
 	if (pic && pic->texture) {
-		dc.GetDrawContext()->BindTexture(0, pic->texture);
-		uint32_t color = whiteAlpha(std::clamp(ease((time_now_d() - pic->timeLoaded) * 3.0f) * alpha, 0.0f, 1.0f)) & 0xFFc0c0c0;
-
-		// TODO: Make this configurable?
-		const BackgroundFillMode mode = BackgroundFillMode::AdaptiveCropToScreen;
-
-		const Bounds screenBounds = dc.GetBounds();
-		float imageW = screenBounds.w;
-		float imageH = screenBounds.h;
-		float imageAspect = (float)pic->texture->Width() / (float)pic->texture->Height();
-
-		float squash = imageAspect / screenBounds.AspectRatio();
-
-		// Allow a lot of leeway for the image aspect - let it stretch a bit, and only then start cropping.
-		const float aspectLeeway = 0.5f;
-		if (mode == BackgroundFillMode::AdaptiveCropToScreen && squash >= 0.6f && squash < 1.7f) {
-			imageAspect = screenBounds.AspectRatio();
-		}
-
-		// Fit the image into the screen bounds according to the fill mode.
-		if (imageAspect > screenBounds.AspectRatio()) {
-			// Image is wider than screen.
-			if (mode == BackgroundFillMode::AdaptiveCropToScreen) {
-				// Crop width.
-				imageW = screenBounds.h * imageAspect;
-			} else if (mode == BackgroundFillMode::FitToScreen) {
-				// Fit height.
-				imageH = screenBounds.w / imageAspect;
-			}
-		} else {
-			// Image is taller than screen.
-			if (mode == BackgroundFillMode::AdaptiveCropToScreen) {
-				// Crop height.
-				imageH = screenBounds.w / imageAspect;
-			} else if (mode == BackgroundFillMode::FitToScreen) {
-				// Fit width.
-				imageW = screenBounds.h / imageAspect;
-			}
-		}
-
-		Bounds finalImageBounds = Bounds::FromCenterWH(screenBounds.centerX(), screenBounds.centerY(), imageW, imageH);
-
-		dc.Draw()->DrawTexRect(finalImageBounds, 0, 0, 1, 1, color);
-		dc.Flush();
-		dc.RebindTexture();
+		float alphaMul = ease((time_now_d() - pic->timeLoaded) * 3.0f);
+		DrawBackgroundTexture(dc, pic->texture, focus, alpha * alphaMul);
 	} else {
 		::DrawBackground(dc, 1.0f, focus);
 		dc.RebindTexture();

--- a/UI/Background.h
+++ b/UI/Background.h
@@ -11,5 +11,6 @@ void UIBackgroundInit(UIContext &dc);
 void UIBackgroundShutdown();
 void DrawGameBackground(UIContext &dc, const Path &gamePath, Lin::Vec3 focus, float alpha);
 void DrawBackground(UIContext &dc, float alpha, Lin::Vec3 focus);
+void DrawBackgroundTexture(UIContext &dc, Draw::Texture *texture, Lin::Vec3 focus, float alpha);
 
 uint32_t GetBackgroundColorWithAlpha(const UIContext &dc);

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -554,6 +554,9 @@ void GameScreen::CreateContextMenu(UI::ViewGroup *parent) {
 		Choice *removeButton = parent->Add(new Choice(ga->T("Remove From Recent"), ImageID("I_UNPIN")));
 		removeButton->OnClick.Add([this](UI::EventParams &e) {
 			g_recentFiles.Remove(gamePath_.ToString());
+			System_PostUIMessage(UIMessage::GAME_SELECTED, "");
+			// TODO: We should be able to do TriggerFinish here, but unfortunately
+			// the screen manager still considers the popup dialog the current dialog.
 			screenManager()->switchScreen(new MainScreen());
 		});
 	}

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -500,7 +500,9 @@ void GameScreen::CreateSettingsViews(UI::ViewGroup *rightColumn) {
 	rightColumn->Add(rightColumnItems);
 
 	if (!inGame_ && FileTypeIsPlayable(info_->fileType)) {
-		rightColumnItems->Add(new Choice(ga->T("Play"), ImageID("I_PLAY")))->OnClick.Handle(this, &GameScreen::OnPlay);
+		rightColumnItems->Add(new Choice(ga->T("Play"), ImageID("I_PLAY")))->OnClick.Add([this](UI::EventParams &e) {
+			screenManager()->switchScreen(new EmuScreen(gamePath_));
+		});
 	}
 
 	if (!info_->id.empty() && !inGame_) {
@@ -520,7 +522,9 @@ void GameScreen::CreateSettingsViews(UI::ViewGroup *rightColumn) {
 
 	if (g_Config.bEnableCheats) {
 		auto pa = GetI18NCategory(I18NCat::PAUSE);
-		rightColumnItems->Add(new Choice(pa->T("Cheats"), ImageID("I_CHEAT")))->OnClick.Handle(this, &GameScreen::OnCwCheat);
+		rightColumnItems->Add(new Choice(pa->T("Cheats"), ImageID("I_CHEAT")))->OnClick.Add([this](UI::EventParams &e) {
+			screenManager()->push(new CwCheatScreen(gamePath_));
+		});
 	}
 
 	isHomebrew_ = info_ && info_->region == GameRegion::HOMEBREW;
@@ -548,7 +552,10 @@ void GameScreen::CreateContextMenu(UI::ViewGroup *parent) {
 	// TODO: This is synchronous, bad!
 	if (!inGame_ && g_recentFiles.ContainsFile(gamePath_.ToString())) {
 		Choice *removeButton = parent->Add(new Choice(ga->T("Remove From Recent"), ImageID("I_UNPIN")));
-		removeButton->OnClick.Handle(this, &GameScreen::OnRemoveFromRecent);
+		removeButton->OnClick.Add([this](UI::EventParams &e) {
+			g_recentFiles.Remove(gamePath_.ToString());
+			screenManager()->switchScreen(new MainScreen());
+		});
 	}
 
 	if (info_->saveDataSize) {
@@ -625,18 +632,6 @@ void GameScreen::OnDeleteConfig(UI::EventParams &e) {
 	}));
 }
 
-void GameScreen::OnCwCheat(UI::EventParams &e) {
-	screenManager()->push(new CwCheatScreen(gamePath_));
-}
-
-void GameScreen::OnSwitchBack(UI::EventParams &e) {
-	TriggerFinish(DR_OK);
-}
-
-void GameScreen::OnPlay(UI::EventParams &e) {
-	screenManager()->switchScreen(new EmuScreen(gamePath_));
-}
-
 void GameScreen::OnGameSettings(UI::EventParams &e) {
 	std::shared_ptr<GameInfo> info_ = g_gameInfoCache->GetInfo(NULL, gamePath_, GameInfoFlags::PARAM_SFO);
 	if (info_ && info_->Ready(GameInfoFlags::PARAM_SFO)) {
@@ -693,11 +688,6 @@ void GameScreen::OnDeleteGame(UI::EventParams &e) {
 			}
 		}));
 	}
-}
-
-void GameScreen::OnRemoveFromRecent(UI::EventParams &e) {
-	g_recentFiles.Remove(gamePath_.ToString());
-	screenManager()->switchScreen(new MainScreen());
 }
 
 void GameScreen::OnSetBackground(UI::EventParams &e) {

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -52,15 +52,11 @@ protected:
 
 private:
 	// Event handlers
-	void OnPlay(UI::EventParams &e);
 	void OnGameSettings(UI::EventParams &e);
 	void OnDeleteSaveData(UI::EventParams &e);
 	void OnDeleteGame(UI::EventParams &e);
-	void OnSwitchBack(UI::EventParams &e);
-	void OnRemoveFromRecent(UI::EventParams &e);
 	void OnCreateConfig(UI::EventParams &e);
 	void OnDeleteConfig(UI::EventParams &e);
-	void OnCwCheat(UI::EventParams &e);
 	void OnSetBackground(UI::EventParams &e);
 
 	std::string CRC32string;

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1619,27 +1619,28 @@ void MainScreen::OnLoadFile(UI::EventParams &e) {
 }
 
 void MainScreen::DrawBackground(UIContext &dc) {
-	if (highlightedGamePath_.empty() && prevHighlightedGamePath_.empty()) {
-		return;
-	}
+	constexpr float fadeTime = 0.5f;  // 
 
-	if (DrawBackgroundFor(dc, prevHighlightedGamePath_, 1.0f - prevHighlightProgress_)) {
-		if (prevHighlightProgress_ < 1.0f) {
-			prevHighlightProgress_ += 1.0f / 20.0f;
-		}
-	}
-	if (!highlightedGamePath_.empty()) {
-		if (DrawBackgroundFor(dc, highlightedGamePath_, highlightProgress_)) {
-			if (highlightProgress_ < 1.0f) {
-				highlightProgress_ += 1.0f / 20.0f;
+	double now = time_now_d();
+
+	for (auto iter = highlightedBackgrounds_.begin(); iter != highlightedBackgrounds_.end(); ) {
+		float timeSinceStart = float(now - iter->startTime);
+		float alpha = std::clamp(timeSinceStart / fadeTime, 0.0f, 1.0f);
+		if (iter->endTime > 0.0) {
+			float fadeOutAlpha = std::max(0.0f, float(now - iter->endTime) / fadeTime);
+			if (fadeOutAlpha > 1.0f) {
+				iter = highlightedBackgrounds_.erase(iter);
+				continue;
 			}
+			alpha *= 1.0f - fadeOutAlpha;
 		}
+		DrawBackgroundFor(dc, iter->gamePath, alpha);
+		iter++;
 	}
 }
 
-bool MainScreen::DrawBackgroundFor(UIContext &dc, const Path &gamePath, float progress) {
-	::DrawGameBackground(dc, gamePath, Lin::Vec3(0.f, 0.f, 0.f), progress);
-	return true;
+void MainScreen::DrawBackgroundFor(UIContext &dc, const Path &gamePath, float alpha) {
+	::DrawGameBackground(dc, gamePath, Lin::Vec3(0.f, 0.f, 0.f), alpha);
 }
 
 void MainScreen::OnGameSelected(UI::EventParams &e) {
@@ -1658,26 +1659,40 @@ void MainScreen::OnGameSelected(UI::EventParams &e) {
 	screenManager()->push(new GameScreen(path, false));
 }
 
+void MainScreen::InstantHighlight(const Path &path) {
+	// Clear the previous highlight immediately, so we don't have multiple at once.
+	highlightedBackgrounds_.clear();
+	highlightedBackgrounds_.push_back({path, 0.0f, -1.0});
+}
+
 void MainScreen::OnGameHighlight(UI::EventParams &e) {
 	using namespace UI;
 
 	Path path(e.s);
 
-	// Don't change when re-highlighting what's already highlighted.
-	if (path != highlightedGamePath_ || e.a == FF_LOSTFOCUS) {
-		if (!highlightedGamePath_.empty()) {
-			if (prevHighlightedGamePath_.empty() || prevHighlightProgress_ >= 0.75f) {
-				prevHighlightedGamePath_ = highlightedGamePath_;
-				prevHighlightProgress_ = 1.0 - highlightProgress_;
-			}
-			highlightedGamePath_.clear();
-		}
-		if (e.a == FF_GOTFOCUS) {
-			highlightedGamePath_ = path;
-			highlightProgress_ = 0.0f;
+	if (path == highlightedGamePath_) {
+		// Already highlighted, nothing to do.
+		return;
+	}
+
+	// Trigger fadeouts on any active highlights.
+	for (auto &iter : highlightedBackgrounds_) {
+		if (iter.endTime < 0.0) {
+			iter.endTime = time_now_d();
 		}
 	}
 
+	highlightedGamePath_ = path;
+
+	_dbg_assert_(!path.empty());
+
+	if (path.empty()) {
+		// Nothing highlighed? Exit.
+		return;
+	}
+
+	// Add a new entry to the highlight list.
+	highlightedBackgrounds_.push_back({path, time_now_d(), -1.0});
 	if ((!highlightedGamePath_.empty() || e.a == FF_LOSTFOCUS) && !lockBackgroundAudio_) {
 		g_BackgroundAudio.SetGame(highlightedGamePath_);
 	}
@@ -1733,8 +1748,7 @@ void MainScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	} else if (tag == "Game") {
 		if (!restoreFocusGamePath_.empty() && UI::IsFocusMovementEnabled()) {
 			// Prevent the background from fading, since we just were displaying it.
-			highlightedGamePath_ = restoreFocusGamePath_;
-			highlightProgress_ = 1.0f;
+			InstantHighlight(restoreFocusGamePath_);
 
 			// Refocus the game button itself.
 			int tab = tabHolder_->GetCurrentTab();

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1619,14 +1619,21 @@ void MainScreen::OnLoadFile(UI::EventParams &e) {
 }
 
 void MainScreen::DrawBackground(UIContext &dc) {
+	if (highlightedBackgrounds_.empty()) {
+		return;
+	}
+
 	constexpr float fadeTime = 0.5f;  // 
 
 	double now = time_now_d();
 
 	for (auto iter = highlightedBackgrounds_.begin(); iter != highlightedBackgrounds_.end(); ) {
-		float timeSinceStart = float(now - iter->startTime);
+		std::shared_ptr<GameInfo> ginfo;
+		ginfo = g_gameInfoCache->GetInfo(dc.GetDrawContext(), iter->gamePath, GameInfoFlags::PIC1);
+		float timeSinceStart = float(now - std::max(iter->startTime, ginfo->pic1.timeLoaded));
 		float alpha = std::clamp(timeSinceStart / fadeTime, 0.0f, 1.0f);
 		if (iter->endTime > 0.0) {
+			// TODO: Consider only fading out if it's the last one in the list, to avoid background shine-through.
 			float fadeOutAlpha = std::max(0.0f, float(now - iter->endTime) / fadeTime);
 			if (fadeOutAlpha > 1.0f) {
 				iter = highlightedBackgrounds_.erase(iter);
@@ -1634,8 +1641,13 @@ void MainScreen::DrawBackground(UIContext &dc) {
 			}
 			alpha *= 1.0f - fadeOutAlpha;
 		}
-		DrawBackgroundFor(dc, iter->gamePath, alpha);
 		iter++;
+
+		if (!ginfo->pic1.texture) {
+			continue;
+		}
+
+		DrawBackgroundTexture(dc, ginfo->pic1.texture, Lin::Vec3(0.0f, 0.0f, 0.0f), alpha);
 	}
 }
 

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -122,6 +122,12 @@ private:
 
 class RemoteISOBrowseScreen;
 
+struct HighlightedBackground {
+	Path gamePath;
+	double startTime;
+	double endTime;
+};
+
 class MainScreen : public UIBaseScreen {
 public:
 	MainScreen();
@@ -149,7 +155,7 @@ protected:
 	void sendMessage(UIMessage message, const char *value) override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
-	bool DrawBackgroundFor(UIContext &dc, const Path &gamePath, float progress);
+	void DrawBackgroundFor(UIContext &dc, const Path &gamePath, float alpha);
 
 	void OnGameSelected(UI::EventParams &e);
 	void OnGameSelectedInstant(UI::EventParams &e);
@@ -168,10 +174,9 @@ protected:
 	Path restoreFocusGamePath_;
 	std::vector<GameBrowser *> gameBrowsers_;
 
+	std::vector<HighlightedBackground> highlightedBackgrounds_;
 	Path highlightedGamePath_;
-	Path prevHighlightedGamePath_;
-	float highlightProgress_ = 0.0f;
-	float prevHighlightProgress_ = 0.0f;
+
 	bool backFromStore_ = false;
 	bool lockBackgroundAudio_ = false;
 	bool lastVertical_ = false;
@@ -181,6 +186,8 @@ protected:
 	std::string searchFilter_;
 
 	friend class RemoteISOBrowseScreen;
+private:
+	void InstantHighlight(const Path &path);
 };
 
 class UmdReplaceScreen : public UIBaseDialogScreen {


### PR DESCRIPTION
This was caused because of the delay of loading the background - while the newly selected background was being loaded, DrawGameBackground would fall back to redrawing the non-game background on top of the old one fading out, which looked bad. Plus, now we can have multiple backgrounds fading out simultaneously, removing any risk of any flicker or jarring flashes.

- Also threw in a fix for #21438