### PR TITLE
Android: Upgrade protobuf dependency to 0.10.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
 	id("com.android.application") version "9.1.1" apply false
-	id("com.google.protobuf") version "0.9.6" apply false
+	id("com.google.protobuf") version "0.10.0" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 # This suppression is only needed for the legacy build.
 android.ndk.suppressMinSdkVersionError=21
-android.newDsl=false
+android.newDsl=true


### PR DESCRIPTION
This lets use set `newDsl=true` in gradle.properties, which makes us compliant with future gradle versions, so no more need to worry about that for the foreseeable future.