### PR TITLE
adhoc: add sprawl brazilian relay server

### DIFF
--- a/assets/adhoc-servers.json
+++ b/assets/adhoc-servers.json
@@ -156,6 +156,16 @@
 			"description": "For players looking to play any games",
 			"data_mode": "AemuPostoffice",
 			"status_data_json": "https://cat.wjg.jp/data.json"
+		},
+		{
+			"name": "Sprawl Relay - Brazil",
+			"host": "brazil-01.sprawl-relay.link",
+			"discord": "",
+			"web": "https://status-brazil-01.sprawl-relay.link",
+			"location": "Brazil",
+			"description": "For players looking to play any games",
+			"data_mode": "AemuPostoffice",
+			"status_data_json": ""
 		}
 	]
 }


### PR DESCRIPTION
Adds a new brazilian relay server. This is a re-implementation of the reference postoffice server that I want to put out in the wild to test for stability/performance, if the results are good I'll expand it to more regions.