### PR TITLE
threadmanager: remove detect cpu max 16 threads for compute

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -20,7 +20,6 @@
 // * For some tasks, splitting the input values up linearly between the threads
 //   is not fair. However, we ignore that for now.
 
-const int MAX_CORES_TO_USE = 16;
 const int MIN_IO_BLOCKING_THREADS = 4;
 static constexpr size_t TASK_PRIORITY_COUNT = (size_t)TaskPriority::COUNT;
 
@@ -219,8 +218,8 @@ void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
 	if (IsInitialized()) {
 		Teardown();
 	}
-
-	numComputeThreads_ = std::min(numRealCores * numLogicalCoresPerCpu, MAX_CORES_TO_USE);
+	
+	numComputeThreads_ = numRealCores * numLogicalCoresPerCpu;
 	// Double it for the IO blocking threads.
 	int numThreads = numComputeThreads_ + std::max(MIN_IO_BLOCKING_THREADS, numComputeThreads_);
 	numThreads_ = numThreads;


### PR DESCRIPTION
Removing restrictions greatly improves performance software rendering on multi-core systems above 16 threads.

On my 72 threads without limit, software renderer is much better to play, there is no wheezing sound, and PPSSPP also does not report that game is too slow.

In Github video sounds muted. Download video and open for listen wheezing-corrupted sounds in PPSSPP.

Before with cpu 16 threads limit:


https://github.com/user-attachments/assets/36307441-6cd6-46e0-973e-2b2a5d45844d



After:


https://github.com/user-attachments/assets/b3bdbcca-844d-40d8-8dd0-80d201c3907f

