### PR TITLE
UI improvements: CwCheat titles/comments, easier to scroll tabs

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -344,7 +344,6 @@ bool Clickable::Key(const KeyInput &key) {
 
 bool StickyChoice::Touch(const TouchInput &touch) {
 	bool contains = bounds_.Contains(touch.x, touch.y);
-	dragging_ = false;
 	if (!IsEnabled()) {
 		down_ = false;
 		return contains;
@@ -352,12 +351,18 @@ bool StickyChoice::Touch(const TouchInput &touch) {
 
 	if (touch.flags & TouchInputFlags::DOWN) {
 		if (contains) {
+			dragging_ = true;
+		}
+	}
+	if (touch.flags & TouchInputFlags::UP) {
+		if (dragging_ && contains && !(touch.flags & TouchInputFlags::CANCEL)) {
 			if (IsFocusMovementEnabled())
 				SetFocusedView(this);
-			down_ = true;
 			ClickInternal();
+			dragging_ = false;
 			return true;
 		}
+		dragging_ = false;
 	}
 	return false;
 }

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -1171,12 +1171,23 @@ bool CheatsInEffect() {
 bool DetectCheatTitle(std::string_view name, std::string_view *title) {
 	// Use Saramagrean title convention (the most common cheats.db file).
 	const size_t firstOffset = name.find("_[>>>");
-	const size_t secondOffset = name.find("<<<]_");
-	bool isTitle = firstOffset != std::string::npos && secondOffset != std::string::npos && firstOffset < secondOffset;
+	const size_t secondOffset = name.rfind("<<<]_");
+	const bool isTitle = firstOffset != std::string::npos && secondOffset != std::string::npos && firstOffset < secondOffset;
 	if (!isTitle) {
 		return false;
 	}
 	// Extract the title substring.
 	*title = std::string_view(name.data() + firstOffset + 5, secondOffset - (firstOffset + 5));
+	return true;
+}
+
+bool DetectCheatPostComment(std::string_view name, std::string_view *comment) {
+	const size_t firstOffset = name.find("\xE2\x86\x91[#");  // Up arrow and [#
+	const size_t secondOffset = name.rfind(']');
+	const bool isPostComment = firstOffset != std::string::npos && secondOffset != std::string::npos && secondOffset > firstOffset;
+	if (!isPostComment) {
+		return false;
+	}
+	*comment = std::string_view(name.data() + firstOffset + 5, secondOffset - (firstOffset + 5));
 	return true;
 }

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -1167,3 +1167,16 @@ bool CheatsInEffect() {
 		return false;
 	return cheatEngine->HasCheats();
 }
+
+bool DetectCheatTitle(std::string_view name, std::string_view *title) {
+	// Use Saramagrean title convention (the most common cheats.db file).
+	const size_t firstOffset = name.find("_[>>>");
+	const size_t secondOffset = name.find("<<<]_");
+	bool isTitle = firstOffset != std::string::npos && secondOffset != std::string::npos && firstOffset < secondOffset;
+	if (!isTitle) {
+		return false;
+	}
+	// Extract the title substring.
+	*title = std::string_view(name.data() + firstOffset + 5, secondOffset - (firstOffset + 5));
+	return true;
+}

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -26,6 +26,7 @@ struct CheatLine {
 };
 
 bool DetectCheatTitle(std::string_view name, std::string_view *title);
+bool DetectCheatPostComment(std::string_view name, std::string_view *title);
 
 struct CheatCode {
 	std::string name;
@@ -37,8 +38,11 @@ struct CheatFileInfo {
 	std::string name;
 	bool enabled;
 
-	bool IsTitle(std::string_view *title) {
+	bool IsTitle(std::string_view *title) const {
 		return DetectCheatTitle(name, title);
+	}
+	bool IsPostComment(std::string_view *comment) const {
+		return DetectCheatPostComment(name, comment);
 	}
 };
 

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -25,6 +25,8 @@ struct CheatLine {
 	uint32_t part2;
 };
 
+bool DetectCheatTitle(std::string_view name, std::string_view *title);
+
 struct CheatCode {
 	std::string name;
 	std::vector<CheatLine> lines;
@@ -34,6 +36,10 @@ struct CheatFileInfo {
 	int lineNum;
 	std::string name;
 	bool enabled;
+
+	bool IsTitle(std::string_view *title) {
+		return DetectCheatTitle(name, title);
+	}
 };
 
 struct CheatOperation;

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -127,9 +127,17 @@ void CwCheatScreen::CreateContentViews(UI::ViewGroup *parent) {
 	rightScroll->Add(rightColumn);
 	rightColumn->Add(new ItemHeader(cw->T("Cheats")));
 	for (size_t i = 0; i < fileInfo_.size(); ++i) {
-		rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name))->OnClick.Add([=](UI::EventParams &) {
-			OnCheckBox((int)i);
-		});
+		std::string_view title;
+		if (fileInfo_[i].IsTitle(&title)) {
+			// Title.
+			TextView *titleView = rightColumn->Add(new TextView(title, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8, 0))));
+			titleView->SetTextSize(UI::TextSize::Big);
+		} else {
+			// Regular cheat code.
+			rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name))->OnClick.Add([=](UI::EventParams &) {
+				OnCheckBox((int)i);
+			});
+		}
 	}
 }
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -33,6 +33,7 @@
 
 #include "UI/GameInfoCache.h"
 #include "UI/CwCheatScreen.h"
+#include "UI/MiscViews.h"
 
 static const int FILE_CHECK_FRAME_INTERVAL = 53;
 
@@ -124,19 +125,29 @@ void CwCheatScreen::CreateContentViews(UI::ViewGroup *parent) {
 	rightScroll->RememberPosition(&g_Config.fCwCheatScrollPosition);
 
 	LinearLayout *rightColumn = new LinearLayoutList(ORIENT_VERTICAL, new LinearLayoutParams(200, FILL_PARENT));
+	rightColumn->SetSpacing(0.0f);
 	rightScroll->Add(rightColumn);
 	rightColumn->Add(new ItemHeader(cw->T("Cheats")));
+	bool prevIsTitle = false;
 	for (size_t i = 0; i < fileInfo_.size(); ++i) {
-		std::string_view title;
-		if (fileInfo_[i].IsTitle(&title)) {
+		std::string_view text;
+		if (fileInfo_[i].IsTitle(&text)) {
 			// Title.
-			TextView *titleView = rightColumn->Add(new TextView(title, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8, 0))));
+			TextView *titleView = rightColumn->Add(new TextView(text, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8, 8, 8, 0))));
 			titleView->SetTextSize(UI::TextSize::Big);
+			prevIsTitle = true;
+		} else if (fileInfo_[i].IsPostComment(&text)) {
+			rightColumn->Add(new SettingHint(text, nullptr));
+			prevIsTitle = false;
 		} else {
 			// Regular cheat code.
+			if (!prevIsTitle) {
+				rightColumn->Add(new Spacer(8.0f));
+			}
 			rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name))->OnClick.Add([=](UI::EventParams &) {
 				OnCheckBox((int)i);
 			});
+			prevIsTitle = false;
 		}
 	}
 }


### PR DESCRIPTION
Supports titles and comments as used in Saramagrean's cheats.db.

Also makes it possible to scroll tab strips without activating tabs in the process.


<img width="404" height="378" alt="image" src="https://github.com/user-attachments/assets/9d109bed-ac25-4b50-9d75-e843fafa50c6" />

Just some stuff I realized I wanted to get in before tackling #21580