### PR TITLE
Windows Vulkan: default to borderless fullscreen, add exclusive option

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -670,7 +670,9 @@ VkResult VulkanContext::CreateDevice(int physical_device) {
 	}
 
 	extensionsLookup_.EXT_provoking_vertex = EnableDeviceExtension(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME, 0);
-
+#ifdef VK_EXT_full_screen_exclusive
+	extensionsLookup_.EXT_full_screen_exclusive = EnableDeviceExtension(VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME, 0);
+#endif
 	extensionsLookup_.KHR_present_mode_fifo_latest_ready = EnableDeviceExtension(VK_KHR_PRESENT_MODE_FIFO_LATEST_READY_EXTENSION_NAME, 0);
 	if (!extensionsLookup_.KHR_present_mode_fifo_latest_ready) {
 		// Enable the EXT extension instead if available, it's equivalent (was promoted).
@@ -1532,8 +1534,15 @@ bool VulkanContext::InitSwapchain(VkPresentModeKHR desiredPresentMode) {
 
 #ifdef VK_EXT_full_screen_exclusive
 	VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo{ VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
-	fullScreenInfo.fullScreenExclusive = fullScreenExclusiveMode_;
-	swap_chain_info.pNext = &fullScreenInfo;
+	VkSurfaceFullScreenExclusiveWin32InfoEXT win32ExclusiveInfo{ VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT };
+	if (extensionsLookup_.EXT_full_screen_exclusive) {
+		fullScreenInfo.fullScreenExclusive = fullScreenExclusiveMode_;
+		if (fullScreenExclusiveMode_ == VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT) {
+			win32ExclusiveInfo.hmonitor = MonitorFromWindow((HWND)winsysData2_, MONITOR_DEFAULTTONEAREST);
+			fullScreenInfo.pNext = &win32ExclusiveInfo;
+		}
+		swap_chain_info.pNext = &fullScreenInfo;
+	}
 #endif
 
 	res = vkCreateSwapchainKHR(device_, &swap_chain_info, NULL, &swapchain_);

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1530,6 +1530,12 @@ bool VulkanContext::InitSwapchain(VkPresentModeKHR desiredPresentMode) {
 		swap_chain_info.compositeAlpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
 	}
 
+#ifdef VK_EXT_full_screen_exclusive
+	VkSurfaceFullScreenExclusiveInfoEXT fullScreenInfo{ VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT };
+	fullScreenInfo.fullScreenExclusive = fullScreenExclusiveMode_;
+	swap_chain_info.pNext = &fullScreenInfo;
+#endif
+
 	res = vkCreateSwapchainKHR(device_, &swap_chain_info, NULL, &swapchain_);
 	if (res != VK_SUCCESS) {
 		ERROR_LOG(Log::G3D, "vkCreateSwapchainKHR failed! %s", VulkanResultToString(res));

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -412,6 +412,10 @@ public:
 		return presentMode_;
 	}
 
+#ifdef VK_EXT_full_screen_exclusive
+	void SetFullScreenExclusiveMode(VkFullScreenExclusiveEXT mode) { fullScreenExclusiveMode_ = mode; }
+#endif
+
 	std::vector<VkPresentModeKHR> GetAvailablePresentModes() const {
 		return availablePresentModes_;
 	}
@@ -529,6 +533,11 @@ private:
 	bool swapchainInited_ = false;
 
 	PhysicalDeviceFeatures deviceFeatures_;
+
+#ifdef VK_EXT_full_screen_exclusive
+	VkFullScreenExclusiveEXT fullScreenExclusiveMode_ = VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT;
+#endif 
+
 
 	VkSurfaceCapabilitiesKHR surfCapabilities_{};
 	std::vector<VkSurfaceFormatKHR> surfFormats_{};

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -536,7 +536,7 @@ private:
 
 #ifdef VK_EXT_full_screen_exclusive
 	VkFullScreenExclusiveEXT fullScreenExclusiveMode_ = VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT;
-#endif 
+#endif
 
 
 	VkSurfaceCapabilitiesKHR surfCapabilities_{};

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -272,6 +272,7 @@ struct VulkanExtensions {
 	bool EXT_provoking_vertex;
 	bool KHR_present_mode_fifo_latest_ready;
 	bool EXT_scalar_block_layout;
+	bool EXT_full_screen_exclusive;
 	// bool EXT_depth_range_unrestricted;  // Allows depth outside [0.0, 1.0] in 32-bit float depth buffers.
 };
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -953,6 +953,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
 	// Note that it must also be enabled on the pipelines (which we do).
 	caps_.provokingVertexLast = vulkan->GetDeviceFeatures().enabled.provokingVertex.provokingVertexLast;
 
+	caps_.fullScreenExclusiveSupported = vulkan->Extensions().EXT_full_screen_exclusive;
 	// Present mode stuff
 	caps_.presentMaxInterval = 1;
 	caps_.presentInstantModeChange = false;  // TODO: Fix this with some work in VulkanContext

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -633,6 +633,7 @@ struct DeviceCaps {
 	bool requiresHalfPixelOffset;
 	bool provokingVertexLast;  // GL behavior, what the PSP does
 	bool verySlowShaderCompiler;
+	bool fullScreenExclusiveSupported;
 
 	// Old style, for older GL or Direct3D 9.
 	u32 clipPlanesSupported;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -748,8 +748,8 @@ static const ConfigSetting graphicsSettings[] = {
 
 #ifndef MOBILE_DEVICE
 	ConfigSetting("FullScreen", SETTING(g_Config, bFullScreen), false, CfgFlag::DEFAULT),
+	ConfigSetting("FullScreenExclusive", SETTING(g_Config, bAllowFullScreenExclusive), false, CfgFlag::DEFAULT),
 	ConfigSetting("FullScreenMulti", SETTING(g_Config, bFullScreenMulti), false, CfgFlag::DEFAULT),
-	ConfigSetting("FullScreenExclusive", SETTING(g_Config, bFullScreenExclusive), false, CfgFlag::DEFAULT),
 #endif
 
 #if PPSSPP_PLATFORM(IOS)

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -749,6 +749,7 @@ static const ConfigSetting graphicsSettings[] = {
 #ifndef MOBILE_DEVICE
 	ConfigSetting("FullScreen", SETTING(g_Config, bFullScreen), false, CfgFlag::DEFAULT),
 	ConfigSetting("FullScreenMulti", SETTING(g_Config, bFullScreenMulti), false, CfgFlag::DEFAULT),
+	ConfigSetting("FullScreenExclusive", SETTING(g_Config, bFullScreenExclusive), false, CfgFlag::DEFAULT),
 #endif
 
 #if PPSSPP_PLATFORM(IOS)

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -325,6 +325,7 @@ public:
 	int iAppSwitchMode;
 	bool bFullScreen;
 	bool bFullScreenMulti;
+	bool bFullScreenExclusive;
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	int iMultiSampleLevel;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -325,7 +325,7 @@ public:
 	int iAppSwitchMode;
 	bool bFullScreen;
 	bool bFullScreenMulti;
-	bool bFullScreenExclusive;
+	bool bAllowFullScreenExclusive;
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	int iMultiSampleLevel;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -421,12 +421,18 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 				System_ApplyFullscreenState();
 			});
 		}
-#ifdef VK_EXT_full_screen_exclusive
-		CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenExclusive, gr->T("Exclusive fullscreen")));
-		fullscreenExclusive->SetEnabledFunc([] {
-			return g_Config.bFullScreen;
-		});
-#endif
+		if (draw->GetDeviceCaps().fullScreenExclusiveSupported) {
+			CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenExclusive, gr->T("Exclusive fullscreen")));
+			fullscreenExclusive->SetEnabledFunc([] {
+				return g_Config.bFullScreen;
+			});
+			fullscreenExclusive->OnClick.Add([this](UI::EventParams &e) {
+				TriggerRestartOrDo([this]() {
+					g_Config.bFullScreenExclusive = !g_Config.bFullScreenExclusive;
+					RecreateViews();
+				});
+			});
+		}
 #endif
 		// Display Layout Editor: To avoid overlapping touch controls on large tablets, meet geeky demands for integer zoom/unstretched image etc.
 		Choice *displayEditor = graphicsSettings->Add(new Choice(gr->T("Display layout & effects")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -412,25 +412,25 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 		fullscreenCheckbox->OnClick.Add([](UI::EventParams &e) {
 			System_ApplyFullscreenState();
 		});
-		if (System_GetPropertyInt(SYSPROP_DISPLAY_COUNT) > 1) {
-			CheckBox *fullscreenMulti = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenMulti, gr->T("Use all displays")));
-			fullscreenMulti->SetEnabledFunc([] {
-				return g_Config.bFullScreen;
-			});
-			fullscreenMulti->OnClick.Add([](UI::EventParams &e) {
-				System_ApplyFullscreenState();
-			});
-		}
 		if (draw->GetDeviceCaps().fullScreenExclusiveSupported) {
 			CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenExclusive, gr->T("Exclusive fullscreen")));
 			fullscreenExclusive->SetEnabledFunc([] {
-				return g_Config.bFullScreen;
+				return g_Config.bFullScreen && !g_Config.bFullScreenMulti;
 			});
 			fullscreenExclusive->OnClick.Add([this](UI::EventParams &e) {
 				TriggerRestartOrDo([this]() {
 					g_Config.bFullScreenExclusive = !g_Config.bFullScreenExclusive;
 					RecreateViews();
 				});
+			});
+		}
+		if (System_GetPropertyInt(SYSPROP_DISPLAY_COUNT) > 1) {
+			CheckBox *fullscreenMulti = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenMulti, gr->T("Use all displays")));
+			fullscreenMulti->SetEnabledFunc([] {
+				return g_Config.bFullScreen && !g_Config.bFullScreenExclusive;
+			});
+			fullscreenMulti->OnClick.Add([](UI::EventParams &e) {
+				System_ApplyFullscreenState();
 			});
 		}
 #endif

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -421,6 +421,10 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 				System_ApplyFullscreenState();
 			});
 		}
