### PR TITLE
Restore the "Landscape auto" orientation mode

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1590,9 +1590,7 @@ void Config::PostLoadCleanup() {
 	}
 
 	// Squash unsupported screen rotations.
-	if (g_Config.iScreenRotation == ROTATION_AUTO_HORIZONTAL) {
-		g_Config.iScreenRotation = ROTATION_LOCKED_HORIZONTAL;
-	} else if (g_Config.iScreenRotation == ROTATION_LOCKED_VERTICAL180) {
+	if (g_Config.iScreenRotation == ROTATION_LOCKED_VERTICAL180) {
 		g_Config.iScreenRotation = ROTATION_LOCKED_VERTICAL;
 	}
 

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -93,7 +93,7 @@ enum {
 	ROTATION_LOCKED_VERTICAL = 2,
 	ROTATION_LOCKED_HORIZONTAL180 = 3,
 	ROTATION_LOCKED_VERTICAL180 = 4,  // Deprecated
-	ROTATION_AUTO_HORIZONTAL = 5,     // Deprecated
+	ROTATION_AUTO_HORIZONTAL = 5,     // Un-deprecated again
 };
 
 enum TextureFiltering {

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -167,7 +167,7 @@ public:
 	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
 
 	void Describe(char *buf, size_t size) const override { snprintf(buf, size, "ISOBlock"); }
-	std::shared_ptr<BlockDevice> GetBlockDevice() { return isoFileSystem_->GetBlockDevice(); }
+	std::shared_ptr<BlockDevice> GetBlockDevice() override { return isoFileSystem_->GetBlockDevice(); }
 
 private:
 	std::shared_ptr<IFileSystem> isoFileSystem_;

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -766,9 +766,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -795,7 +795,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -804,9 +804,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -81,9 +81,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -139,9 +139,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -169,9 +169,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-clipboard"
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -782,9 +782,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -849,9 +849,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1343,9 +1343,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -1629,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2497,18 +2497,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/UI/AdhocServerScreen.cpp
+++ b/UI/AdhocServerScreen.cpp
@@ -49,7 +49,7 @@ public:
 			*outEditValue_ = editValue_;
 		}
 	}
