### PR TITLE
IR more optimize added +2 for downcount and prereserve after clear

### DIFF
--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -253,6 +253,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 	js.inDelaySlot = false;
 	js.PrefixStart();
 	ir.Clear();
+	ir.Reserve(64); // Estimate a reasonable number of IR instructions per block
 
 	js.numInstructions = 0;
 	while (js.compiling) {
@@ -305,7 +306,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 	}
 	else {
 		std::vector<IRInst> block_instructions = code->GetInstructions();
-		instructions.reserve(block_instructions.capacity());
+		instructions.reserve(block_instructions.size() + 2); // +2 for Downcount and LogIRBlock
 		// The first instruction is "Downcount"
 		instructions.push_back(block_instructions.front());
 		instructions.push_back({ IROp::LogIRBlock, {0}, 0, 0, 0 });


### PR DESCRIPTION
@hrydgard, code review changes, did someone forget to allocate memory for two downcount instructions, and to what extent was 64 allocation per block correctly selected after cleaning?