+		CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenExclusive, gr->T("Exclusive fullscreen")));
+		fullscreenExclusive->SetEnabledFunc([] {
+			return g_Config.bFullScreen;
+		});
 #endif
 		// Display Layout Editor: To avoid overlapping touch controls on large tablets, meet geeky demands for integer zoom/unstretched image etc.
 		Choice *displayEditor = graphicsSettings->Add(new Choice(gr->T("Display layout & effects")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -413,13 +413,13 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 			System_ApplyFullscreenState();
 		});
 		if (draw->GetDeviceCaps().fullScreenExclusiveSupported) {
-			CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenExclusive, gr->T("Exclusive fullscreen")));
+			CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bAllowFullScreenExclusive, gr->T("Allow exclusive fullscreen")));
 			fullscreenExclusive->SetEnabledFunc([] {
 				return g_Config.bFullScreen && !g_Config.bFullScreenMulti;
 			});
 			fullscreenExclusive->OnClick.Add([this](UI::EventParams &e) {
 				TriggerRestartOrDo([this]() {
-					g_Config.bFullScreenExclusive = !g_Config.bFullScreenExclusive;
+					g_Config.bAllowFullScreenExclusive = !g_Config.bAllowFullScreenExclusive;
 					RecreateViews();
 				});
 			});
