### PR TITLE
UI: Instant type-to-search in game browsers

### DIFF
--- a/Common/Math/geom2d.h
+++ b/Common/Math/geom2d.h
@@ -19,7 +19,7 @@ struct Point2D {
 	}
 
 	/*
-	FocusDirection directionTo(const Point &other) const {
+	FocusMove directionTo(const Point &other) const {
 		int angle = atan2f(other.y - y, other.x - x) / (2 * M_PI) - 0.125;
 
 	}*/

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -148,7 +148,7 @@ void LayoutViewHierarchy(const UIContext &dc, const UI::Margins &rootMargins, Vi
 	root->Layout();
 }
 
-static void MoveFocus(ViewGroup *root, FocusDirection direction) {
+static void MoveFocus(ViewGroup *root, FocusMove direction) {
 	View *focusedView = GetFocusedView();
 	if (!focusedView) {
 		// Nothing was focused when we got in here. Focus the first non-group in the hierarchy.
@@ -406,15 +406,15 @@ DialogResult UpdateViewHierarchy(ViewGroup *root) {
 		} else {
 			for (size_t i = 0; i < focusMoves.size(); i++) {
 				switch (focusMoves[i]) {
-				case NKCODE_DPAD_LEFT: MoveFocus(root, FOCUS_LEFT); break;
-				case NKCODE_DPAD_RIGHT: MoveFocus(root, FOCUS_RIGHT); break;
-				case NKCODE_DPAD_UP: MoveFocus(root, FOCUS_UP); break;
-				case NKCODE_DPAD_DOWN: MoveFocus(root, FOCUS_DOWN); break;
-				case NKCODE_PAGE_UP: MoveFocus(root, FOCUS_PREV_PAGE); break;
-				case NKCODE_PAGE_DOWN: MoveFocus(root, FOCUS_NEXT_PAGE); break;
-				case NKCODE_MOVE_HOME: MoveFocus(root, FOCUS_FIRST); break;
-				case NKCODE_MOVE_END: MoveFocus(root, FOCUS_LAST); break;
-				case NKCODE_TAB: MoveFocus(root, FOCUS_NEXT); break;
+				case NKCODE_DPAD_LEFT: MoveFocus(root, FocusMove::LEFT); break;
+				case NKCODE_DPAD_RIGHT: MoveFocus(root, FocusMove::RIGHT); break;
+				case NKCODE_DPAD_UP: MoveFocus(root, FocusMove::UP); break;
+				case NKCODE_DPAD_DOWN: MoveFocus(root, FocusMove::DOWN); break;
+				case NKCODE_PAGE_UP: MoveFocus(root, FocusMove::PREV_PAGE); break;
+				case NKCODE_PAGE_DOWN: MoveFocus(root, FocusMove::NEXT_PAGE); break;
+				case NKCODE_MOVE_HOME: MoveFocus(root, FocusMove::FIRST); break;
+				case NKCODE_MOVE_END: MoveFocus(root, FocusMove::LAST); break;
+				case NKCODE_TAB: MoveFocus(root, FocusMove::NEXT); break;
 				}
 			}
 		}

--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -365,7 +365,7 @@ bool ScrollView::SubviewFocused(View *view) {
 	return true;
 }
 
-NeighborResult ScrollView::FindScrollNeighbor(View *view, const Point2D &target, FocusDirection direction, NeighborResult best) {
+NeighborResult ScrollView::FindScrollNeighbor(View *view, const Point2D &target, FocusMove direction, NeighborResult best) {
 	if (ContainsSubview(view) && views_[0]->IsViewGroup()) {
 		ViewGroup *vg = static_cast<ViewGroup *>(views_[0]);
 		int found = -1;
@@ -381,10 +381,10 @@ NeighborResult ScrollView::FindScrollNeighbor(View *view, const Point2D &target,
 		if (found != -1) {
 			float mult = 0.0f;
 			switch (direction) {
-			case FOCUS_PREV_PAGE:
+			case FocusMove::PREV_PAGE:
 				mult = -1.0f;
 				break;
-			case FOCUS_NEXT_PAGE:
+			case FocusMove::NEXT_PAGE:
 				mult = 1.0f;
 				break;
 			default:

--- a/Common/UI/ScrollView.h
+++ b/Common/UI/ScrollView.h
@@ -48,7 +48,7 @@ public:
 		shadows_ = shadows;
 	}
 
-	NeighborResult FindScrollNeighbor(View *view, const Point2D &target, FocusDirection direction, NeighborResult best) override;
+	NeighborResult FindScrollNeighbor(View *view, const Point2D &target, FocusMove direction, NeighborResult best) override;
 
 private:
 	Margins GetMargins() const;

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -160,25 +160,25 @@ void View::PersistData(PersistStatus status, std::string anonId, PersistMap &sto
 	}
 }
 
-Point2D View::GetFocusPosition(FocusDirection dir) const {
+Point2D View::GetFocusPosition(FocusMove dir) const {
 	// The +2/-2 is some extra fudge factor to cover for views sitting right next to each other.
 	// Distance zero yields strange results otherwise.
 	switch (dir) {
-	case FOCUS_LEFT: return Point2D(bounds_.x + 2, bounds_.centerY());
-	case FOCUS_RIGHT: return Point2D(bounds_.x2() - 2, bounds_.centerY());
-	case FOCUS_UP: return Point2D(bounds_.centerX(), bounds_.y + 2);
-	case FOCUS_DOWN: return Point2D(bounds_.centerX(), bounds_.y2() - 2);
+	case FocusMove::LEFT: return Point2D(bounds_.x + 2, bounds_.centerY());
+	case FocusMove::RIGHT: return Point2D(bounds_.x2() - 2, bounds_.centerY());
+	case FocusMove::UP: return Point2D(bounds_.centerX(), bounds_.y + 2);
+	case FocusMove::DOWN: return Point2D(bounds_.centerX(), bounds_.y2() - 2);
 
 	default:
 		return bounds_.Center();
 	}
 }
 
-Point2D CollapsibleHeader::GetFocusPosition(FocusDirection dir) const {
+Point2D CollapsibleHeader::GetFocusPosition(FocusMove dir) const {
 	// Bias the focus position to the left.
 	switch (dir) {
-	case FOCUS_UP: return Point2D(bounds_.x + 50, bounds_.y + 2);
-	case FOCUS_DOWN: return Point2D(bounds_.x + 50, bounds_.y2() - 2);
+	case FocusMove::UP: return Point2D(bounds_.x + 50, bounds_.y + 2);
+	case FocusMove::DOWN: return Point2D(bounds_.x + 50, bounds_.y2() - 2);
 	default:
 		return View::GetFocusPosition(dir);
 	}

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -118,17 +118,17 @@ struct Theme {
 };
 
 // The four cardinal directions should be enough, plus Prev/Next in "element order".
-enum FocusDirection {
-	FOCUS_UP,
-	FOCUS_DOWN,
-	FOCUS_LEFT,
-	FOCUS_RIGHT,
-	FOCUS_NEXT,
-	FOCUS_PREV,
-	FOCUS_FIRST,
-	FOCUS_LAST,
-	FOCUS_PREV_PAGE,
-	FOCUS_NEXT_PAGE,
+enum class FocusMove {
+	UP,
+	DOWN,
+	LEFT,
+	RIGHT,
+	NEXT,
+	PREV,
+	FIRST,
+	LAST,
+	PREV_PAGE,
+	NEXT_PAGE,
 };
 
 typedef float Size;  // can also be WRAP_CONTENT or FILL_PARENT.
@@ -181,18 +181,18 @@ enum class BorderStyle {
 	ITEM_DOWN_BG,
 };
 
-inline FocusDirection Opposite(FocusDirection d) {
+inline FocusMove Opposite(FocusMove d) {
 	switch (d) {
-	case FOCUS_UP: return FOCUS_DOWN;
-	case FOCUS_DOWN: return FOCUS_UP;
-	case FOCUS_LEFT: return FOCUS_RIGHT;
-	case FOCUS_RIGHT: return FOCUS_LEFT;
-	case FOCUS_PREV: return FOCUS_NEXT;
-	case FOCUS_NEXT: return FOCUS_PREV;
-	case FOCUS_FIRST: return FOCUS_LAST;
-	case FOCUS_LAST: return FOCUS_FIRST;
-	case FOCUS_PREV_PAGE: return FOCUS_NEXT_PAGE;
-	case FOCUS_NEXT_PAGE: return FOCUS_PREV_PAGE;
+	case FocusMove::UP: return FocusMove::DOWN;
+	case FocusMove::DOWN: return FocusMove::UP;
+	case FocusMove::LEFT: return FocusMove::RIGHT;
+	case FocusMove::RIGHT: return FocusMove::LEFT;
+	case FocusMove::PREV: return FocusMove::NEXT;
+	case FocusMove::NEXT: return FocusMove::PREV;
+	case FocusMove::FIRST: return FocusMove::LAST;
+	case FocusMove::LAST: return FocusMove::FIRST;
+	case FocusMove::PREV_PAGE: return FocusMove::NEXT_PAGE;
+	case FocusMove::NEXT_PAGE: return FocusMove::PREV_PAGE;
 	}
 	return d;
 }
@@ -414,7 +414,7 @@ public:
 
 	virtual bool CanBeFocused() const { return true; }
 	virtual bool SubviewFocused(View *view) { return false; }
-	virtual bool CanMoveFocus(FocusDirection dir) const { return true; }
+	virtual bool CanMoveFocus(FocusMove dir) const { return true; }
 
 	void SetPopupStyle(bool popupStyle) { popupStyle_ = popupStyle; }
 
@@ -461,7 +461,7 @@ public:
 	virtual bool IsViewGroup() const { return false; }
 	virtual bool ContainsSubview(const View *view) const { return false; }
 
-	virtual Point2D GetFocusPosition(FocusDirection dir) const;
+	virtual Point2D GetFocusPosition(FocusMove dir) const;
 
 	template <class T>
 	T *AddTween(T *t) {
@@ -944,7 +944,7 @@ public:
 	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 
-	Point2D GetFocusPosition(FocusDirection dir) const override;
+	Point2D GetFocusPosition(FocusMove dir) const override;
 
 	void SetHasSubitems(bool hasSubItems) { hasSubItems_ = hasSubItems; }
 	void SetOpenPtr(bool *open) {
@@ -1117,7 +1117,7 @@ public:
 
 	void FocusChanged(int focusFlags) override;
 
-	bool CanMoveFocus(FocusDirection dir) const override { return dir != FocusDirection::FOCUS_LEFT && dir != FocusDirection::FOCUS_RIGHT; }
+	bool CanMoveFocus(FocusMove dir) const override { return dir != FocusMove::LEFT && dir != FocusMove::RIGHT; }
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
 	std::string DescribeText() const override;

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -314,7 +314,7 @@ static float VerticalOverlap(const Bounds &a, const Bounds &b) {
 		return std::min(1.0f, overlap / minH);
 }
 
-float GetTargetScore(const Point2D &originPos, int originIndex, const View *origin, const View *destination, FocusDirection direction) {
+float GetTargetScore(const Point2D &originPos, int originIndex, const View *origin, const View *destination, FocusMove direction) {
 	// Skip labels and things like that.
 	if (!destination->CanBeFocused())
 		return 0.0f;
@@ -328,10 +328,7 @@ float GetTargetScore(const Point2D &originPos, int originIndex, const View *orig
 	float dx = destPos.x - originPos.x;
 	float dy = destPos.y - originPos.y;
 
-	float distance = sqrtf(dx*dx + dy*dy);
-	if (distance == 0.0f) {
-		distance = 0.001f;
-	}
+	const float distance = std::max(sqrtf(dx*dx + dy*dy), 0.001f);
 	float overlap = 0.0f;
 	const float dirX = dx / distance;
 	const float dirY = dy / distance;
@@ -341,21 +338,21 @@ float GetTargetScore(const Point2D &originPos, int originIndex, const View *orig
 	const float horizOverlap = HorizontalOverlap(origin->GetBounds(), destination->GetBounds());
 	const float vertOverlap = VerticalOverlap(origin->GetBounds(), destination->GetBounds());
 	if (horizOverlap == 1.0f && vertOverlap == 1.0f) {
-		if (direction != FOCUS_PREV_PAGE && direction != FOCUS_NEXT_PAGE) {
+		if (direction != FocusMove::PREV_PAGE && direction != FocusMove::NEXT_PAGE) {
 			INFO_LOG(Log::UI, "Contain overlap: %s, %s", origin->Tag().c_str(), destination->Tag().c_str());
 			return 0.0f;
 		}
 	}
 	float originSize = 0.0f;
 	switch (direction) {
-	case FOCUS_LEFT:
+	case FocusMove::LEFT:
 		overlap = vertOverlap;
 		originSize = origin->GetBounds().w;
 		if (dirX > 0.0f) {
 			wrongDirection = true;
 		}
 		break;
-	case FOCUS_UP:
+	case FocusMove::UP:
 		overlap = horizOverlap;
 		originSize = origin->GetBounds().h;
 		if (dirY > 0.0f) {
@@ -363,14 +360,14 @@ float GetTargetScore(const Point2D &originPos, int originIndex, const View *orig
 		}
 		vertical = true;
 		break;
-	case FOCUS_RIGHT:
+	case FocusMove::RIGHT:
 		overlap = vertOverlap;
 		originSize = origin->GetBounds().w;
 		if (dirX < 0.0f) {
 			wrongDirection = true;
 		}
 		break;
-	case FOCUS_DOWN:
+	case FocusMove::DOWN:
 		overlap = horizOverlap;
 		originSize = origin->GetBounds().h;
 		if (dirY < 0.0f) {
@@ -378,27 +375,27 @@ float GetTargetScore(const Point2D &originPos, int originIndex, const View *orig
 		}
 		vertical = true;
 		break;
-	case FOCUS_FIRST:
+	case FocusMove::FIRST:
 		if (originIndex == -1)
 			return 0.0f;
 		if (dirX > 0.0f || dirY > 0.0f)
 			return 0.0f;
 		// More distance is good.
 		return distance;
-	case FOCUS_LAST:
+	case FocusMove::LAST:
 		if (originIndex == -1)
 			return 0.0f;
 		if (dirX < 0.0f || dirY < 0.0f)
 			return 0.0f;
 		// More distance is good.
 		return distance;
-	case FOCUS_PREV_PAGE:
-	case FOCUS_NEXT_PAGE:
+	case FocusMove::PREV_PAGE:
+	case FocusMove::NEXT_PAGE:
 		// Not always, but let's go with the bonus on height.
 		vertical = true;
 		break;
-	case FOCUS_PREV:
-	case FOCUS_NEXT:
+	case FocusMove::PREV:
+	case FocusMove::NEXT:
 		ERROR_LOG(Log::UI, "Invalid focus direction");
 		break;
 	}
@@ -414,12 +411,12 @@ float GetTargetScore(const Point2D &originPos, int originIndex, const View *orig
 	}
 }
 
-static float GetDirectionScore(int originIndex, const View *origin, View *destination, FocusDirection direction) {
+static float GetDirectionScore(int originIndex, const View *origin, View *destination, FocusMove direction) {
 	Point2D originPos = origin->GetFocusPosition(direction);
 	return GetTargetScore(originPos, originIndex, origin, destination, direction);
 }
 
-NeighborResult ViewGroup::FindNeighbor(View *view, FocusDirection direction, NeighborResult result) {
+NeighborResult ViewGroup::FindNeighbor(View *view, FocusMove direction, NeighborResult result) {
 	if (!IsEnabled()) {
 		INFO_LOG(Log::UI, "Not enabled");
 		return result;
@@ -438,12 +435,12 @@ NeighborResult ViewGroup::FindNeighbor(View *view, FocusDirection direction, Nei
 	}
 
 	switch (direction) {
-	case FOCUS_UP:
-	case FOCUS_LEFT:
-	case FOCUS_RIGHT:
-	case FOCUS_DOWN:
-	case FOCUS_FIRST:
-	case FOCUS_LAST:
+	case FocusMove::UP:
+	case FocusMove::LEFT:
+	case FocusMove::RIGHT:
+	case FocusMove::DOWN:
+	case FocusMove::FIRST:
+	case FocusMove::LAST:
 		{
 			// First, try the child views themselves as candidates
 			for (size_t i = 0; i < views_.size(); i++) {
@@ -472,15 +469,15 @@ NeighborResult ViewGroup::FindNeighbor(View *view, FocusDirection direction, Nei
 			}
 			return result;
 		}
-	case FOCUS_PREV_PAGE:
-	case FOCUS_NEXT_PAGE:
+	case FocusMove::PREV_PAGE:
+	case FocusMove::NEXT_PAGE:
 		return FindScrollNeighbor(view, Point2D(INFINITY, INFINITY), direction, result);
-	case FOCUS_PREV:
+	case FocusMove::PREV:
 		// If view not found, no neighbor to find.
 		if (num == -1)
 			return NeighborResult(nullptr, 0.0f);
 		return NeighborResult(views_[(num + views_.size() - 1) % views_.size()], 0.0f);
-	case FOCUS_NEXT:
+	case FocusMove::NEXT:
 		// If view not found, no neighbor to find.
 		if (num == -1)
 			return NeighborResult(0, 0.0f);
@@ -492,7 +489,7 @@ NeighborResult ViewGroup::FindNeighbor(View *view, FocusDirection direction, Nei
 	}
 }
 
-NeighborResult ViewGroup::FindScrollNeighbor(View *view, const Point2D &target, FocusDirection direction, NeighborResult best) {
+NeighborResult ViewGroup::FindScrollNeighbor(View *view, const Point2D &target, FocusMove direction, NeighborResult best) {
 	if (!IsEnabled())
 		return best;
 	if (GetVisibility() != V_VISIBLE)

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -63,8 +63,8 @@ public:
 	View *GetDefaultFocusView() { return defaultFocusView_; }
 
 	// Assumes that layout has taken place.
-	NeighborResult FindNeighbor(View *view, FocusDirection direction, NeighborResult best);
-	virtual NeighborResult FindScrollNeighbor(View *view, const Point2D &target, FocusDirection direction, NeighborResult best);
+	NeighborResult FindNeighbor(View *view, FocusMove direction, NeighborResult best);
+	virtual NeighborResult FindScrollNeighbor(View *view, const Point2D &target, FocusMove direction, NeighborResult best);
 
 	bool CanBeFocused() const override { return false; }
 	bool IsViewGroup() const override { return true; }

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -115,6 +115,19 @@ bool HasMainButtonMapping(const std::vector<InputMapping> &mappings) {
 	return false;
 }
 
+static void RemoveKeyboardLetterKeys(std::vector<InputMapping> &mappings) {
+	std::vector<InputMapping> result;
+	for (auto &mapping : mappings) {
+		if (mapping.deviceId == DEVICE_ID_KEYBOARD) {
+			if (mapping.keyCode >= NKCODE_A && mapping.keyCode <= NKCODE_Z) {
+				continue;
+			}
+		}
+		result.push_back(mapping);
+	}
+	mappings = result;
+}
+
 // TODO: This is such a mess...
 void UpdateNativeMenuKeys() {
 	std::vector<InputMapping> confirmKeys, cancelKeys;
@@ -193,6 +206,12 @@ void UpdateNativeMenuKeys() {
 		INFO_LOG(Log::System, "Cancel key: %s", MultiInputMapping(cancelKeys[i]).ToVisualString().c_str());
 	}
 	*/
+
+	// Remove keyboard letter keys from some arrays, as they will collide with text input for instant search.
+	RemoveKeyboardLetterKeys(tabLeft);
+	RemoveKeyboardLetterKeys(tabRight);
+	RemoveKeyboardLetterKeys(confirmKeys);
+	RemoveKeyboardLetterKeys(cancelKeys);
 
 	SetDPadKeys(upKeys, downKeys, leftKeys, rightKeys);
 	SetConfirmCancelKeys(confirmKeys, cancelKeys);

--- a/UI/GameBrowser.cpp
+++ b/UI/GameBrowser.cpp
@@ -791,18 +791,17 @@ void GameBrowser::Draw(UIContext &dc) {
 
 void SearchBar::Draw(UIContext &dc) {
 	using namespace UI;
-	Bounds overlayBounds = bounds_.Inset(12, 0, 12, 0);
 
-	dc.FillRect(dc.GetTheme().itemStyle.background, overlayBounds);
+	dc.FillRect(dc.GetTheme().itemStyle.background, bounds_);
 
 	const ImageID searchIcon = ImageID("I_SEARCH");
 	const AtlasImage *image = dc.Draw()->GetAtlas()->getImage(searchIcon);
 	int leftMargin = 10;
 	if (image) {
 		dc.Draw()->DrawImage(searchIcon, bounds_.x + leftMargin, bounds_.centerY(), 1.0f, 0xFFFFFFFF, ALIGN_VCENTER);
-		leftMargin += image->w;
+		leftMargin += image->w + 10;
 	}
-	dc.DrawText(searchFilter_, overlayBounds.x + leftMargin, overlayBounds.centerY(), 0xFFFFFFFF, ALIGN_VCENTER);
+	dc.DrawText(searchFilter_, bounds_.x + leftMargin, bounds_.centerY(), 0xFFFFFFFF, ALIGN_VCENTER);
 }
 
 void SearchBar::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
@@ -816,7 +815,7 @@ void SearchBar::GetContentDimensions(const UIContext &dc, float &w, float &h) co
 		h = std::max(h, (float)image->h);
 	}
 	w += 20;  // Padding
-	h += 10;
+	h += 24;
 }
 
 bool SearchBar::Touch(const TouchInput &input) {

--- a/UI/GameBrowser.cpp
+++ b/UI/GameBrowser.cpp
@@ -825,7 +825,8 @@ bool SearchBar::Touch(const TouchInput &input) {
 	// for the user to be able to get out of searches without knowing ESC (or backspacing the whole search string).
 	if (input.flags & TouchInputFlags::DOWN) {
 		if (bounds_.Contains(input.x, input.y)) {
-			OnCancel.Trigger(UI::EventParams{this});
+			UI::EventParams params{this};
+			OnCancel.Trigger(params);
 			return true;
 		}
 	}

--- a/UI/GameBrowser.cpp
+++ b/UI/GameBrowser.cpp
@@ -770,16 +770,48 @@ void GameBrowser::Draw(UIContext &dc) {
 void SearchBar::Draw(UIContext &dc) {
 	using namespace UI;
 	Bounds overlayBounds = bounds_.Inset(12, 0, 12, 0);
+
 	dc.FillRect(dc.GetTheme().itemStyle.background, overlayBounds);
-	dc.DrawText(searchFilter_, overlayBounds.x + 10, overlayBounds.centerY(), 0xFFFFFFFF, ALIGN_VCENTER);
+
+	const ImageID searchIcon = ImageID("I_SEARCH");
+	const AtlasImage *image = dc.Draw()->GetAtlas()->getImage(searchIcon);
+	int leftMargin = 10;
+	if (image) {
+		dc.Draw()->DrawImage(searchIcon, bounds_.x + leftMargin, bounds_.centerY(), 1.0f, 0xFFFFFFFF, ALIGN_VCENTER);
+		leftMargin += image->w + 10;
+	}
+	dc.DrawText(searchFilter_, overlayBounds.x + leftMargin, overlayBounds.centerY(), 0xFFFFFFFF, ALIGN_VCENTER);
 }
 
 void SearchBar::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
 	w = 0;
 	h = 0;
+	const ImageID searchIcon = ImageID("I_SEARCH");
 	dc.MeasureText(dc.GetTheme().uiFont, 1.0f, 1.0f, searchFilter_, &w, &h);
+	const AtlasImage *image = dc.Draw()->GetAtlas()->getImage(searchIcon);
+	if (image) {
+		w += image->w + 10;
+		h = std::max(h, (float)image->h);
+	}
 	w += 20;  // Padding
 	h += 10;
+}
+
+bool SearchBar::Touch(const TouchInput &input) {
+	// Search bar has a simple touch-to-cancel functionality,
+	// for the user to be able to get out of searches without knowing ESC (or backspacing the whole search string).
+	if (input.flags & TouchInputFlags::DOWN) {
+		OnCancel.Trigger(UI::EventParams{this});
+		return false;
+	}
+	return true;
+}
+
+void GameBrowser::SetSearchBar(SearchBar *searchBar) {
+	searchBar_ = searchBar;
+	searchBar_->OnCancel.Add([this](UI::EventParams &) {
+		SetSearchFilter("");
+	});
 }
 
 static bool IsValidPBP(const Path &path, bool allowHomebrew) {

--- a/UI/GameBrowser.cpp
+++ b/UI/GameBrowser.cpp
@@ -31,6 +31,7 @@
 #include "Common/TimeUtil.h"
 #include "Common/StringUtils.h"
 #include "Common/System/OSD.h"
+#include "Common/Data/Encoding/Utf8.h"
 #include "Core/System.h"
 #include "Core/Util/RecentFiles.h"
 #include "Core/HLE/sceCtrl.h"
@@ -532,26 +533,65 @@ void GameBrowser::SetPath(const Path &path) {
 	Refresh();
 }
 
-void GameBrowser::ApplySearchFilter(const std::string &filter) {
-	searchFilter_ = filter;
-	std::transform(searchFilter_.begin(), searchFilter_.end(), searchFilter_.begin(), tolower);
+bool GameBrowser::Key(const KeyInput &input) {
+	bool retval = LinearLayout::Key(input);
+	if (retval) {
+		return true;
+	}
 
+	// Only one is visible at a time, so we can just grab all Char input.
+	if (input.flags & KeyInputFlags::CHAR) {
+		const int unichar = input.keyCode;
+		if (unichar >= 0x20) {
+			// Insert it! (todo: do it with a string insert)
+			char buf[8];
+			buf[u8_wc_toutf8(buf, unichar)] = '\0';
+			searchFilter_ += buf;
+			ApplySearchFilter();
+			retval = true;
+		}
+	} else if (input.flags & KeyInputFlags::DOWN) {
+		if (input.keyCode == NKCODE_DEL) {
+			if (!searchFilter_.empty()) {
+				searchFilter_.pop_back();
+				ApplySearchFilter();
+				retval = true;
+			}
+		} else if (!searchFilter_.empty() && input.keyCode == NKCODE_ESCAPE) {
+			searchFilter_.clear();
+			ApplySearchFilter();
+			retval = true;
+		}
+	}
+	return retval;
+}
+
+void GameBrowser::SetSearchFilter(const std::string &filter) {
+	searchFilter_ = filter;
 	// We don't refresh because game info loads asynchronously anyway.
 	ApplySearchFilter();
 }
 
 void GameBrowser::ApplySearchFilter() {
+	if (searchBar_) {
+		searchBar_->SetSearchFilter(searchFilter_);
+		searchBar_->SetVisibility(searchFilter_.empty() ? UI::V_GONE : UI::V_VISIBLE);
+	}
+
 	if (searchFilter_.empty() && searchStates_.empty()) {
 		// We haven't hidden anything, and we're not searching, so do nothing.
 		searchPending_ = false;
 		return;
 	}
 
+	std::string filter = searchFilter_;
+	std::transform(filter.begin(), filter.end(), filter.begin(), tolower);
+
 	searchPending_ = false;
 	// By default, everything is matching.
 	searchStates_.resize(gameList_->GetNumSubviews(), SearchState::MATCH);
 
-	if (searchFilter_.empty()) {
+	if (filter.empty()) {
 		// Just quickly mark anything we hid as visible again.
 		for (int i = 0; i < gameList_->GetNumSubviews(); ++i) {
 			UI::View *v = gameList_->GetViewByIndex(i);
@@ -581,7 +621,7 @@ void GameBrowser::ApplySearchFilter() {
 		}
 
 		std::transform(label.begin(), label.end(), label.begin(), tolower);
-		bool match = v->CanBeFocused() && label.find(searchFilter_) != label.npos;
+		bool match = v->CanBeFocused() && label.find(filter) != label.npos;
 		if (match && searchStates_[i] != SearchState::MATCH) {
 			// It was previously visible and force hidden, so show it again.
 			v->SetVisibility(UI::V_VISIBLE);
@@ -721,9 +761,25 @@ void GameBrowser::Draw(UIContext &dc) {
 				view->Draw(dc);
 		}
 	}
+
 	if (clip_) {
 		dc.PopScissor();
 	}
+}
+
+void SearchBar::Draw(UIContext &dc) {
+	using namespace UI;
+	Bounds overlayBounds = bounds_.Inset(12, 0, 12, 0);
+	dc.FillRect(dc.GetTheme().itemStyle.background, overlayBounds);
+	dc.DrawText(searchFilter_, overlayBounds.x + 10, overlayBounds.centerY(), 0xFFFFFFFF, ALIGN_VCENTER);
+}
+
+void SearchBar::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
+	w = 0;
+	h = 0;
+	dc.MeasureText(dc.GetTheme().uiFont, 1.0f, 1.0f, searchFilter_, &w, &h);
+	w += 20;  // Padding
+	h += 10;
 }
 
 static bool IsValidPBP(const Path &path, bool allowHomebrew) {

--- a/UI/GameBrowser.cpp
+++ b/UI/GameBrowser.cpp
@@ -778,7 +778,7 @@ void SearchBar::Draw(UIContext &dc) {
 	int leftMargin = 10;
 	if (image) {
 		dc.Draw()->DrawImage(searchIcon, bounds_.x + leftMargin, bounds_.centerY(), 1.0f, 0xFFFFFFFF, ALIGN_VCENTER);
-		leftMargin += image->w + 10;
+		leftMargin += image->w;
 	}
 	dc.DrawText(searchFilter_, overlayBounds.x + leftMargin, overlayBounds.centerY(), 0xFFFFFFFF, ALIGN_VCENTER);
 }

--- a/UI/GameBrowser.cpp
+++ b/UI/GameBrowser.cpp
@@ -24,6 +24,7 @@
 #include "Common/UI/Context.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
+#include "Common/UI/Root.h"
 
 #include "Common/Math/curves.h"
 #include "Common/Net/URL.h"
@@ -543,36 +544,45 @@ bool GameBrowser::Key(const KeyInput &input) {
 	if (input.flags & KeyInputFlags::CHAR) {
 		const int unichar = input.keyCode;
 		if (unichar >= 0x20) {
+			// TODO: Save focus state here.
+
 			// Insert it! (todo: do it with a string insert)
 			char buf[8];
 			buf[u8_wc_toutf8(buf, unichar)] = '\0';
 			searchFilter_ += buf;
-			ApplySearchFilter();
+			ApplySearchFilter(true);
 			retval = true;
 		}
 	} else if (input.flags & KeyInputFlags::DOWN) {
 		if (input.keyCode == NKCODE_DEL) {
 			if (!searchFilter_.empty()) {
 				searchFilter_.pop_back();
-				ApplySearchFilter();
+				ApplySearchFilter(true);
 				retval = true;
+				if (searchFilter_.empty()) {
+					// TODO: Restore focus state here.
+					UI::EnableFocusMovement(false);
+				}
 			}
 		} else if (!searchFilter_.empty() && input.keyCode == NKCODE_ESCAPE) {
 			searchFilter_.clear();
-			ApplySearchFilter();
+			ApplySearchFilter(false);
 			retval = true;
+
+			// TODO: Restore focus state here.
+			UI::EnableFocusMovement(false);
 		}
 	}
 	return retval;
 }
 
-void GameBrowser::SetSearchFilter(const std::string &filter) {
+void GameBrowser::SetSearchFilter(const std::string &filter, bool setKeyboardFocus) {
 	searchFilter_ = filter;
 	// We don't refresh because game info loads asynchronously anyway.
-	ApplySearchFilter();
+	ApplySearchFilter(setKeyboardFocus);
 }
 
-void GameBrowser::ApplySearchFilter() {
+void GameBrowser::ApplySearchFilter(bool setKeyboardFocus) {
 	if (searchBar_) {
 		searchBar_->SetSearchFilter(searchFilter_);
 		searchBar_->SetVisibility(searchFilter_.empty() ? UI::V_GONE : UI::V_VISIBLE);
@@ -603,6 +613,8 @@ void GameBrowser::ApplySearchFilter() {
 		return;
 	}
 
+	View *firstMatch = nullptr;
+
 	for (int i = 0; i < gameList_->GetNumSubviews(); ++i) {
 		UI::View *v = gameList_->GetViewByIndex(i);
 		std::string label = v->DescribeText();
@@ -622,6 +634,9 @@ void GameBrowser::ApplySearchFilter() {
 
 		std::transform(label.begin(), label.end(), label.begin(), tolower);
 		bool match = v->CanBeFocused() && label.find(filter) != label.npos;
+		if (match && !firstMatch) {
+			firstMatch = v;
+		}
 		if (match && searchStates_[i] != SearchState::MATCH) {
 			// It was previously visible and force hidden, so show it again.
 			v->SetVisibility(UI::V_VISIBLE);
@@ -630,6 +645,13 @@ void GameBrowser::ApplySearchFilter() {
 			v->SetVisibility(UI::V_GONE);
 			searchStates_[i] = SearchState::MISMATCH;
 		}
+	}
+
+	if (firstMatch) {
+		if (setKeyboardFocus) {
+			UI::EnableFocusMovement(true);
+		}
+		UI::SetFocusedView(firstMatch);
 	}
 }
 
@@ -729,7 +751,7 @@ void GameBrowser::Update() {
 		refreshPending_ = false;
 	}
 	if (searchPending_) {
-		ApplySearchFilter();
+		ApplySearchFilter(false);
 	}
 }
 
@@ -798,19 +820,22 @@ void SearchBar::GetContentDimensions(const UIContext &dc, float &w, float &h) co
 }
 
 bool SearchBar::Touch(const TouchInput &input) {
+	bool retval = UI::InertView::Touch(input);
 	// Search bar has a simple touch-to-cancel functionality,
 	// for the user to be able to get out of searches without knowing ESC (or backspacing the whole search string).
 	if (input.flags & TouchInputFlags::DOWN) {
-		OnCancel.Trigger(UI::EventParams{this});
-		return false;
+		if (bounds_.Contains(input.x, input.y)) {
+			OnCancel.Trigger(UI::EventParams{this});
+			return true;
+		}
 	}
-	return true;
+	return retval;
 }
 
 void GameBrowser::SetSearchBar(SearchBar *searchBar) {
 	searchBar_ = searchBar;
 	searchBar_->OnCancel.Add([this](UI::EventParams &) {
-		SetSearchFilter("");
+		SetSearchFilter("", false);
 	});
 }
 

--- a/UI/GameBrowser.h
+++ b/UI/GameBrowser.h
@@ -23,6 +23,19 @@ enum class BrowseFlags {
 };
 ENUM_CLASS_BITOPS(BrowseFlags);
 
+class SearchBar : public UI::InertView {
+public:
+	SearchBar(UI::LayoutParams *params) : UI::InertView(params) { SetVisibility(UI::Visibility::V_GONE); }
+	void Draw(UIContext &dc) override;
+
+	void SetSearchFilter(std::string_view filter) {
+		searchFilter_ = filter;
+	}
+	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
+private:
+	std::string searchFilter_ = "N/A";
+};
+
 class GameBrowser : public UI::LinearLayout {
 public:
 	GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool portrait, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams = nullptr);
@@ -33,7 +46,11 @@ public:
 
 	void FocusGame(const Path &gamePath);
 	void SetPath(const Path &path);
-	void ApplySearchFilter(const std::string &filter);
+	void SetSearchBar(SearchBar *searchBar) {
+		searchBar_ = searchBar;
+	}
+	bool Key(const KeyInput &key) override;
+	void SetSearchFilter(const std::string &filter);
 	void Draw(UIContext &dc) override;
 	void Update() override;
 	void RequestRefresh() {
@@ -80,6 +97,7 @@ private:
 
 	UI::ViewGroup *gameList_ = nullptr;
 	PathBrowser path_;
+	SearchBar *searchBar_ = nullptr;
 	bool *gridStyle_ = nullptr;
 	BrowseFlags browseFlags_;
 	std::string lastText_;

--- a/UI/GameBrowser.h
+++ b/UI/GameBrowser.h
@@ -28,10 +28,13 @@ public:
 	SearchBar(UI::LayoutParams *params) : UI::InertView(params) { SetVisibility(UI::Visibility::V_GONE); }
 	void Draw(UIContext &dc) override;
 
+	bool Touch(const TouchInput &input) override;
 	void SetSearchFilter(std::string_view filter) {
 		searchFilter_ = filter;
 	}
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
+
+	UI::Event OnCancel;
 private:
 	std::string searchFilter_ = "N/A";
 };
@@ -46,9 +49,7 @@ public:
 
 	void FocusGame(const Path &gamePath);
 	void SetPath(const Path &path);
-	void SetSearchBar(SearchBar *searchBar) {
-		searchBar_ = searchBar;
-	}
+	void SetSearchBar(SearchBar *searchBar);
 	bool Key(const KeyInput &key) override;
 	void SetSearchFilter(const std::string &filter);
 	void Draw(UIContext &dc) override;

--- a/UI/GameBrowser.h
+++ b/UI/GameBrowser.h
@@ -51,7 +51,7 @@ public:
 	void SetPath(const Path &path);
 	void SetSearchBar(SearchBar *searchBar);
 	bool Key(const KeyInput &key) override;
-	void SetSearchFilter(const std::string &filter);
+	void SetSearchFilter(const std::string &filter, bool setKeyboardFocus);
 	void Draw(UIContext &dc) override;
 	void Update() override;
 	void RequestRefresh() {
@@ -66,7 +66,7 @@ protected:
 	virtual bool DisplayTopBar();
 	virtual bool HasSpecialFiles(std::vector<Path> &filenames);
 	virtual Path HomePath();
-	void ApplySearchFilter();
+	void ApplySearchFilter(bool setKeyboardFocus);
 
 	void Refresh();
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -138,7 +138,10 @@ void MainScreen::CreateRecentTab() {
 	using namespace UI;
 	auto mm = GetI18NCategory(I18NCat::MAINMENU);
 
-	ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	LinearLayout *recentContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	SearchBar *search = recentContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+
+	ScrollView *scrollRecentGames = recentContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	scrollRecentGames->SetTag("MainScreenRecentGames");
 
 	bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
@@ -146,11 +149,12 @@ void MainScreen::CreateRecentTab() {
 	GameBrowser *tabRecentGames = new GameBrowser(GetRequesterToken(),
 		Path("!RECENT"), BrowseFlags::NONE, portrait, &g_Config.bGridView1, screenManager(), "", "",
 		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	tabRecentGames->SetSearchBar(search);
 
 	scrollRecentGames->Add(tabRecentGames);
 	gameBrowsers_.push_back(tabRecentGames);
 
-	tabHolder_->AddTab(mm->T("Recent"), ImageID::invalid(), scrollRecentGames);
+	tabHolder_->AddTab(mm->T("Recent"), ImageID::invalid(), recentContainer);
 	tabRecentGames->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
 	tabRecentGames->OnHoldChoice.Handle(this, &MainScreen::OnGameSelected);
 	tabRecentGames->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
@@ -572,8 +576,11 @@ void MainScreen::update() {
 	UpdateUIState(UISTATE_MENU);
 
 	if (searchChanged_) {
-		for (auto browser : gameBrowsers_)
-			browser->ApplySearchFilter(searchFilter_);
+		for (auto browser : gameBrowsers_) {
+			if (browser->GetVisibility() == UI::V_VISIBLE) {
+				browser->SetSearchFilter(searchFilter_);
+			}
+		}
 		searchChanged_ = false;
 	}
 }

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -166,17 +166,22 @@ GameBrowser *MainScreen::CreateBrowserTab(const Path &path, std::string_view tit
 
 	const bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
 
-	ScrollView *scrollView = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	LinearLayout *tabContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	SearchBar *search = tabContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+
+	ScrollView *scrollView = tabContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	scrollView->SetTag(title);  // Re-use title as tag, should be fine.
 
 	GameBrowser *gameBrowser = new GameBrowser(GetRequesterToken(), path, browseFlags, portrait, bGridView, screenManager(),
 		mm->T(howToTitle), howToUri,
 		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 
+	gameBrowser->SetSearchBar(search);
+
 	scrollView->Add(gameBrowser);
 	gameBrowsers_.push_back(gameBrowser);
 
-	tabHolder_->AddTab(mm->T(title), ImageID::invalid(), scrollView);
+	tabHolder_->AddTab(mm->T(title), ImageID::invalid(), tabContainer);
 	if (scrollPos) {
 		scrollView->RememberPosition(scrollPos);
 	}

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -141,8 +141,8 @@ void MainScreen::CreateRecentTab() {
 	LinearLayout *recentContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	SearchBar *search = recentContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 
-	ScrollView *scrollRecentGames = recentContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-	scrollRecentGames->SetTag("MainScreenRecentGames");
+	ScrollView *scrollView = recentContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));
+	scrollView->SetTag("MainScreenRecentGames");
 
 	bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
 
@@ -151,7 +151,7 @@ void MainScreen::CreateRecentTab() {
 		new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	tabRecentGames->SetSearchBar(search);
 
-	scrollRecentGames->Add(tabRecentGames);
+	scrollView->Add(tabRecentGames);
 	gameBrowsers_.push_back(tabRecentGames);
 
 	tabHolder_->AddTab(mm->T("Recent"), ImageID::invalid(), recentContainer);
@@ -169,7 +169,7 @@ GameBrowser *MainScreen::CreateBrowserTab(const Path &path, std::string_view tit
 	LinearLayout *tabContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	SearchBar *search = tabContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 
-	ScrollView *scrollView = tabContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+	ScrollView *scrollView = tabContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));
 	scrollView->SetTag(title);  // Re-use title as tag, should be fine.
 
 	GameBrowser *gameBrowser = new GameBrowser(GetRequesterToken(), path, browseFlags, portrait, bGridView, screenManager(),

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -138,10 +138,11 @@ void MainScreen::CreateRecentTab() {
 	using namespace UI;
 	auto mm = GetI18NCategory(I18NCat::MAINMENU);
 
-	LinearLayout *recentContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
-	SearchBar *search = recentContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+	LinearLayout *tabContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	tabContainer->SetSpacing(0.0f);
+	SearchBar *search = tabContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, Margins(8, 8, 8, 0))));
 
-	ScrollView *scrollView = recentContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));
+	ScrollView *scrollView = tabContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));
 	scrollView->SetTag("MainScreenRecentGames");
 
 	bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
@@ -154,7 +155,7 @@ void MainScreen::CreateRecentTab() {
 	scrollView->Add(tabRecentGames);
 	gameBrowsers_.push_back(tabRecentGames);
 
-	tabHolder_->AddTab(mm->T("Recent"), ImageID::invalid(), recentContainer);
+	tabHolder_->AddTab(mm->T("Recent"), ImageID::invalid(), tabContainer);
 	tabRecentGames->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
 	tabRecentGames->OnHoldChoice.Handle(this, &MainScreen::OnGameSelected);
 	tabRecentGames->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
@@ -167,6 +168,7 @@ GameBrowser *MainScreen::CreateBrowserTab(const Path &path, std::string_view tit
 	const bool portrait = GetDeviceOrientation() == DeviceOrientation::Portrait;
 
 	LinearLayout *tabContainer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
+	tabContainer->SetSpacing(0.0f);
 	SearchBar *search = tabContainer->Add(new SearchBar(new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 
 	ScrollView *scrollView = tabContainer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -583,7 +583,7 @@ void MainScreen::update() {
 	if (searchChanged_) {
 		for (auto browser : gameBrowsers_) {
 			if (browser->GetVisibility() == UI::V_VISIBLE) {
-				browser->SetSearchFilter(searchFilter_);
+				browser->SetSearchFilter(searchFilter_, false);
 			}
 		}
 		searchChanged_ = false;

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -678,6 +678,7 @@ void MainScreen::OnGameHighlight(UI::EventParams &e) {
 			}
 		}
 		highlightedGamePath_.clear();
+		g_BackgroundAudio.SetGame(Path());
 		return;
 	}
 
@@ -871,6 +872,7 @@ void GridSettingsPopupScreen::CreatePopupContents(UI::ViewGroup *parent) {
 
 	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
 	LinearLayout *items = new LinearLayoutList(ORIENT_VERTICAL);
+	items->SetSpacing(0.0f);
 
 	items->Add(new CheckBox(&g_Config.bGridView1, sy->T("Display Recent on a grid")));
 	items->Add(new CheckBox(&g_Config.bGridView2, sy->T("Display Games on a grid")));


### PR DESCRIPTION

<img width="546" height="343" alt="image" src="https://github.com/user-attachments/assets/ed2a84e6-b233-45af-aa70-37ddf696132d" />

New UI feature to search your game lists very quickly and easily, just start typing and the game list will filter and select the first match, so you can just type some letters and hit Enter to start playing.

Unfortunately, it collides with the default keyboard bindings for L/R and X/O which are used in the UI to switch tabs and confirm/cancel. However, I'm not sure if that's an issue as Enter/ESC still works and on a device with a keyboard you have other ways to switch tabs anyway (although we should probably add Ctrl+Tab and Ctrl+Shift+Tab bindings at some point).

Opinions?