### PR TITLE
Updating the HLE names of some functions

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -779,7 +779,7 @@ const HLEFunction ThreadManForUser[] =
 	{0X94416130, &WrapU_UUUU<sceKernelGetThreadmanIdList>,           "sceKernelGetThreadmanIdList",               'x', "xxxx"    },
 	{0X57CF62DD, &WrapU_U<sceKernelGetThreadmanIdType>,              "sceKernelGetThreadmanIdType",               'x', "x"       },
 	{0XBC80EC7C, &WrapU_UUU<sceKernelExtendThreadStack>,             "sceKernelExtendThreadStack",                'x', "xxx"     },
-	// NOTE: Takes a UID from sceKernelMemory's AllocMemoryBlock and seems thread stack related.
+	// NOTE: Takes a UID from sceKernelMemory's sceKernelAllocMemoryBlock and seems thread stack related.
 	//{0x28BFD974, nullptr,                                           "ThreadManForUser_28BFD974",                  '?', ""        },
 
 	{0X82BC5777, &WrapU64_V<sceKernelGetSystemTimeWide>,             "sceKernelGetSystemTimeWide",                'X', ""        },

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1626,22 +1626,22 @@ int sceKernelReferVplStatus(SceUID uid, u32 infoPtr) {
 	}
 }
 
-// this is an unnamed hle function
-static u32 AllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAddr) {
+
+static u32 sceKernelAllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAddr) {
 	if (Memory::IsValidAddress(paramsAddr) && Memory::Read_U32(paramsAddr) != 4) {
-		ERROR_LOG_REPORT(Log::sceKernel, "AllocMemoryBlock(%s): unsupported params size %d", pname, Memory::Read_U32(paramsAddr));
+		ERROR_LOG_REPORT(Log::sceKernel, "sceKernelAllocMemoryBlock(%s): unsupported params size %d", pname, Memory::Read_U32(paramsAddr));
 		return hleNoLog(SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT);
 	}
 	if (type != PSP_SMEM_High && type != PSP_SMEM_Low) {
-		ERROR_LOG_REPORT(Log::sceKernel, "AllocMemoryBlock(%s): unsupported type %d", pname, type);
+		ERROR_LOG_REPORT(Log::sceKernel, "sceKernelAllocMemoryBlock(%s): unsupported type %d", pname, type);
 		return hleNoLog(SCE_KERNEL_ERROR_ILLEGAL_MEMBLOCKTYPE);
 	}
 	if (size == 0) {
-		WARN_LOG_REPORT(Log::sceKernel, "AllocMemoryBlock(%s): invalid size %x", pname, size);
+		WARN_LOG_REPORT(Log::sceKernel, "sceKernelAllocMemoryBlock(%s): invalid size %x", pname, size);
 		return hleNoLog(SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED);
 	}
 	if (!pname) {
-		ERROR_LOG_REPORT(Log::sceKernel, "AllocMemoryBlock(): NULL name");
+		ERROR_LOG_REPORT(Log::sceKernel, "sceKernelAllocMemoryBlock(): NULL name");
 		return hleNoLog(SCE_KERNEL_ERROR_ERROR);
 	}
 
@@ -1651,16 +1651,16 @@ static u32 AllocMemoryBlock(const char *pname, u32 type, u32 size, u32 paramsAdd
 		return hleLogError(Log::sceKernel, SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED, "allocation failed");
 	}
 	SceUID uid = kernelObjects.Create(block);
-	return hleLogDebugOrError(Log::sceKernel, uid, "SysMemUserForUser_FE707FDF");
+	return hleLogDebugOrError(Log::sceKernel, uid, "sceKernelAllocMemoryBlock");
 }
 