@@ -427,7 +427,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 		if (System_GetPropertyInt(SYSPROP_DISPLAY_COUNT) > 1) {
 			CheckBox *fullscreenMulti = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenMulti, gr->T("Use all displays")));
 			fullscreenMulti->SetEnabledFunc([] {
-				return g_Config.bFullScreen && !g_Config.bFullScreenExclusive;
+				return g_Config.bFullScreen && !g_Config.bAllowFullScreenExclusive;
 			});
 			fullscreenMulti->OnClick.Add([](UI::EventParams &e) {
 				System_ApplyFullscreenState();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -421,10 +421,12 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 				System_ApplyFullscreenState();
 			});
 		}
+#ifdef VK_EXT_full_screen_exclusive
 		CheckBox* fullscreenExclusive = graphicsSettings->Add(new CheckBox(&g_Config.bFullScreenExclusive, gr->T("Exclusive fullscreen")));
 		fullscreenExclusive->SetEnabledFunc([] {
 			return g_Config.bFullScreen;
 		});
+#endif
 #endif
 		// Display Layout Editor: To avoid overlapping touch controls on large tablets, meet geeky demands for integer zoom/unstretched image etc.
 		Choice *displayEditor = graphicsSettings->Add(new Choice(gr->T("Display layout & effects")));

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -128,7 +128,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	VkPresentModeKHR presentMode = ConfigPresentModeToVulkan(draw_);
 
 #ifdef VK_EXT_full_screen_exclusive
