### PR TITLE
fix adhoc server option missing when updating or using local address, bump aemu_postoffice

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1045,10 +1045,11 @@ void GameSettingsScreen::CreateNetworkingSettings(UI::ViewGroup *networkingSetti
 				screenManager()->push(new AdhocServerInfoScreen(entry));
 			});
 		} else {
-			networkingSettings->Add(new Choice(n->T("Ad hoc server address"), new LinearLayoutParams(1.0f)))->OnClick.Add(launchAdhocServerScreen);
+			// This case happens when updating from a previous version, as well as clicking on one of the local addresses
+			networkingSettings->Add(new ChoiceWithFixedValueDisplay(g_Config.sProAdhocServer, n->T("Ad hoc server address")))->OnClick.Add(launchAdhocServerScreen);
 		}
 	} else {
-		networkingSettings->Add(new Choice(n->T("Ad hoc server address"), new LinearLayoutParams(1.0f)))->OnClick.Add(launchAdhocServerScreen);
+		networkingSettings->Add(new ChoiceWithFixedValueDisplay(g_Config.sProAdhocServer, n->T("Ad hoc server address")))->OnClick.Add(launchAdhocServerScreen);
 	}
 
 	static const char *relayModes[] = {"Auto", "Yes", "No"};


### PR DESCRIPTION
Fix adhoc server option missing when updating or using local address:

- Prior to this change, adhoc server option does not render when `g_Config.sProAdhocServer` has value, but the hostname is not found with AdhocGetServerByHost. This can be caused by either updating from an older version of PPSSPP, or using one of the local address in the server list.

bump aemu_postoffice:

- Take steps to avoid SIGPIPE being generated on unix platforms

