### PR TITLE
Fix some textures getting stuck unscaled with GPU texture upscalers

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -883,9 +883,13 @@ VkResult VulkanContext::CreateDevice(int physical_device) {
 	case VULKAN_VENDOR_QUALCOMM:
 		devicePerfClass_ = PerfClass::SLOW;
 #if PPSSPP_PLATFORM(ANDROID)
+		// The roughest heuristic ever, this needs improvement.
 		if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 30) {
 			devicePerfClass_ = PerfClass::FAST;
 		}
+#elif PPSSPP_PLATFORM(WINDOWS)
+		// All the modern Qualcomm PC laptops are fast enough to be called FAST.
+		devicePerfClass_ = PerfClass::FAST;
 #endif
 		break;
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -544,7 +544,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 			}
 		}
 
-		if (match && (entry->status & TexCacheEntry::STATUS_TO_SCALE) && standardScaleFactor_ != 1 && texelsScaledThisFrame_ < TEXCACHE_MAX_TEXELS_SCALED) {
+		if (match && (entry->status & TexCacheEntry::STATUS_TO_SCALE) && (standardScaleFactor_ > 1 || shaderScaleFactor_ > 1) && texelsScaledThisFrame_ < TEXCACHE_MAX_TEXELS_SCALED) {
 			if ((entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
 				// INFO_LOG(Log::G3D, "Reloading texture to do the scaling we skipped..");
 				match = false;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -3102,3 +3102,58 @@ CheckAlphaResult TextureCacheCommon::CheckCLUTAlpha(const uint8_t *pixelData, GE
 		return CheckAlpha32((const u32 *)pixelData, w, 0xFF000000);
 	}
 }
+
+std::string TexStatusToString(TexCacheEntry::TexStatus status) {
+	std::string result;
+	switch (status & TexCacheEntry::STATUS_MASK) {
+	case TexCacheEntry::STATUS_HASHING:
+		result += "HASHING ";
+		break;
+	case TexCacheEntry::STATUS_RELIABLE:
+		result += "RELIABLE ";
+		break;
+	case TexCacheEntry::STATUS_UNRELIABLE:
+		result += "UNRELIABLE ";
+		break;
+	}
+	if (status & TexCacheEntry::STATUS_ALPHA_MASK) {
+		result += "ALPHA";
+	}
+	if (status & TexCacheEntry::STATUS_CLUT_VARIANTS) {
+		result += "CLUTVARIANTS ";
+	}
+	if (status & TexCacheEntry::STATUS_CLUT_RECHECK) {
+		result += "CLUT_RECHECK ";
+	}
+	if (status & TexCacheEntry::STATUS_CHANGE_FREQUENT) {
+		result += "FREQ ";
+	}
+	if (status & TexCacheEntry::STATUS_UNRELIABLE) {
+		result += "UNREL ";
+	}
+	if (status & TexCacheEntry::STATUS_TO_SCALE) {
+		result += "TOSCALE ";
+	}
+	if (status & TexCacheEntry::STATUS_IS_SCALED_OR_REPLACED) {
+		result += "SCALED/REPL ";
+	}
+	if (status & TexCacheEntry::STATUS_NO_MIPS) {
+		result += "NO_MIPS ";
+	}
+	if (status & TexCacheEntry::STATUS_CLUT_GPU) {
+		result += "CLUT_GPU ";
+	}
+	if (status & TexCacheEntry::STATUS_FORCE_REBUILD) {
+		result += "FORCE_REBUILD ";
+	}
+	if (status & TexCacheEntry::STATUS_3D) {
+		result += "3D ";
+	}
+	if (status & TexCacheEntry::STATUS_VIDEO) {
+		result += "VIDEO ";
+	}
+	if (status & TexCacheEntry::STATUS_BGRA) {
+		result += "BGRA ";
+	}
+	return result.empty() ? "None" : result;
+}

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -237,6 +237,8 @@ struct TexCacheEntry {
 	static u64 CacheKey(u32 addr, u8 format, u16 dim, u32 cluthash);
 };
 
+std::string TexStatusToString(TexCacheEntry::TexStatus status);
+
 // Can't be unordered_map, we use lower_bound ... although for some reason that (used to?) compiles on MSVC.
 // Would really like to replace this with DenseHashMap but can't as long as we need lower_bound.
 typedef std::map<u64, std::unique_ptr<TexCacheEntry>> TexCache;

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -174,7 +174,7 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 				ImGui::Image(texId, ImVec2(w, h));
 				ImGui::Text("%08x: %dx%d, %d mips, %s", (uint32_t)(cfg.selectedTexAddr & 0xFFFFFFFF), w, h, entry->maxLevel + 1, GeTextureFormatToString((GETextureFormat)entry->format));
 				ImGui::Text("Stride: %d", entry->bufw);
-				ImGui::Text("Status: %08x", entry->status);  // TODO: Show the flags
+				ImGui::Text("Status: %08x: %s", entry->status, TexStatusToString((TexCacheEntry::TexStatus)(entry->status)).c_str());
 				ImGui::Text("Hash: %08x", entry->fullhash);
 				ImGui::Text("CLUT Hash: %08x", entry->cluthash);
 				ImGui::Text("Minihash: %08x", entry->minihash);


### PR DESCRIPTION
Just a simple logic bug that didn't take into account GPU texture upscalers.

Noticed this while testing #21527 

Plus some minor ImGeDebugger improvements, and consider PC laptops with Qualcomm "fast".