-	vulkan_->SetFullScreenExclusiveMode(g_Config.bFullScreen && g_Config.bFullScreenExclusive
+	vulkan_->SetFullScreenExclusiveMode(g_Config.bFullScreen && g_Config.bAllowFullScreenExclusive
 		? VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT
 		: VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT);
 #endif
@@ -178,7 +178,7 @@ void WindowsVulkanContext::Resize() {
 	VkPresentModeKHR presentMode = ConfigPresentModeToVulkan(draw_);
 
 #ifdef VK_EXT_full_screen_exclusive
-	vulkan_->SetFullScreenExclusiveMode(g_Config.bFullScreen && g_Config.bFullScreenExclusive
+	vulkan_->SetFullScreenExclusiveMode(g_Config.bFullScreen && g_Config.bAllowFullScreenExclusive
 		? VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT
 		: VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT);
 #endif

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -126,6 +126,13 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	draw_ = Draw::T3DCreateVulkanContext(vulkan_, useMultiThreading);
 
 	VkPresentModeKHR presentMode = ConfigPresentModeToVulkan(draw_);
+
+#ifdef VK_EXT_full_screen_exclusive
+	vulkan_->SetFullScreenExclusiveMode(g_Config.bFullScreen && g_Config.bFullScreenExclusive
+		? VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT
+		: VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT);
+#endif
+
 	if (!vulkan_->InitSwapchain(presentMode)) {
 		*error_message = vulkan_->InitError();
 		Shutdown();
@@ -169,6 +176,13 @@ void WindowsVulkanContext::Shutdown() {
 void WindowsVulkanContext::Resize() {
 	draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 	VkPresentModeKHR presentMode = ConfigPresentModeToVulkan(draw_);
+
+#ifdef VK_EXT_full_screen_exclusive
+	vulkan_->SetFullScreenExclusiveMode(g_Config.bFullScreen && g_Config.bFullScreenExclusive
+		? VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT
+		: VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT);
+#endif
+
 	vulkan_->InitSwapchain(presentMode);
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 }


### PR DESCRIPTION
## Summary

This change was done in particular for Vulkan. The Vulkan swapchain had no explicit fullscreen exclusive mode set, which I believe was causing drivers to default to exclusive fullscreen. Based on information I saw in issue #12347, Vulkan entering exclusive fullscreen might be unintentional behavior. I used PresentMon to confirm the presentation mode was "Hardware: Legacy Flip" when PPSSPP was in focus, which indicates exclusive fullscreen. It was also breaking Windows Auto HDR.

Despite Microsoft's documentation of Auto HDR for D3D11 and D3D12, it also works with Vulkan when the swapchain characteristics align with expected requirements and the executable name is on the Auto HDR whitelist. PPSSPP meets these swapchain characteristics and is on that list. That's why Vulkan using borderless fullscreen does trigger Windows Auto HDR, despite it not being widely documented.

The exclusive fullscreen option is now available for those who want the lowest amount of latency (even though on modern Windows borderless fullscreen is the better option for many reasons), but more importantly, it is there to avoid drivers defaulting to the wrong presentation model.

## Changes

- Added `bFullScreenExclusive` config option
- Added "Exclusive fullscreen" checkbox in settings, only enabled when fullscreen is active
- Vulkan swapchain now explicitly sets `VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT` by default, with `VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT` when exclusive is opted into

## Test plan

- Verify borderless fullscreen works with Vulkan
- Verify Auto HDR activates with Vulkan in borderless mode
- Verify exclusive fullscreen option works
- Verify setting is greyed out when fullscreen is disabled
- Verify no regressions on D3D11 and OpenGL
- Verify Android build is unaffected