### PR TITLE
md5/sha1: secure erase crypto contexts and buffers

### DIFF
--- a/Common/Crypto/md5.cpp
+++ b/Common/Crypto/md5.cpp
@@ -341,7 +341,7 @@ void ppsspp_md5_hmac_finish( md5_context *ctx, unsigned char output[16] )
     ppsspp_md5_update( ctx, tmpbuf, 16 );
     ppsspp_md5_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    memset_s( tmpbuf, sizeof( tmpbuf ), 0, sizeof( tmpbuf ) );
 }
 
 /*

--- a/Common/Crypto/sha1.cpp
+++ b/Common/Crypto/sha1.cpp
@@ -352,7 +352,7 @@ void sha1_hmac_starts( sha1_context *ctx, unsigned char *key, int keylen )
     sha1_starts( ctx );
     sha1_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    memset_s( sum, sizeof( sum ), 0, sizeof( sum ) );
 }
 
 /*
@@ -376,7 +376,7 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] )
     sha1_update( ctx, tmpbuf, 20 );
     sha1_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    memset_s( tmpbuf, sizeof( tmpbuf ), 0, sizeof( tmpbuf ) );
 }
 
 /*
@@ -392,7 +392,7 @@ void sha1_hmac( unsigned char *key, int keylen,
     sha1_hmac_update( &ctx, input, ilen );
     sha1_hmac_finish( &ctx, output );
 
-    memset( &ctx, 0, sizeof( sha1_context ) );
+    memset_s( &ctx, sizeof( sha1_context ), 0, sizeof( sha1_context ) );
 }
 
 #if defined(POLARSSL_SELF_TEST)


### PR DESCRIPTION
References:
- https://stackoverflow.com/questions/56565539/memset-s-what-does-the-standard-mean-with-this-piece-of-text
- https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1315r2.html
