### PR TITLE
Minor QOL changes (CwCheat/Background screen)

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -778,6 +778,9 @@ void CheckBox::Draw(UIContext &dc) {
 		}
 		if (down_) {
 			style = dc.GetTheme().itemDownStyle;
+		} else if (highlightChecked_ && Toggled()) {
+			style = dc.GetTheme().itemStyle;
+			style.background.color = alphaMul(style.background.color, 1.90f); // increase opacity (darker)
 		}
 	}
 

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -909,12 +909,12 @@ private:
 class CheckBox : public ClickableItem {
 public:
 	CheckBox(bool *toggle, std::string_view text, std::string_view smallText = "", LayoutParams *layoutParams = nullptr)
-		: ClickableItem(layoutParams), toggle_(toggle), text_(text), smallText_(smallText) {
+		: ClickableItem(layoutParams), toggle_(toggle), highlightChecked_(false), text_(text), smallText_(smallText) {
 	}
 
 	// Image-only "checkbox", lights up instead of showing a checkmark.
 	CheckBox(bool *toggle, ImageID imageID, LayoutParams *layoutParams = nullptr)
-		: ClickableItem(layoutParams), toggle_(toggle), imageID_(imageID) {
+		: ClickableItem(layoutParams), toggle_(toggle), highlightChecked_(false), imageID_(imageID) {
 	}
 
 	void Draw(UIContext &dc) override;
@@ -928,10 +928,15 @@ public:
 	// we don't allow these for checkboxes.
 	void SetAutoResult(DialogResult result) override {}
 
+	void SetHighlightChecked(bool highlightChecked) {
+		highlightChecked_ = highlightChecked;
+	}
+
 protected:
 	void ClickInternal() override;
 
 	bool *toggle_;
+	bool highlightChecked_; // only for non-image mode
 	std::string text_;
 	std::string smallText_;
 	ImageID imageID_;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -315,6 +315,7 @@ ConfigSetting("CwCheatHighlightCheckedCheats", SETTING(g_Config, bCwCheatHighlig
 
 	ConfigSetting("BackgroundAnimation", SETTING(g_Config, iBackgroundAnimation), 1, CfgFlag::DEFAULT),
 	ConfigSetting("TransparentBackground", SETTING(g_Config, bTransparentBackground), true, CfgFlag::DEFAULT),
+	ConfigSetting("ShowPic1OnBackgroundScreen", SETTING(g_Config, bShowPic1OnBackgroundScreen), true, CfgFlag::DEFAULT),
 	ConfigSetting("UITint", SETTING(g_Config, fUITint), 0.0, CfgFlag::DEFAULT),
 	ConfigSetting("UISaturation", SETTING(g_Config, fUISaturation), &DefaultUISaturation, CfgFlag::DEFAULT),
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -247,6 +247,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("AutoLoadSaveState", SETTING(g_Config, iAutoLoadSaveState), 0, CfgFlag::PER_GAME),
 	ConfigSetting("EnableCheats", SETTING(g_Config, bEnableCheats), false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("EnablePlugins", SETTING(g_Config, bEnablePlugins), true, CfgFlag::PER_GAME | CfgFlag::REPORT),
+ConfigSetting("CwCheatHighlightCheckedCheats", SETTING(g_Config, bCwCheatHighlightCheckedCheats), true, CfgFlag::DEFAULT),
 	ConfigSetting("CwCheatRefreshRate", SETTING(g_Config, iCwCheatRefreshIntervalMs), 77, CfgFlag::PER_GAME),
 	ConfigSetting("CwCheatScrollPosition", SETTING(g_Config, fCwCheatScrollPosition), 0.0f, CfgFlag::PER_GAME),
 	ConfigSetting("GameListScrollPosition", SETTING(g_Config, fGameListScrollPosition), 0.0f, CfgFlag::DEFAULT),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -828,6 +828,7 @@ std::string DefaultProAdhocServer() {
 
 static const ConfigSetting soundSettings[] = {
 	ConfigSetting("Enable", SETTING(g_Config, bEnableSound), true, CfgFlag::PER_GAME),
+ConfigSetting("EnableGameScreenBackgroundAudio", SETTING(g_Config, bEnableGameScreenBackgroundAudio), true, CfgFlag::DEFAULT),
 	ConfigSetting("ExtraAudioBuffering", SETTING(g_Config, bExtraAudioBuffering), false, CfgFlag::DEFAULT),
 	ConfigSetting("AudioBufferSize", SETTING(g_Config, iSDLAudioBufferSize), 256, CfgFlag::DEFAULT),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -354,6 +354,7 @@ public:
 	bool bEnableCheats;
 	bool bReloadCheats;
 	bool bEnablePlugins;
+bool bCwCheatHighlightCheckedCheats;
 	int iCwCheatRefreshIntervalMs;
 	float fCwCheatScrollPosition;
 	float fGameListScrollPosition;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -392,6 +392,7 @@ bool bCwCheatHighlightCheckedCheats;
 
 	// Sound
 	bool bEnableSound;
+bool bEnableGameScreenBackgroundAudio;
 	int iSDLAudioBufferSize;
 	int iAudioBufferSize;
 	bool bFillAudioGaps;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -428,6 +428,7 @@ bool bEnableGameScreenBackgroundAudio;
 	float fGameGridScale;
 	int iBackgroundAnimation;  // enum BackgroundAnimation
 	bool bTransparentBackground;
+bool bShowPic1OnBackgroundScreen;
 	int iSettingsCurrentTab;
 	int iDeveloperSettingsCurrentTab;
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -127,7 +127,9 @@ void CwCheatScreen::CreateContentViews(UI::ViewGroup *parent) {
 	rightScroll->Add(rightColumn);
 	rightColumn->Add(new ItemHeader(cw->T("Cheats")));
 	for (size_t i = 0; i < fileInfo_.size(); ++i) {
-		rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name))->OnClick.Add([=](UI::EventParams &) {
+		auto checkbox = new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name);
+		checkbox->SetHighlightChecked(g_Config.bCwCheatHighlightCheckedCheats);
+		rightColumn->Add(checkbox)->OnClick.Add([=](UI::EventParams &) {
 			OnCheckBox((int)i);
 		});
 	}

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -148,7 +148,11 @@ private:
 };
 
 GameScreen::GameScreen(const Path &gamePath, bool inGame) : UITwoPaneBaseDialogScreen(gamePath, TwoPaneFlags::SettingsToTheRight | TwoPaneFlags::CustomContextMenu), inGame_(inGame) {
-	g_BackgroundAudio.SetGame(gamePath);
+	if (g_Config.bEnableGameScreenBackgroundAudio) {
+		g_BackgroundAudio.SetGame(gamePath);
+	} else {
+		g_BackgroundAudio.SetGame(Path());
+	}
 	System_PostUIMessage(UIMessage::GAME_SELECTED, gamePath.ToString());
 
 	// We want to re-fetch savedata size when opening this screen. We re-fetch PARAM_SFO because it's connected to updating the hasConfig bool.

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -106,7 +106,7 @@ ScreenRenderFlags BackgroundScreen::render(ScreenRenderMode mode) {
 	Lin::Vec3 focus;
 	screenManager()->getFocusPosition(focus.x, focus.y, focus.z);
 
-	if (!gamePath_.empty()) {
+	if (g_Config.bShowPic1OnBackgroundScreen && !gamePath_.empty()) {
 		::DrawGameBackground(*uiContext, gamePath_, focus, 1.0f);
 	} else {
 		::DrawBackground(*uiContext, 1.0f, focus);


### PR DESCRIPTION
Here's a small QOL PR that will benefit players who spend quite some time in the cheats listing, and or have troubles finding which cheats are enabled.

This adds 3 new simple settings:
1. `CwCheatHighlightCheckedCheats` under `[General]` (defaults to `true`):
Controls whether the currently enabled cheats should be *slightly* highlighted (increased opacity i.e. darker background).
It can be difficult to see which cheats are enabled or disabled in the cheats list, even more so with the background image.
2. `ShowPic1OnBackgroundScreen` under `[General]` (defaults to `true`):
Controls whether to display the game's PIC1 picture in the BackgroundScreen and therefore, in the cheats listing.
Setting this to `false` greatly improves the readability. 
3. `EnableGameScreenBackgroundAudio` under `[Sound]` (defaults to `true`):
Controls whether to play the game's SND0 audio in the background in the GameScreen.

Those settings can only be toggled in the `ppsspp.ini` file for now.

The UI `CheckBox` class was added a flag and a method to enable/disable the dark highlight effect in non-image mode.  
Note it's disabled by default, and so far, only the CwCheatScreen has a use for it.

<img width="1920" height="1040" alt="cwcheats_highlight_bg" src="https://github.com/user-attachments/assets/ecbf6e47-0367-4ef0-ae61-ea276ca80921" />
<img width="1920" height="1040" alt="cwcheats_highlight_nobg" src="https://github.com/user-attachments/assets/1d551528-0a71-46a5-9f49-1af143fd19d5" />