-// this is an unnamed hle function
-static u32 FreeMemoryBlock(u32 uid) {
+
+static u32 sceKernelFreeMemoryBlock(u32 uid) {
 	return hleLogDebugOrError(Log::sceKernel, kernelObjects.Destroy<PartitionMemoryBlock>(uid));
 }
 
-// this is an unnamed hle function
-static u32 GetMemoryBlockPtr(u32 uid, u32 addr) {
+
+static u32 sceKernelGetMemoryBlockAddr(u32 uid, u32 addr) {
 	u32 error;
 	PartitionMemoryBlock *block = kernelObjects.Get<PartitionMemoryBlock>(uid, error);
 	if (block) {
@@ -2122,9 +2122,9 @@ const HLEFunction SysMemUserForUser[] = {
 	{0X6231A71D, nullptr,                                         "sceKernelSetPTRIG",                     '?', ""     },
 	{0X39F49610, nullptr,                                         "sceKernelGetPTRIG",                     '?', ""     },
 	// Obscure raw block API
-	{0XDB83A952, &WrapU_UU<GetMemoryBlockPtr>,                    "SysMemUserForUser_DB83A952",            'x', "xx"   },  // GetMemoryBlockAddr
-	{0X50F61D8A, &WrapU_U<FreeMemoryBlock>,                       "SysMemUserForUser_50F61D8A",            'x', "x"    },  // FreeMemoryBlock
-	{0XFE707FDF, &WrapU_CUUU<AllocMemoryBlock>,                   "SysMemUserForUser_FE707FDF",            'x', "sxxx" },  // AllocMemoryBlock
+	{0XDB83A952, &WrapU_UU<sceKernelGetMemoryBlockAddr>,          "sceKernelGetMemoryBlockAddr",           'x', "xx"   },
+	{0X50F61D8A, &WrapU_U<sceKernelFreeMemoryBlock>,              "sceKernelFreeMemoryBlock",              'x', "x"    },
+	{0XFE707FDF, &WrapU_CUUU<sceKernelAllocMemoryBlock>,          "sceKernelAllocMemoryBlock",             'x', "sxxx" },
 	{0XD8DE5C1E, &WrapU_V<SysMemUserForUser_D8DE5C1E>,            "SysMemUserForUser_D8DE5C1E",            'x', ""     },
 };
 

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -546,7 +546,8 @@ static int scePowerTick() {
 	return hleLogDebug(Log::sceMisc, 0);
 }
 
-static u32 IsPSPNonFat() {
+static u32 scePowerCheckWlanCoexistenceClock() {
+	// PSP-1000 vs PSP-2000/3000
 	return hleLogDebug(Log::sceMisc, g_Config.iPSPModel);
 }
 
@@ -603,7 +604,7 @@ static const HLEFunction scePower[] = {
 	{0X469989AD, &WrapU_UUU<scePowerSetClockFrequency>,       "scePower_469989ad",                 'x', "xxx"}, // This is also the same as SetClockFrequency
 	{0X545A7F3C, nullptr,                                     "scePower_545A7F3C",                 '?', ""   }, // TODO: Supposedly the same as SetClockFrequency also?
 	{0XA4E93389, nullptr,                                     "scePower_A4E93389",                 '?', ""   }, // TODO: Supposedly the same as SetClockFrequency also?
-	{0XA85880D0, &WrapU_V<IsPSPNonFat>,                       "scePower_a85880d0_IsPSPNonFat",     'x', ""   },
+	{0XA85880D0, &WrapU_V<scePowerCheckWlanCoexistenceClock>, "scePowerCheckWlanCoexistenceClock", 'x', ""   },
 	{0X3951AF53, nullptr,                                     "scePowerWaitRequestCompletion",     '?', ""   },
 	{0X0442D852, nullptr,                                     "scePowerRequestColdReset",          '?', ""   },
 	{0XBAFA3DF0, nullptr,                                     "scePowerGetCallbackMode",           '?', ""   },


### PR DESCRIPTION
The [Libdoc](https://artart78.github.io/PSPLibDoc/modules/sysmem.prx_SysMemUserForUser.html) and the [psdevwiki](https://www.psdevwiki.com/ps3/PSP_Emulation) list the memory raw block API functions as `sceKernelGetMemoryBlockAddr`, `sceKernelFreeMemoryBlock` and `sceKernelAllocMemoryBlock`. I don't have much to say about these 3.

I also have been thinking about renaming the incredibly ugly `scePower_a85880d0_IsPSPNonFat` to `scePowerCheckWlanCoexistenceClock` (from the same wiki). We currently call the implementation `IsPSPNonFat`, which means "is PSP slim aka PSP-2000/3000?". False means "we are fat aka PSP-1000". The way I understand it is if the WLAN is enabled, PSP's clock freq is capped on the original model, so the name `scePowerCheckWlanCoexistenceClock` makes sense. By the way, I don't think we emulate this. Maybe it's not important.

Why these funcs? I ran into them while looking into PSP2i. And I've also checked how this `scePower_a85880d0` func is used there... Well... The value is compared to 1 and then passed as arg to a clock configuring function. And it goes like:
```c++
  uint freq = 333;
  if (param_1 != 1) {
    freq = 222;
  }
  iVar1 = scePowerSetClockFrequency(freq, freq, freq >> 1);
```
So yes, it really is used as a dynamic check to make sure the same code can run on both old and newer models and get the max possible frequency.

Note: we can hold this PR if you're not ready to accept these names yet. Just something I think we *could* clean up.