### PR TITLE
Fix EA games infrastructure configuration

### DIFF
--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -18,7 +18,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspuefa07.ea.com": "eahub.eu"
 			},
@@ -42,7 +41,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspfifa07.ea.com": "eahub.eu"
 			},
@@ -68,7 +66,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspfifa08.ea.com": "eahub.eu"
 			},
@@ -95,7 +92,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspfifa09.ea.com": "eahub.eu"
 			},
@@ -124,7 +120,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspfifa10.ea.com": "eahub.eu"
 			},
@@ -152,7 +147,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspuefa06.ea.com": "eahub.eu"
 			},
@@ -172,7 +166,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspworldcup10.ea.com": "eahub.eu"
 			},
@@ -195,7 +188,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspkok06.ea.com": "eahub.eu"
 			},
@@ -215,7 +207,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspmadden07.ea.com": "eahub.eu"
 			},
@@ -234,7 +225,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspmadden08.ea.com": "eahub.eu"
 			},
@@ -254,7 +244,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspmadden09.ea.com": "eahub.eu"
 			},
@@ -275,7 +264,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspmadden10.ea.com": "eahub.eu"
 			},
@@ -293,11 +281,9 @@
 				"group": "EA Nation Hub",
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
-			"dns": "81.49.107.142",
-			"dyn_dns": "eahub.eu",
+			"dns": "eahub.eu",
 			"domains": {
-				"pspmoh07.ea.com": "81.49.107.142",
-				"tos.ea.com": "81.49.107.142"
+				"pspmoh07.ea.com": "eahub.eu",
 			},
 			"score": 5,
 			"known_working_ids": [
@@ -325,10 +311,8 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspmoh08.ea.com": "eahub.eu",
-				"tos.ea.com": "eahub.eu"
 			},
 			"score": 1,
 			"known_working_ids": [
@@ -351,7 +335,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnba06.ea.com": "eahub.eu"
 			},
@@ -370,7 +353,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnba07.ea.com": "eahub.eu"
 			},
@@ -389,7 +371,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnba08.ea.com": "eahub.eu"
 			},
@@ -408,7 +389,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspncaa07.ea.com": "eahub.eu"
 			},
@@ -427,7 +407,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnfs06.ea.com": "eahub.eu"
 			},
@@ -448,7 +427,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnfs07.ea.com": "eahub.eu"
 			},
@@ -469,7 +447,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnfs08.ea.com": "eahub.eu"
 			},
@@ -490,7 +467,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnfs09.ea.com": "eahub.eu"
 			},
@@ -510,7 +486,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"pspnhl07.ea.com": "eahub.eu"
 			},
@@ -530,7 +505,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"psptw07.ea.com": "eahub.eu"
 			},
@@ -551,7 +525,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"psptw08.ea.com": "eahub.eu"
 			},
@@ -572,7 +545,6 @@
 				"url": "https://discord.gg/fwrQHHxrQQ"
 			},
 			"dns": "eahub.eu",
-			"dyn_dns": "eahub.eu",
 			"domains": {
 				"psptw10.ea.com": "eahub.eu"
 			},


### PR DESCRIPTION
- Fixed Medal Of Honor Heroes DNS
- Removed `dyn_dns` attribute for EA Nation Hub server since it is now static