### PR TITLE
libretro: set extra paths for webOS on gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,3 +174,4 @@ libretro-build-webos-armv7a:
   extends:
     - .libretro-webos-armv7a-cmake
     - .core-defs
+    - .cmake-defs


### PR DESCRIPTION
webOS need EXTRA_PATH set to build

https://git.libretro.com/libretro/ppsspp/-/jobs/1214094