### PR TITLE
Implement pause on lost focus on SDL

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -318,6 +318,9 @@ static const ConfigSetting generalSettings[] = {
 
 #if defined(USING_WIN_UI)
 	ConfigSetting("TopMost", SETTING(g_Config, bTopMost), false, CfgFlag::DEFAULT),
+#endif
+
+#if defined(USING_WIN_UI) || (defined (SDL) && !defined(MOBILE_DEVICE))
 	ConfigSetting("PauseOnLostFocus", SETTING(g_Config, bPauseOnLostFocus), false, CfgFlag::PER_GAME),
 #endif
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -195,9 +195,9 @@ public:
 	int iLogOutputTypes;  // enum class LogOutput
 	int iDumpFileTypes;  // DumpFileType bitflag enum
 	bool bFullscreenOnDoubleclick;
-
-	// These four are Win UI only
 	bool bPauseOnLostFocus;
+
+	// These are Win UI only
 	bool bTopMost;
 	bool bIgnoreWindowsKey;
 	bool bRestartRequired;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -997,6 +997,22 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			break;
 		}
 
+		case SDL_WINDOWEVENT_FOCUS_LOST:
+		{
+			if (g_Config.bPauseOnLostFocus && GetUIState() == UISTATE_INGAME) {
+				Core_Break(BreakReason::UIFocus, 0);
+			}
+		}
+		break;
+
+		case SDL_WINDOWEVENT_FOCUS_GAINED:
+		{
+			if (Core_BreakReason() == BreakReason::UIFocus) {
+				Core_Resume();
+			}
+		}
+		break;
+
 		case SDL_WINDOWEVENT_MINIMIZED:
 		case SDL_WINDOWEVENT_HIDDEN:
 			Native_NotifyWindowHidden(true);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1431,7 +1431,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	static const char *screenshotModeChoices[] = { "Final processed image", "Raw game image" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iScreenshotMode, sy->T("Screenshot mode"), screenshotModeChoices, 0, ARRAY_SIZE(screenshotModeChoices), I18NCat::SYSTEM, screenManager()));
 	// TODO: Make this setting available on Mac too.
-#if PPSSPP_PLATFORM(WINDOWS)
+#if PPSSPP_PLATFORM(WINDOWS) || (defined (SDL) && !defined(MOBILE_DEVICE))
 	systemSettings->Add(new CheckBox(&g_Config.bPauseOnLostFocus, sy->T("Pause when not focused")));
 #endif
 


### PR DESCRIPTION
This option was Windows exclusive and this commit implements it on SDL as well.

It is hidden on mobile devices because it makes no sense there.


Only tested on Linux.
It seems that `Core/Config.cpp` was checking `USING_WIN_UI` but `UI/GameSettingsScreen.cpp` `PPSSPP_PLATFORM(WINDOWS)`; dunno if this makes any difference.