### PR TITLE
Fix for auto-installing plugins from zip

### DIFF
--- a/Common/UI/Notice.h
+++ b/Common/UI/Notice.h
@@ -30,6 +30,10 @@ public:
 	void SetLevel(NoticeLevel level) {
 		level_ = level;
 	}
+	void SetLevelAndText(NoticeLevel level, std::string_view text) {
+		level_ = level;
+		text_ = text;
+	}
 	void SetSquishy(bool squishy) {
 		squishy_ = squishy;
 	}

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -509,21 +509,22 @@ void DetectZipFileContents(zip_t *z, ZipFileInfo *info) {
 		totalFileSize += stat.size;
 
 		std::string fileName(fn);
-		std::string zippedName = fileName;  // actually, lowercase-name
-		std::transform(zippedName.begin(), zippedName.end(), zippedName.begin(),
-			[](unsigned char c) { return asciitolower(c); });  // Not using std::tolower to avoid Turkish I->ı conversion.
-		// Ignore macos metadata stuff
-		if (startsWith(zippedName, "__macosx/")) {
-			continue;
-		}
-		if (endsWith(zippedName, "/")) {
+		if (endsWith(fileName, "/")) {
 			// A directory. Not all zips bother including these.
 			continue;
 		}
 
+		std::string lowerCaseName = fileName;  // actually, lowercase-name
+		std::transform(lowerCaseName.begin(), lowerCaseName.end(), lowerCaseName.begin(),
+			[](unsigned char c) { return asciitolower(c); });  // Not using std::tolower to avoid Turkish I->ı conversion.
+		// Ignore macos metadata stuff
+		if (startsWith(lowerCaseName, "__macosx/")) {
+			continue;
+		}
+
 		int prevSlashLocation = -1;
-		int slashCount = countSlashes(zippedName, &prevSlashLocation);
-		if (zippedName.find("eboot.pbp") != std::string::npos) {
+		int slashCount = countSlashes(lowerCaseName, &prevSlashLocation);
+		if (lowerCaseName.find("eboot.pbp") != std::string::npos) {
 			if (slashCount >= 1 && (!isPSPMemstickGame || prevSlashLocation < stripChars + 1)) {
 				stripChars = prevSlashLocation + 1;
 				isPSPMemstickGame = true;
@@ -531,11 +532,11 @@ void DetectZipFileContents(zip_t *z, ZipFileInfo *info) {
 				INFO_LOG(Log::HLE, "Wrong number of slashes (%i) in '%s'", slashCount, fn);
 			}
 			// TODO: Extract icon and param.sfo from the pbp to be able to display it on the install screen.
-		} else if (endsWith(zippedName, ".iso") || endsWith(zippedName, ".cso") || endsWith(zippedName, ".chd")) {
+		} else if (endsWith(lowerCaseName, ".iso") || endsWith(lowerCaseName, ".cso") || endsWith(lowerCaseName, ".chd")) {
 			if (slashCount <= 1) {
 				// We only do this if the ISO file is in the root or one level down.
 				isZippedISO = true;
-				INFO_LOG(Log::HLE, "ISO found in zip: %s", zippedName.c_str());
+				INFO_LOG(Log::HLE, "ISO found in zip: %s", lowerCaseName.c_str());
 				if (info->isoFileIndex != -1) {
 					INFO_LOG(Log::HLE, "More than one ISO file found in zip. Ignoring additional ones.");
 				} else {
@@ -543,27 +544,27 @@ void DetectZipFileContents(zip_t *z, ZipFileInfo *info) {
 					info->contentName = fn;
 				}
 			}
-		} else if (zippedName.find("textures.ini") != std::string::npos) {
-			int slashLocation = (int)zippedName.find_last_of('/');
+		} else if (lowerCaseName.find("textures.ini") != std::string::npos) {
+			int slashLocation = (int)lowerCaseName.find_last_of('/');
 			if (stripCharsTexturePack == -1 || slashLocation < stripCharsTexturePack + 1) {
 				stripCharsTexturePack = slashLocation + 1;
 				isTexturePack = true;
 				info->textureIniIndex = i;
 			}
-		} else if (endsWith(zippedName, ".ppdmp")) {
+		} else if (endsWith(lowerCaseName, ".ppdmp")) {
 			isFrameDump = true;
 			info->isoFileIndex = i;
 			info->contentName = fn;
-		} else if (endsWith(zippedName, ".ppst")) {
-			int slashLocation = (int)zippedName.find_last_of('/');
+		} else if (endsWith(lowerCaseName, ".ppst")) {
+			int slashLocation = (int)lowerCaseName.find_last_of('/');
 			if (stripChars == 0 || slashLocation < stripChars + 1) {
 				stripChars = slashLocation + 1;
 			}
 			isSaveStates = true;
 			info->gameTitle = fn;
-		} else if (endsWith(zippedName, "psp_game/sysdir/eboot.bin") || endsWith(zippedName, "psp_game/sysdir/boot.bin")) {
+		} else if (endsWith(lowerCaseName, "psp_game/sysdir/eboot.bin") || endsWith(lowerCaseName, "psp_game/sysdir/boot.bin")) {
 			isExtractedISO = true;
-		} else if (endsWith(zippedName, "/param.sfo")) {
+		} else if (endsWith(lowerCaseName, "/param.sfo")) {
 			// Get the game name so we can display it.
 			std::string paramSFOContents;
 			if (ZipExtractFileToMemory(z, i, &paramSFOContents)) {
@@ -581,13 +582,18 @@ void DetectZipFileContents(zip_t *z, ZipFileInfo *info) {
 					}
 				}
 			}
-		} else if (endsWith(zippedName, "/icon0.png")) {
+		} else if (endsWith(lowerCaseName, "/icon0.png")) {
 			hasIcon0PNG = true;
-		} else if (endsWith(zippedName, "/plugin.ini") && slashCount == 1) {
+		} else if (endsWith(lowerCaseName, "/plugin.ini") && slashCount >= 1) {
+			int slashLocation = (int)lowerCaseName.find_last_of('/');
+			// Find previous slash to determine the root of the plugin, so we can display it properly.
+			int prevSlashLocation = (int)lowerCaseName.find_last_of('/', slashLocation - 1);
+			_dbg_assert_(prevSlashLocation != std::string::npos);
+			stripChars = prevSlashLocation + 1;
 			hasPluginIni = true;
 			ZipExtractFileToMemory(z, i, &info->iniContents);
 			info->contentName = fileName.substr(0, fileName.find_last_of('/'));
-		} else if (endsWith(zippedName, ".prx") && slashCount == 1) {
+		} else if (endsWith(lowerCaseName, ".prx")) {
 			hasPRX = true;
 		}
 		if (slashCount == 0) {

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -175,7 +175,7 @@ void GameManager::Update() {
 	}
 }
 
-bool ZipCanExtractWithoutOverwrite(struct zip *z, const Path &destination, int maxOkFiles) {
+bool ZipCanExtractWithoutOverwrite(struct zip *z, const Path &destination, int stripChars, int maxOkFiles) {
 	int numFiles = zip_get_num_files(z);
 	if (numFiles > maxOkFiles && maxOkFiles >= 0) {
 		// Ignore the check, just assume we can't.
@@ -260,7 +260,7 @@ void GameManager::InstallZipContents(ZipFileTask task) {
 	}
 
 	// Check for 7z. We don't support very many scenarios here yet, but we do support ISO install.
-	if (task.zipFileInfo->archiveType == ArchiveType::SevenZ) {
+	if (task.zipFileInfo && task.zipFileInfo->archiveType == ArchiveType::SevenZ) {
 		Path destPath = task.destination;
 		g_OSD.SetProgressBar("install", di->T("Installing..."), 0.0f, 0.0f, 0.0f, 0.1f);
 		Path fn(task.zipFileInfo->isoFilename);
@@ -662,7 +662,7 @@ bool GameManager::ExtractZipContents(struct zip *z, const Path &dest, const ZipF
 
 		bool isDir = zippedName.empty() || zippedName.back() == '/';
 		if (!isDir && zippedName.find('/') != std::string::npos) {
-			outFilename = dest / zippedName.substr(0, zippedName.rfind('/'));
+			outFilename = dest / zippedName.substr(info.stripChars, zippedName.rfind('/') - info.stripChars);
 		} else if (!isDir) {
 			outFilename = dest;
 		}

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -119,4 +119,4 @@ private:
 
 extern GameManager g_GameManager;
 
-bool ZipCanExtractWithoutOverwrite(struct zip *z, const Path &destination, int maxOkFiles);
+bool ZipCanExtractWithoutOverwrite(struct zip *z, const Path &destination, int stripChars, int maxOkFiles);

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block"
@@ -139,9 +139,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -598,15 +598,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -748,12 +747,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -842,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -873,9 +872,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1045,9 +1044,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1165,9 +1164,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1289,7 +1288,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1298,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1361,9 +1360,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1401,7 +1400,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1567,7 +1566,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -1662,9 +1661,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -1718,7 +1717,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -1865,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1878,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1888,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1898,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1911,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1946,7 +1945,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2013,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2395,7 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -165,8 +165,6 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 			leftColumn->Add(new TextView(zipFileInfo_.contentName));
 		}
 
-		doneView_ = leftColumn->Add(new TextView(""));
-
 		if (zipFileInfo_.contents == ZipFileContents::ISO_FILE) {
 			const bool isInDownloads = File::IsProbablyInDownloadsFolder(zipPath_);
 			Path parent;
@@ -205,7 +203,7 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 		leftColumn->Add(new TextView(GetFriendlyPath(zipPath_)));
 		Path pluginsDir = GetSysDirectory(DIRECTORY_PLUGINS);
 		ZipContainer zipFile = ZipOpenPath(zipPath_);
-		overwrite = !ZipCanExtractWithoutOverwrite(zipFile, pluginsDir, 50);
+		overwrite = !ZipCanExtractWithoutOverwrite(zipFile, pluginsDir, zipFileInfo_.stripChars, 50);
 		ZipClose(zipFile);
 		std::stringstream sstream(zipFileInfo_.iniContents);
 		IniFile ini;
@@ -236,7 +234,7 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 
 		Path savestateDir = GetSysDirectory(DIRECTORY_SAVESTATE);
 		ZipContainer zipFile = ZipOpenPath(zipPath_);
-		overwrite = !ZipCanExtractWithoutOverwrite(zipFile, savestateDir, 50);
+		overwrite = !ZipCanExtractWithoutOverwrite(zipFile, savestateDir, zipFileInfo_.stripChars, 50);
 		ZipClose(zipFile);
 
 		destFolders_.push_back(savestateDir);
@@ -253,7 +251,7 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 
 		Path savedataDir = GetSysDirectory(DIRECTORY_SAVEDATA);
 		ZipContainer zipFile = ZipOpenPath(zipPath_);
-		overwrite = !ZipCanExtractWithoutOverwrite(zipFile, savedataDir, 50);
+		overwrite = !ZipCanExtractWithoutOverwrite(zipFile, savedataDir, zipFileInfo_.stripChars, 50);
 		ZipClose(zipFile);
 
 		destFolders_.push_back(savedataDir);
@@ -307,7 +305,8 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 		break;
 	}
 
-	doneView_ = leftColumn->Add(new TextView(""));
+	doneView_ = leftColumn->Add(new NoticeView(NoticeLevel::SUCCESS, "", ""));
+	doneView_->SetVisibility(Visibility::V_GONE);
 
 	if (destFolders_.size() > 1) {
 		leftColumn->Add(new TextView(iz->T("Install into folder")));
@@ -374,11 +373,14 @@ void InstallZipScreen::update() {
 		}
 		std::string err = g_GameManager.GetInstallError();
 		if (!err.empty()) {
-			if (doneView_)
-				doneView_->SetText(iz->T(err));
+			if (doneView_) {
+				doneView_->SetLevelAndText(NoticeLevel::ERROR, iz->T(err));
+				doneView_->SetVisibility(Visibility::V_VISIBLE);
+			}
 		} else if (installStarted_) {
 			if (doneView_) {
-				doneView_->SetText(iz->T("Installed!"));
+				doneView_->SetLevelAndText(NoticeLevel::SUCCESS, iz->T("Installed!"));
+				doneView_->SetVisibility(Visibility::V_VISIBLE);
 			}
 			if (playChoice_) {
 				// Encourage the user to back out and play directly from the main screen,

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -24,6 +24,7 @@
 
 #include "UI/BaseScreens.h"
 #include "UI/SimpleDialogScreen.h"
+#include "Common/UI/Notice.h"
 
 class SavedataView;
 
@@ -49,7 +50,7 @@ private:
 	UI::Choice *installChoice_ = nullptr;
 	UI::Choice *playChoice_ = nullptr;
 	UI::Choice *backChoice_ = nullptr;
-	UI::TextView *doneView_ = nullptr;
+	NoticeView *doneView_ = nullptr;
 	SavedataView *existingSaveView_ = nullptr;
 	Path savedataToOverwrite_;
 	Path zipPath_;


### PR DESCRIPTION
If the directory structure wasn't 1-level, we previously rejected zips with plugin.ini.

Now we can auto-install them. This will make it much easier to add existing plugins to the homebrew store in the near future.