### PR TITLE
Depth raster: Handle triangles properly when backface culling is disabled

### DIFF
--- a/GPU/Common/DepthRaster.cpp
+++ b/GPU/Common/DepthRaster.cpp
@@ -409,6 +409,8 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 		return true;
 	};
 
+	const bool cullDisabled = !draw.cullEnabled;
+
 	for (int i = 0; i < count; i += 3) {
 		// Collect valid triangles into buffer.
 		const float *v0 = transformed + indexBuffer[i] * 4;
@@ -420,6 +422,14 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 			verts[collected] = v0;
 			verts[collected + 1] = v1;
 			verts[collected + 2] = v2;
+			if (cullDisabled) {
+				collected += 3;
+				// Add the reverse triangle too. We could alternatively handle culling later in the pipeline, but mainly
+				// Syphon Filter needs this (issue #21498) and this simplifies things.
+				verts[collected] = v0;
+				verts[collected + 1] = v2;
+				verts[collected + 2] = v1;
+			}
 			collected += 3;
 		} else {
 			planeCulled++;
@@ -433,12 +443,12 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 			collected = 12;
 		}
 
-		if (collected != 12) {
+		if (collected < 12) {
 			// Fetch more!
 			continue;
 		}
 
-		collected = 0;
+		collected -= 12;
 
 		// These names are wrong .. until we transpose.
 		Vec4F32 x0 = Vec4F32::Load(verts[0]);
@@ -505,7 +515,7 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 		x2 &= inGuardBand;
 
 		// Floating point double triangle area. Can't be reused for the integer-snapped raster reliably (though may work...)
-		// Still good for culling early and pretty cheap to compute.
+		// Still good for backface culling early and pretty cheap to compute.
 		Vec4F32 doubleTriArea = (x1 - x0) * (y2 - y0) - (x2 - x0) * (y1 - y0) - Vec4F32::Splat((float)(MIN_TWICE_TRI_AREA));
 		if (!AnyZeroSignBit(doubleTriArea)) {
 			gpuStats.numDepthRasterEarlySize += 4;

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -1141,7 +1141,6 @@ void DrawEngineCommon::FlushQueuedDepth() {
 
 	const bool collectStats = coreCollectDebugStats;
 	const bool lowQ = g_Config.iDepthRasterMode == (int)DepthRasterMode::LOW_QUALITY;
-
 	for (const auto &draw : depthDraws_) {
 		int *tx = depthScreenVerts_;
 		int *ty = depthScreenVerts_ + DEPTH_SCREENVERTS_COMPONENT_COUNT;
@@ -1168,9 +1167,13 @@ void DrawEngineCommon::FlushQueuedDepth() {
 				break;
 			}
 		}
-		{
+		if (outVertCount > 0) {
 			TimeCollector collectStat(&gpuStats.msRasterizeDepth, collectStats);
-			DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw, tileScissor, lowQ);
+			if (!Memory::IsValid4AlignedAddress(draw.depthAddr)) {
+				continue;
+			}
+			u16 *depthPtr = (uint16_t *)Memory::GetPointerWriteUnchecked(draw.depthAddr);
+			DepthRasterScreenVerts(depthPtr, draw.depthStride, tx, ty, tz, outVertCount, draw, tileScissor, lowQ);
 		}
 	}
 

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1344,6 +1344,9 @@ void DrawMediaDecodersView(ImConfig &cfg, ImControl &control) {
 					if (ctx->BufferState() == ATRAC_STATUS_ALL_DATA_LOADED) {
 						if (ImGui::Button("Save to disk...")) {
 							System_BrowseForFileSave(cfg.requesterToken, "Save AT3 file", "song.at3", BrowseFileType::ATRAC3, [=](const std::string &filename, int) {
+								if (!Memory::IsValidRange(info.buffer, info.bufferByte)) {
+									return;
+								}
 								const u8 *data = Memory::GetPointerRange(info.buffer, info.bufferByte);
 								if (!data) {
 									return;

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -426,31 +426,34 @@ bool ImGePixelViewer::FormatValueAt(char *buf, size_t bufSize, int x, int y) con
 	// Go look directly in RAM.
 	int bpp = BufferFormatBytesPerPixel(format);
 	u32 pixelAddr = addr + (y * stride + x) * bpp;
+	if (!Memory::IsValidAddress(pixelAddr)) {
+		return false;
+	}
 	switch (format) {
 	case GE_FORMAT_8888:
-		snprintf(buf, bufSize, "%08x", Memory::Read_U32(pixelAddr));
+		snprintf(buf, bufSize, "%08x", Memory::ReadUnchecked_U32(pixelAddr));
 		break;
 	case GE_FORMAT_4444:
 	{
-		u16 raw = Memory::Read_U16(pixelAddr);
+		u16 raw = Memory::ReadUnchecked_U16(pixelAddr);
 		snprintf(buf, bufSize, "%08x (raw: %04x)", RGBA4444ToRGBA8888(raw), raw);
 		break;
 	}
 	case GE_FORMAT_565:
 	{
-		u16 raw = Memory::Read_U16(pixelAddr);
+		u16 raw = Memory::ReadUnchecked_U16(pixelAddr);
 		snprintf(buf, bufSize, "%08x (raw: %04x)", RGB565ToRGBA8888(raw), raw);
 		break;
 	}
 	case GE_FORMAT_5551:
 	{
-		u16 raw = Memory::Read_U16(pixelAddr);
+		u16 raw = Memory::ReadUnchecked_U16(pixelAddr);
 		snprintf(buf, bufSize, "%08x (raw: %04x)", RGBA5551ToRGBA8888(raw), raw);
 		break;
 	}
 	case GE_FORMAT_DEPTH16:
 	{
-		u16 raw = Memory::Read_U16(pixelAddr);
+		u16 raw = Memory::ReadUnchecked_U16(pixelAddr);
 		snprintf(buf, bufSize, "%0.4f (raw: %04x / %d)", (float)raw / 65535.0f, raw, raw);
 		break;
 	}
@@ -779,7 +782,7 @@ void ImGeDisasmView::Draw(GPUDebugInterface *gpuDebug) {
 		if (Memory::IsValid4AlignedAddress(addr)) {
 			draw_list->AddText(lineStart, 0xFFC0C0C0, addrBuffer);
 
-			u32 opcode = Memory::Read_U32(addr);
+			u32 opcode = Memory::ReadUnchecked_U32(addr);
 			GPUDebugOp op = gpuDebug->DisassembleOp(addr, opcode);
 			u32 color = 0xFFFFFFFF;
 			char temp[16];
@@ -842,7 +845,7 @@ void ImGeDisasmView::Draw(GPUDebugInterface *gpuDebug) {
 			}
 		} else if (Memory::IsValid4AlignedAddress(dragAddr_)) {
 			char buffer[64];
-			u32 opcode = Memory::Read_U32(dragAddr_);
+			u32 opcode = Memory::ReadUnchecked_U32(dragAddr_);
 			GPUDebugOp op = gpuDebug->DisassembleOp(dragAddr_, opcode);
 			// affect dragAddr_?
 			if (ImGui::MenuItem("Copy Address", NULL, false)) {
@@ -1182,7 +1185,8 @@ void ImGeDebuggerWindow::Draw(ImConfig &cfg, ImControl &control, GPUDebugInterfa
 	DisplayList list;
 	bool isOnBlockTransfer = false;
 	if (gpuDebug->GetCurrentDisplayList(list)) {
-		op = Memory::Read_U32(list.pc);
+		_dbg_assert_(Memory::IsValid4AlignedAddress(list.pc));
+		op = Memory::ReadUnchecked_U32(list.pc);
 
 		// TODO: Also add support for block transfer previews!
 

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -998,7 +998,7 @@ void ImMemDumpWindow::Draw(ImConfig &cfg, MIPSDebugInterface *debug) {
 				errorMsg_ = "Couldn't open file for writing";
 			} else {
 				if (mode_ == MemDumpMode::Raw) {
-					const uint8_t *ptr = Memory::GetPointer(address_);
+					const uint8_t *ptr = Memory::GetPointerUnchecked(address_);
 					fwrite(ptr, 1, size_, file);
 				} else {
 					std::string disassembly = DisassembleRange(address_, size_, true, debug);


### PR DESCRIPTION
Fixes #21498 

Thanks @Blakrajder for the detailed reporting!

Also fixes a few misbehaviors in the GE debugger.