### PR TITLE
RAIntegration fixes

### DIFF
--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -247,7 +247,7 @@ void FrameData::Submit(VulkanContext *vulkan, FrameSubmitType type, FrameDataSha
 	}
 
 	if (res == VK_ERROR_DEVICE_LOST) {
-		_assert_msg_(false, "Lost the Vulkan device in vkQueueSubmit! If this happens again, switch Graphics Backend away from Vulkan");
+		_assert_msg_(false, "Lost the Vulkan device in vkQueueSubmit!\n\nIf this happens again, switch Graphics Backend away from Vulkan");
 	} else {
 		_assert_msg_(res == VK_SUCCESS, "vkQueueSubmit failed (main)! result=%s", VulkanResultToString(res));
 	}

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -578,6 +578,12 @@ static void raintegration_event_handler(const rc_client_raintegration_event_t *e
 		// it's appropriate, but the event lets the frontend do things like enable/disable rewind or cheats.
 		g_Config.bAchievementsHardcoreMode = rc_client_get_hardcore_enabled(client);
 		break;
+	case RC_CLIENT_RAINTEGRATION_EVENT_MENU_CHANGED:
+		System_RunCallbackInWndProc([](void *vhWnd, void *userdata) {
+			HWND hWnd = reinterpret_cast<HWND>(vhWnd);
+			rc_client_raintegration_rebuild_submenu(g_rcClient, GetMenu(hWnd));
+		}, nullptr);
+		break;
 	default:
 		ERROR_LOG(Log::Achievements, "Unsupported RAIntegration event %u\n", event->type);
 		break;

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -980,8 +980,8 @@ namespace MainWindow {
 			break;
 
 		default:
-			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
-				if (wmId >= ID_FILE_SAVESTATE_SLOT_BASE && wmId < ID_FILE_SAVESTATE_SLOT_BASE + g_Config.iSaveStateSlotCount) {
+			if (wmId >= ID_FILE_SAVESTATE_SLOT_BASE && wmId < ID_FILE_SAVESTATE_SLOT_BASE + g_Config.iSaveStateSlotCount) {
+				if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 					g_Config.iCurrentStateSlot = wmId - ID_FILE_SAVESTATE_SLOT_BASE;
 				}
 				break;


### PR DESCRIPTION
Fix an issue that ate menu events, and add support for the menu rebuild event (the way I assume it's supposed to work).

RAIntegration still has problems loading a second game in the same process, for some reason.