-	virtual bool CanComplete(DialogResult result) { return result == DR_OK ? !editValue_.empty() : true; }
+	virtual bool CanComplete(DialogResult result) override { return result == DR_OK ? !editValue_.empty() : true; }
 
 	const char *tag() const override { return "AdhocAddServerPopup"; }
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -300,9 +300,6 @@ void GameButton::Draw(UIContext &dc) {
 	if (down_) {
 		style = dc.GetTheme().itemDownStyle;
 	}
-	if (startsWith(ginfo->GetTitle(), "Nddemo")) {
-		style = style;
-	}
 
 	// Some types we just draw a default icon for.
 	ImageID imageIcon = ImageID::invalid();

--- a/UI/MiscViews.cpp
+++ b/UI/MiscViews.cpp
@@ -237,12 +237,13 @@ void GameImageView::Draw(UIContext &dc) {
 
 void AddRotationPicker(ScreenManager *screenManager, UI::ViewGroup *parent, bool text) {
 	using namespace UI;
-	static const char *screenRotation[] = { "Auto", "Landscape", "Portrait", "Landscape Reversed" };
+	static const char *screenRotation[] = { "Auto", "Landscape", "Portrait", "Landscape Reversed", "N/A", "Landscape Auto"};
 	static const std::map<int, ImageID> screenRotationIcons{
 		{ROTATION_AUTO, ImageID("I_DEVICE_ROTATION_AUTO")},
 		{ROTATION_LOCKED_HORIZONTAL, ImageID("I_DEVICE_ROTATION_LANDSCAPE")},
 		{ROTATION_LOCKED_VERTICAL, ImageID("I_DEVICE_ROTATION_PORTRAIT")},
 		{ROTATION_LOCKED_HORIZONTAL180, ImageID("I_DEVICE_ROTATION_LANDSCAPE_REV")},
+		{ROTATION_AUTO_HORIZONTAL, ImageID("I_DEVICE_ROTATION_LANDSCAPE_AUT")},
 	};
 
 	auto co = GetI18NCategory(I18NCat::CONTROLS);
@@ -256,7 +257,7 @@ void AddRotationPicker(ScreenManager *screenManager, UI::ViewGroup *parent, bool
 
 	// Portrait Reversed is not recommended on iPhone (and we also ban it in the plist).
 	// However it's recommended to support it on iPad, so maybe we will in the future.
-	rot->HideChoice(4);
+	rot->HideChoice(ROTATION_LOCKED_VERTICAL180);
 	rot->OnChoice.Add([](UI::EventParams &) {
 		INFO_LOG(Log::System, "New display rotation: %d", g_Config.iScreenRotation);
 		System_Notify(SystemNotification::ROTATE_UPDATED);

--- a/UI/UIAtlas.cpp
+++ b/UI/UIAtlas.cpp
@@ -172,6 +172,7 @@ static const ImageMeta imageIDs[] = {
 	{"I_DEVICE_ROTATION_AUTO", false},
 	{"I_DEVICE_ROTATION_LANDSCAPE", false},
 	{"I_DEVICE_ROTATION_PORTRAIT", false},
+	{"I_DEVICE_ROTATION_LANDSCAPE_AUT", false},
 	{"I_MOVE", false},
 	{"I_RESIZE", false},
 	{"I_LINK_OUT_QUESTION", false},

--- a/assets/ui_images/images.svg
+++ b/assets/ui_images/images.svg
@@ -7,7 +7,7 @@
    viewBox="0 0 158.74998 185.20831"
    version="1.1"
    id="svg1"
-   inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
    sodipodi:docname="images.svg"
    xml:space="preserve"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -24,15 +24,15 @@
      inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="px"
-     inkscape:zoom="11.313709"
-     inkscape:cx="261.54111"
-     inkscape:cy="619.73488"
-     inkscape:window-width="3840"
-     inkscape:window-height="2071"
-     inkscape:window-x="-9"
-     inkscape:window-y="-9"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="309.71276"
+     inkscape:cy="526.44098"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="I_EDIT_TEXT"
+     inkscape:current-layer="layer1"
      showgrid="false"
      showguides="true" /><defs
      id="defs1"><inkscape:path-effect
@@ -4681,7 +4681,29 @@
    id="path1-2"
    style="fill:#ffffff;fill-opacity:1"
    sodipodi:nodetypes="ccssssssccccccccccccccccccccccccccc" />
-</g></g><style
+</g><g
+   id="I_DEVICE_ROTATION_LANDSCAPE_AUT"
+   transform="rotate(-45,30.053683,52.80339)"><g
+     id="g6"
+     transform="rotate(45,24.982115,122.88388)"><g
+       id="g5"
+       transform="matrix(0,0.02189513,-0.02189513,0,49.905227,160.35833)"
+       style="fill:#ffffff;fill-opacity:1;stroke:none">
+	<path
+   id="path5"
+   style="fill:#ffffff;fill-opacity:1;stroke:none"
+   class="st0"
+   d="m 187.64684,-0.00670467 c -31.31297,0 -56.68624,25.38881767 -56.68624,56.70178667 V 455.31782 c 0,31.31197 25.37327,56.68624 56.68624,56.68624 h 167.64555 c 31.31197,0 56.70179,-25.37427 56.70179,-56.68624 V 56.695082 c 0,-31.312969 -25.38982,-56.70178667 -56.70179,-56.70178667 z M 189.40647,19.365499 H 347.472 c 32.17406,0 42.63128,22.427903 42.63128,41.636246 V 413.69712 c 0,17.6192 -11.53333,41.12318 -38.65112,41.12318 H 189.40647 c -19.02726,0 -38.54505,-18.22698 -38.54505,-41.12318 V 60.504224 c 0,-23.138502 13.18539,-41.138725 38.54505,-41.138725 z m 85.50526,448.219311 c 8.09399,0 14.66131,6.05813 14.66131,14.66131 0,8.10999 -6.56732,14.67685 -14.66131,14.67685 -8.09399,0 -14.67685,-6.56786 -14.67685,-14.67685 0,-8.094 6.58286,-14.66131 14.67685,-14.66131 z"
+   sodipodi:nodetypes="sssssssssssssssssssssss" />
+</g></g><path
+     class="st0"
+     d="m 7.9904114,165.23558 v -0.44242 l -1.010372,0.67367 1.010372,0.58944 v -0.36885 c 0.520699,0.0574 0.986902,0.29155 1.338756,0.64306 0.406665,0.407 0.6575212,0.96695 0.6576432,1.58775 h 0.4490984 c -1.14e-4,-1.4042 -1.0740636,-2.55678 -2.4454976,-2.68265 z"
+     id="path17"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.012148" /><path
+     class="st0"
+     d="m 8.3633298,169.2121 c -1.124295,-0.10855 -2.010976,-1.04842 -2.026441,-2.20396 l -0.449098,0.006 c 0.0194,1.40399 1.108612,2.54144 2.481564,2.64878 l 0.006,0.44284 1.001163,-0.68735 -1.018267,-0.57564 z"
+     id="path18"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.012148" /></g></g><style
      type="text/css"
      id="style1">
 	.st0{fill:#000000;}


### PR DESCRIPTION
I removed this a while back because it seemed not very useful and I didn't want to draw another icon. Well, turns out does have users so now it's back.