### PR TITLE
Added support crossplatform low-level allocator mimalloc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -69,3 +69,6 @@
 	path = ext/aemu_postoffice
 	url = https://github.com/Kethen/aemu_postoffice.git
 	branch = ppsspp
+[submodule "ext/mimalloc"]
+	path = ext/mimalloc
+	url = https://github.com/microsoft/mimalloc.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,12 +213,18 @@ option(USE_SYSTEM_MINIUPNPC "Dynamically link against system miniUPnPc" ${USE_SY
 option(USE_ASAN "Use address sanitizer" OFF)
 option(USE_UBSAN "Use undefined behaviour sanitizer" OFF)
 option(USE_CCACHE "Use ccache if detected" ON)
+option(USE_MIMALLOC "Use mimalloc allocator" OFF)
 option(USE_NO_MMAP "Disable mmap usage" OFF)
 option(USE_IAP "IAP enabled" OFF)
 option(GOLD "Gold build" OFF)
 
 if(USE_CCACHE)
 	include(ccache)
+endif()
+
+if(USE_MIMALLOC)
+	add_subdirectory(ext/mimalloc)
+	add_compile_definitions(USE_MIMALLOC)
 endif()
 
 if(USE_SYSTEM_RAPIDJSON)
@@ -2602,6 +2608,10 @@ target_link_libraries(${CoreLibName} Common native chdr kirk cityhash sfmt19937 
 # Winsock
 if(WIN32)
 	target_link_libraries(${CoreLibName} ws2_32)
+endif()
+
+if(USE_MIMALLOC)
+	target_link_libraries(${CoreLibName} mimalloc)
 endif()
 
 if(NOT HTTPS_NOT_AVAILABLE)

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -78,6 +78,18 @@
 
 #endif
 
+#ifdef USE_MIMALLOC
+#include "mimalloc.h"
+#define malloc mi_malloc
+#define calloc mi_calloc
+#define realloc mi_realloc
+#define free mi_free
+#define strdup mi_strdup
+#define wcsdup mi_wcsdup
+#define expand mi_expand
+#define malloc_usable_size mi_malloc_usable_size
+#endif
+
 // Windows compatibility
 #ifndef _WIN32
 #include <limits.h>

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -235,7 +235,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 	}
 	if (g_Config.bCompressSymbols) {
 		uInt out_size = 4096;
-		Bytef *out_data = (Bytef *)std::malloc(out_size);
+		Bytef *out_data = (Bytef *)malloc(out_size);
 		if (out_data == nullptr) {
 			fclose(file);
 			return false;
@@ -245,7 +245,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 		strm.zfree = nullptr;
 		strm.opaque = nullptr;
 		if (deflateInit2(&strm, Z_BEST_COMPRESSION, Z_DEFLATED, MAX_WBITS + 16, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
-			std::free(out_data);
+			free(out_data);
 			fclose(file);
 			return false;
 		}
@@ -265,7 +265,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 					break;
 				case Z_BUF_ERROR:
 					{
-						std::free(out_data);
+						free(out_data);
 						uInt new_out_size = 2 * out_size;
 						if (new_out_size < out_size) {
 							deflateEnd(&strm);
@@ -273,7 +273,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 							return false;
 						}
 						out_size = new_out_size;
-						out_data = (Bytef *)std::malloc(out_size);
+						out_data = (Bytef *)malloc(out_size);
 						if (out_data == nullptr) {
 							deflateEnd(&strm);
 							fclose(file);
@@ -283,7 +283,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 					break;
 				default:
 					deflateEnd(&strm);
-					std::free(out_data);
+					free(out_data);
 					fclose(file);
 					return false;
 			}
@@ -297,7 +297,7 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 			strm.avail_out = out_size;
 		}
 		deflateEnd(&strm);
-		std::free(out_data);
+		free(out_data);
 	} else {
 		// Just plain write it.
 		fwrite(data.data(), 1, data.size(), file);


### PR DESCRIPTION
@hrydgard,

My benchmarks on AMD HD 7750 2GB I'll upload tomorrow with video difference in frametime graph and [Mangohud](https://github.com/flightlessmango/Mangohud) metrics.



For those who need even more performance in working with memory at the expense of RAM consumption, you can build a project with CMake parameter -Dmimalloc mimalloc allocator was originally designed as a performance-first solution.

- Fast paths: In mimalloc, memory allocation and deallocation typically occur in the minimum number of processor cycles
- Free list sharding: It uses segmented lists of free memory, which drastically reduces the load on the processor cache

Not my Benchmarks:
- https://dustri.org/b/files/blackalps_2022.pdf
- https://forums.factorio.com/viewtopic.php?t=83875
- https://lf-hyperledger.atlassian.net/wiki/spaces/BESU/pages/22156632/Reduce+Memory+usage+by+choosing+a+different+low+level+allocator
- https://www.reddit.com/r/cpp/comments/1k30fcd/reasons_to_use_the_system_allocator_instead_of_a/