### PR TITLE
Analog stick autorotation now uses game timing

### DIFF
--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -651,8 +651,11 @@ void ControlMapper::Axis(const AxisInput *axes, size_t count) {
 	KeyMap::UnlockMappings();
 }
 
-void ControlMapper::Update(const DisplayLayoutConfig &config, double now) {
+void ControlMapper::UpdateConfig(const DisplayLayoutConfig &config) {
 	iInternalScreenRotationCached_ = config.bRotateControlsWithScreen ? config.iInternalScreenRotation : ROTATION_LOCKED_HORIZONTAL;
+}
+
+void ControlMapper::UpdateAutoMovements(double now) {
 	if (autoRotatingAnalogCW_) {
 		// Clamp to a square
 		float x = std::min(1.0f, std::max(-1.0f, 1.42f * (float)cos(now * -g_Config.fAnalogAutoRotSpeed)));

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -25,7 +25,8 @@ public:
 // Main use is of course from EmuScreen.cpp, but also useful from control settings etc.
 class ControlMapper {
 public:
-	void Update(const DisplayLayoutConfig &config, double now);
+	void UpdateConfig(const DisplayLayoutConfig &config);
+	void UpdateAutoMovements(double now);
 
 	// Inputs to the table-based mapping
 	// These functions are free-threaded.

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -53,6 +53,7 @@
 #include "Core/HW/Display.h"
 #include "Core/Util/PPGeDraw.h"
 #include "Core/RetroAchievements.h"
+#include "Core/ControlMapper.h"
 
 #include "GPU/GPU.h"
 #include "GPU/GPUState.h"
@@ -540,6 +541,9 @@ void hleEnterVblank(u64 userdata, int cyclesLate) {
 	if (wokeThreads) {
 		__KernelReSchedule("entered vblank");
 	}
+
+	// We use the emulation timebase here, for auto movements to be smooth as seen from the game.
+	g_controlMapper.UpdateAutoMovements(CoreTiming::GetGlobalTimeUs() / 1000000.0);
 
 	numVBlanksSinceFlip++;
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ What's new in 1.19
 	- As usual a lot of tweaks, perf fixes, and fixes for hangs and crashes ([#20343], [#20332], [#20305], [#20303], [#20299], [#20163], [#20152], [#20143], [#20079], [#20137], [#20374])
 	- Two new color themes ([#20334], [#20335]), related themability fixes ([#19984], [#19995], [#20308])
 	- Improvements and bug fixes in the savedata manager ([#19771], [#20170])
-	- Add "Move to trash" deletion funcionality to multiple platforms ([#20230], [#20261])
+	- Add "Move to trash" deletion functionality to multiple platforms ([#20230], [#20261])
 	- Add ability to take "raw" screenshots of gameplay ([#20029])
 	- More files can be loaded directly from ZIP ([#20243])
 	- Developer Settings are now tabbed for easier access ([#20228])

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -501,7 +501,7 @@ void AnalogCalibrationScreen::SetRawAnalog(int stick, float x, float y) {
 }
 
 void AnalogCalibrationScreen::update() {
-	g_controlMapper.Update(g_Config.GetDisplayLayoutConfig(GetDeviceOrientation()), time_now_d());
+	g_controlMapper.UpdateConfig(g_Config.GetDisplayLayoutConfig(GetDeviceOrientation()));
 	// We ignore the secondary stick for now and just use the two views
 	// for raw and psp input.
 	if (stickView_[0]) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1495,7 +1495,7 @@ void EmuScreen::update() {
 	double now = time_now_d();
 
 	DisplayLayoutConfig &config = g_Config.GetDisplayLayoutConfig(GetDeviceOrientation());
-	g_controlMapper.Update(config, now);
+	g_controlMapper.UpdateConfig(config);
 
 	if (saveStatePreview_ && !bootPending_) {
 		int currentSlot = SaveState::GetCurrentSlot();


### PR DESCRIPTION
Should fix frameskipping problem, where this didn't work in God of War (for those quick time events) if frameskipping was on.