### PR TITLE
deploy appimage with `quick-sharun`, add updater

### DIFF
--- a/scripts/makeappimage_64-bit.sh
+++ b/scripts/makeappimage_64-bit.sh
@@ -2,66 +2,26 @@
 
 set -ex
 
-ARCH="$(uname -m)"
-LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
-URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
-UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
-VERSION=${1:-test}
+export ARCH="$(uname -m)"
+export VERSION=${1:-test}
+export ADD_HOOKS="self-updater.hook"
+export UPINFO="gh-releases-zsync|${GITHUB_REPOSITORY%/*}|${GITHUB_REPOSITORY#*/}|latest|*$ARCH.AppImage.zsync"
+export ICON="$PWD"/icons/hicolor/256x256/apps/ppsspp.png
+export DESKTOP="$PWD"/SDL/PPSSPPSDL.desktop
+export DEPLOY_OPENGL=1
+export DEPLOY_VULKAN=1
 
-SYS_LIB_DIR="/usr/lib"
-if [ -d /usr/lib/"$ARCH"-linux-gnu ]; then
-	SYS_LIB_DIR=/usr/lib/"$ARCH"-linux-gnu
-fi
-
-# Prepare AppDir
-mkdir -p ./AppDir/bin
-cd ./AppDir
-
-cp -v  ../SDL/PPSSPPSDL.desktop ./
-cp -v  ../icons/hicolor/256x256/apps/ppsspp.png ./
-cp -v  ../icons/hicolor/256x256/apps/ppsspp.png ./.DirIcon
+QUICK_SHARUN="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh"
 
 # ADD LIBRARIES
-wget "$LIB4BN" -O ./lib4bin
-chmod +x ./lib4bin
-xvfb-run -a -- ./lib4bin -p -v -e -s -k \
-	../build/PPSSPPSDL \
-	"$SYS_LIB_DIR"/libSDL* \
-	"$SYS_LIB_DIR"/libEGL* \
-	"$SYS_LIB_DIR"/libGL* \
-	"$SYS_LIB_DIR"/libvulkan* \
-	"$SYS_LIB_DIR"/dri/* \
-	"$SYS_LIB_DIR"/libXss.so* \
-	"$SYS_LIB_DIR"/pulseaudio/* \
-	"$SYS_LIB_DIR"/pipewire-0.3/* \
-	"$SYS_LIB_DIR"/spa-0.2/*/*
+wget "$QUICK_SHARUN" -O ./quick-sharun
+chmod +x ./quick-sharun
+
+./quick-sharun ./build/PPSSPPSDL
 
 # copy assets dir needs to be next to the binary
-cp -vr ../build/assets ./bin
-
-# Prepare sharun
-echo "Preparing sharun..."
-ln -s ./bin/PPSSPPSDL ./AppRun
-./sharun -g
+cp -vr ./build/assets ./AppDir/bin
 
 # Make AppImage with uruntime
-cd ..
-wget "$URUNTIME" -O ./uruntime
-chmod +x ./uruntime
+quick-sharun --make-appimage
 
-#Add udpate info to runtime
-echo "Adding update information \"$UPINFO\" to runtime..."
-./uruntime --appimage-addupdinfo "$UPINFO"
-
-echo "Generating AppImage..."
-./uruntime --appimage-mkdwarfs -f \
-	--set-owner 0 --set-group 0 \
-	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S26 -B8 \
-	--header uruntime \
-	-i ./AppDir -o PPSSPP-"$VERSION"-anylinux-"$ARCH".AppImage
-
-echo "Generating zsync file..."
-zsyncmake ./*.AppImage -u ./*.AppImage
-
-echo "All Done!"

--- a/scripts/makeappimage_64-bit.sh
+++ b/scripts/makeappimage_64-bit.sh
@@ -23,5 +23,5 @@ chmod +x ./quick-sharun
 cp -vr ./build/assets ./AppDir/bin
 
 # Make AppImage with uruntime
-quick-sharun --make-appimage
+./quick-sharun --make-appimage
 


### PR DESCRIPTION
fixes #21540

quick-sharun is a wrapper over `lib4bin`/`sharun` that greatly simplifies deployment, it also offers additional features and fixes. ([Including an updater](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/main/useful-tools/hooks/self-updater.hook))

The AppImage is now smaller as we are no longer shipping pipewire in it, there is no need since [we can tell SDL to use pulseaudio instead](https://github.com/pkgforge-dev/Anylinux-AppImages/blob/960f236f27ad529907b243fdb57adf79f1598e59/useful-tools/quick-sharun.sh#L2929-L2933)

Artifact: https://github.com/Samueru-sama/ppsspp/actions/runs/24599769708

Tested it working on alpine linux

<img width="1271" height="810" alt="image" src="https://github.com/user-attachments/assets/075f08a6-e078-4f77-8168-01b6ce26a16a" />




