### PR TITLE
Generate UI shaders instead of hardcoding them for each backend

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -13,6 +13,7 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/TimeUtil.h"
 #include "Common/Log.h"
+#include "Common/StringUtils.h"
 
 #include <map>
 
@@ -148,7 +149,6 @@ public:
 		stencilCompareMask_ = compareMask;
 		stencilDirty_ = true;
 	}
-
 
 	void Draw(int vertexCount, int offset) override;
 	void DrawIndexed(int indexCount, int offset) override;
@@ -1125,7 +1125,9 @@ ShaderModule *D3D11DrawContext::CreateShaderModule(ShaderStage stage, ShaderLang
 	}
 	if (errorMsgs) {
 		errors = std::string((const char *)errorMsgs->GetBufferPointer(), errorMsgs->GetBufferSize());
-		ERROR_LOG(Log::G3D, "Failed compiling %s:\n%s\n%s", tag, data, errors.c_str());
+		ERROR_LOG(Log::G3D, "Failed compiling %s:", tag);
+		ERROR_LOG(Log::G3D, "%s", LineNumberString(std::string((const char *)data, dataSize)).c_str());
+		ERROR_LOG(Log::G3D, "%s", errors.c_str());
 	}
 
 	if (result != S_OK) {

--- a/Common/GPU/MiscTypes.h
+++ b/Common/GPU/MiscTypes.h
@@ -41,7 +41,6 @@ constexpr size_t FRAME_TIME_HISTORY_LENGTH = 32;
 
 // Different APIs use different coordinate conventions
 enum class CoordConvention {
-	Direct3D9,
 	Direct3D11,
 	Vulkan,
 	OpenGL,

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -28,18 +28,20 @@ const char * const hlsl_preamble_fs =
 "#define ivec4 int4\n"
 "#define mat4 float4x4\n"
 "#define mat3x4 float4x3\n"  // note how the conventions are backwards
-"#define splat3(x) float3(x, x, x)\n"
-"#define mix lerp\n"
 "#define lowp\n"
 "#define mediump\n"
 "#define highp\n"
+"#define splat3(x) float3(x, x, x)\n"
+"#define mix lerp\n"
 "#define fract frac\n"
 "#define mod(x, y) fmod(x, y)\n"
-"#define inversesqrt rsqrt\n";
+"#define inversesqrt rsqrt\n"
+"\n";
 
 static const char * const hlsl_d3d11_preamble_fs =
 "#define DISCARD discard\n"
-"#define DISCARD_BELOW(x) clip(x);\n";
+"#define DISCARD_BELOW(x) clip(x);\n"
+"\n";
 
 static const char * const vulkan_glsl_preamble_vs =
 "#extension GL_ARB_separate_shader_objects : enable\n"
@@ -82,10 +84,13 @@ static const char * const hlsl_preamble_vs =
 "#define mat2 float2x2\n"
 "#define mat4 float4x4\n"
 "#define mat3x4 float4x3\n"  // note how the conventions are backwards
-"#define splat3(x) vec3(x, x, x)\n"
 "#define lowp\n"
 "#define mediump\n"
 "#define highp\n"
+"#define splat3(x) float3(x, x, x)\n"
+"#define mix lerp\n"
+"#define fract frac\n"
+"#define mod(x, y) fmod(x, y)\n"
 "#define inversesqrt rsqrt\n"
 "\n";
 
@@ -196,7 +201,40 @@ void ShaderWriter::Preamble(Slice<const char *> extensions) {
 	}
 }
 
+void ShaderWriter::DeclareUniforms(const Slice<UniformDef> &uniforms) {
+	switch (lang_.shaderLanguage) {
+	case HLSL_D3D11:
+		if (!uniforms.is_empty()) {
+			C("cbuffer base : register(b0) {\n");
+
+			for (auto &uniform : uniforms) {
+				F("  %s %s;\n", uniform.type, uniform.name);
+			}
+
+			C("};\n");
+		}
+		break;
+	case GLSL_VULKAN:
+		if (!uniforms.is_empty()) {
+			C("layout(std140, set = 0, binding = 0) uniform bufferVals {\n");
+			for (auto &uniform : uniforms) {
+				F("%s %s;\n", uniform.type, uniform.name);
+			}
+			C("};\n");
+		}
+		break;
+
+	default:  // GLSL OpenGL
+		for (auto &uniform : uniforms) {
+			F("uniform %s %s;\n", uniform.type, uniform.name);
+		}
+		break;
+	}
+}
+
 void ShaderWriter::BeginVSMain(Slice<InputDef> inputs, Slice<UniformDef> uniforms, Slice<VaryingDef> varyings) {
+	DeclareUniforms(uniforms);
+
 	_assert_(this->stage_ == ShaderStage::Vertex);
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
@@ -249,18 +287,9 @@ void ShaderWriter::BeginVSMain(Slice<InputDef> inputs, Slice<UniformDef> uniform
 
 void ShaderWriter::BeginFSMain(Slice<UniformDef> uniforms, Slice<VaryingDef> varyings) {
 	_assert_(this->stage_ == ShaderStage::Fragment);
+	DeclareUniforms(uniforms);
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
-		if (!uniforms.is_empty()) {
-			C("cbuffer base : register(b0) {\n");
-
-			for (auto &uniform : uniforms) {
-				F("  %s %s;\n", uniform.type, uniform.name);
-			}
-
-			C("};\n");
-		}
-
 		if (flags_ & ShaderWriterFlags::FS_WRITE_DEPTH) {
 			C("float gl_FragDepth;\n");
 		}
@@ -291,22 +320,12 @@ void ShaderWriter::BeginFSMain(Slice<UniformDef> uniforms, Slice<VaryingDef> var
 			F("layout(location = %d) %s in %s %s;  // %s\n", varying.index, varying.precision ? varying.precision : "", varying.type, varying.name, semanticNames[varying.semantic]);
 		}
 		C("layout(location = 0, index = 0) out vec4 fragColor0;\n");
-		if (!uniforms.is_empty()) {
-			C("layout(std140, set = 0, binding = 0) uniform bufferVals {\n");
-			for (auto &uniform : uniforms) {
-				F("%s %s;\n", uniform.type, uniform.name);
-			}
-			C("};\n");
-		}
 		C("\nvoid main() {\n");
 		break;
 
 	default:  // GLSL OpenGL
 		for (auto &varying : varyings) {
 			F("%s %s %s %s;  // %s\n", lang_.varying_fs, varying.precision ? varying.precision : "", varying.type, varying.name, semanticNames[varying.semantic]);
-		}
-		for (auto &uniform : uniforms) {
-			F("uniform %s %s;\n", uniform.type, uniform.name);
 		}
 		if (!strcmp(lang_.fragColor0, "fragColor0")) {
 			C("out vec4 fragColor0;\n");

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -119,6 +119,7 @@ private:
 	// Several of the shader languages ignore samplers, beware of that.
 	void DeclareSampler2D(const SamplerDef &def);
 	void DeclareTexture2D(const SamplerDef &def);
+	void DeclareUniforms(const Slice<UniformDef> &uniforms);
 	const SamplerDef *GetSamplerDef(const char *name) const;
 
 	void Preamble(Slice<const char *> extensions);

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -275,83 +275,9 @@ static const std::vector<ShaderSource> fsCol = {
 	}
 };
 
-// ================================== VERTEX SHADERS
-
-static const std::vector<ShaderSource> vsCol = {
-	{ GLSL_1xx,
-	"#if __VERSION__ >= 130\n"
-	"#define attribute in\n"
-	"#define varying out\n"
-	"#endif\n"
-	"attribute vec3 Position;\n"
-	"attribute vec4 Color0;\n"
-	"varying vec4 oColor0;\n"
-
-	"uniform mat4 WorldViewProj;\n"
-	"uniform vec2 TintSaturation;\n"
-	"void main() {\n"
-	"  gl_Position = WorldViewProj * vec4(Position, 1.0);\n"
-	"  oColor0 = Color0;\n"
-	"}"
-	},
-	{ ShaderLanguage::HLSL_D3D11,
-	"struct VS_INPUT { float3 Position : POSITION; float4 Color0 : COLOR0; };\n"
-	"struct VS_OUTPUT { float4 Color0 : COLOR0; float4 Position : SV_Position; };\n"
-	"cbuffer ConstantBuffer : register(b0) {\n"
-	"  matrix WorldViewProj;\n"
-	"  float2 TintSaturation;\n"
-	"};\n"
-	"VS_OUTPUT main(VS_INPUT input) {\n"
-	"  VS_OUTPUT output;\n"
-	"  output.Position = mul(WorldViewProj, float4(input.Position, 1.0));\n"
-	"  output.Color0 = input.Color0;\n"
-	"  return output;\n"
-	"}\n"
-	},
-	{ ShaderLanguage::GLSL_VULKAN,
-R"(#version 450
-#extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_420pack : enable
-layout (std140, set = 0, binding = 0) uniform bufferVals {
-	mat4 WorldViewProj;
-	vec2 TintSaturation;
-} myBufferVals;
-layout (location = 0) in vec4 pos;
-layout (location = 1) in vec4 inColor;
-layout (location = 0) out vec4 outColor;
-out gl_PerVertex { vec4 gl_Position; };
-void main() {
-    outColor = inColor;
-	gl_Position = myBufferVals.WorldViewProj * pos;
-}
-)"
-	}
-};
-
 const UniformBufferDesc vsColBufDesc { sizeof(VsColUB), {
 	{ "WorldViewProj", 0, -1, UniformType::MATRIX4X4, 0 },
 	{ "TintSaturation", 4, -1, UniformType::FLOAT2, 64 },
-} };
-
-static const std::vector<ShaderSource> vsTexColNoTint = { {
-	GLSL_1xx,
-	R"(
-#if __VERSION__ >= 130
-#define attribute in
-#define varying out
-#endif
-attribute vec3 Position;
-attribute vec4 Color0;
-attribute vec2 TexCoord0;
-varying vec4 oColor0;
-varying vec2 oTexCoord0;
-uniform mat4 WorldViewProj;
-uniform vec2 TintSaturation;
-void main() {
-	gl_Position = WorldViewProj * vec4(Position, 1.0);
-    oColor0 = Color0;
-	oTexCoord0 = TexCoord0;
-})"
 } };
 
 static_assert(SEM_TEXCOORD0 == 3, "Semantic shader hardcoded in glsl above.");
@@ -395,12 +321,13 @@ const UniformDef g_uniforms[] = {
 	{ "vec2", "TintSaturation", 1 },
 };
 
-static ShaderModule *GenerateVShader(DrawContext *draw, VertexShaderPreset preset) {
+static ShaderModule *GenerateVShader(DrawContext *draw, VertexShaderPreset preset, bool texCoords, bool tint) {
 	const ShaderLanguageDesc &shaderLanguageDesc = draw->GetShaderLanguageDesc();
 	char code[2048];
 	ShaderWriter vsWriter(code, shaderLanguageDesc, ShaderStage::Vertex);
 
-	vsWriter.C(R"(
+	if (tint) {
+		vsWriter.C(R"(
 vec3 rgb2hsv(vec3 c) {
 	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
 	vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
@@ -415,29 +342,35 @@ vec3 hsv2rgb(vec3 c) {
 	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 )");
+	}
 
-	vsWriter.BeginVSMain(g_inputs, g_uniforms, g_varyingsTex);
-	vsWriter.C(R"(
-		gl_Position = mul(WorldViewProj, vec4(Position, 1.0));
+	vsWriter.BeginVSMain(g_inputs, g_uniforms, texCoords ? Slice(g_varyingsTex) : Slice(g_varyings));
+	vsWriter.C("gl_Position = mul(WorldViewProj, vec4(Position, 1.0));\n");
+	if (tint) {
+		vsWriter.C(R"(
 		vec3 hsv = rgb2hsv(Color0.xyz);
 		hsv.x += TintSaturation.x;
 		hsv.y *= TintSaturation.y;
 		oColor0 = vec4(hsv2rgb(hsv), Color0.w);
-		oTexCoord0 = TexCoord0;
-	)");
-	vsWriter.EndVSMain(g_varyingsTex);
-
+)");
+	} else {
+		vsWriter.C("oColor0 = Color0;\n");
+	}
+	if (texCoords) {
+		vsWriter.C("oTexCoord0 = TexCoord0;\n");
+	}
+	vsWriter.EndVSMain(texCoords ? Slice(g_varyingsTex) : Slice(g_varyings));
 	return draw->CreateShaderModule(ShaderStage::Vertex, shaderLanguageDesc.shaderLanguage, (const uint8_t *)code, strlen(code));
 }
 
 bool DrawContext::CreatePresets() {
+	bool tintSupported = true;
 	if (bugs_.Has(Bugs::RASPBERRY_SHADER_COMP_HANG)) {
-		vsPresets_[VS_TEXTURE_COLOR_2D] = CreateShader(this, ShaderStage::Vertex, vsTexColNoTint);
-	} else {
-		vsPresets_[VS_TEXTURE_COLOR_2D] = GenerateVShader(this, VS_TEXTURE_COLOR_2D);
+		tintSupported = false;
 	}
 
-	vsPresets_[VS_COLOR_2D] = CreateShader(this, ShaderStage::Vertex, vsCol);
+	vsPresets_[VS_TEXTURE_COLOR_2D] = GenerateVShader(this, VS_TEXTURE_COLOR_2D, true, tintSupported);
+	vsPresets_[VS_COLOR_2D] = GenerateVShader(this, VS_COLOR_2D, false, tintSupported);
 
 	fsPresets_[FS_TEXTURE_COLOR_2D] = CreateShader(this, ShaderStage::Fragment, fsTexCol);
 	fsPresets_[FS_COLOR_2D] = CreateShader(this, ShaderStage::Fragment, fsCol);

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -4,6 +4,7 @@
 
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/GPU/thin3d.h"
+#include "Common/GPU/ShaderWriter.h"
 #include "Common/Log.h"
 #include "Common/System/Display.h"
 
@@ -353,113 +354,6 @@ void main() {
 })"
 } };
 
-static const std::vector<ShaderSource> vsTexCol = {
-	{ GLSL_1xx,
-	R"(
-#if __VERSION__ >= 130
-#define attribute in
-#define varying out
-#endif
-attribute vec3 Position;
-attribute vec4 Color0;
-attribute vec2 TexCoord0;
-varying vec4 oColor0;
-varying vec2 oTexCoord0;
-uniform mat4 WorldViewProj;
-uniform vec2 TintSaturation;
-vec3 rgb2hsv(vec3 c) {
-	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-	vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
-	vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
-	float d = q.x - min(q.w, q.y);
-	float e = 1.0e-10;
-	return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-}
-vec3 hsv2rgb(vec3 c) {
-	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-}
-void main() {
-	gl_Position = WorldViewProj * vec4(Position, 1.0);
-	vec3 hsv = rgb2hsv(Color0.xyz);
-	hsv.x += TintSaturation.x;
-	hsv.y *= TintSaturation.y;
-    oColor0 = vec4(hsv2rgb(hsv), Color0.w);
-	oTexCoord0 = TexCoord0;
-})",
-	},
-	{ ShaderLanguage::HLSL_D3D11,
-R"(
-struct VS_INPUT { float3 Position : POSITION; float2 Texcoord0 : TEXCOORD0; float4 Color0 : COLOR0; };
-struct VS_OUTPUT { float4 Color0 : COLOR0; float2 Texcoord0 : TEXCOORD0; float4 Position : SV_Position; };
-cbuffer ConstantBuffer : register(b0) {
-	matrix WorldViewProj;
-	float2 TintSaturation;
-};
-float3 rgb2hsv(float3 c) {
-	float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-	float4 p = lerp(float4(c.bg, K.wz), float4(c.gb, K.xy), step(c.b, c.g));
-	float4 q = lerp(float4(p.xyw, c.r), float4(c.r, p.yzx), step(p.x, c.r));
-	float d = q.x - min(q.w, q.y);
-	float e = 1.0e-10;
-	return float3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-}
-float3 hsv2rgb(float3 c) {
-	float4 K = float4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-	float3 p = abs(frac(c.xxx + K.xyz) * 6.0 - K.www);
-	return c.z * lerp(K.xxx, saturate(p - K.xxx), c.y);
-}
-VS_OUTPUT main(VS_INPUT input) {
-	VS_OUTPUT output;
-	float3 hsv = rgb2hsv(input.Color0.xyz);
-	hsv.x += TintSaturation.x;
-	hsv.y *= TintSaturation.y;
-    output.Color0 = float4(hsv2rgb(hsv), input.Color0.w);
-	output.Position = mul(WorldViewProj, float4(input.Position, 1.0));
-	output.Texcoord0 = input.Texcoord0;
-	return output;
-}
-)"
-	},
-	{ ShaderLanguage::GLSL_VULKAN,
-	R"(#version 450
-#extension GL_ARB_separate_shader_objects : enable
-#extension GL_ARB_shading_language_420pack : enable
-layout (std140, set = 0, binding = 0) uniform bufferVals {
-	mat4 WorldViewProj;
-	vec2 TintSaturation;
-} myBufferVals;
-vec3 rgb2hsv(vec3 c) {
-	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
-	vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
-	vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
-	float d = q.x - min(q.w, q.y);
-	float e = 1.0e-10;
-	return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
-}
-vec3 hsv2rgb(vec3 c) {
-	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-}
-layout (location = 0) in vec4 pos;
-layout (location = 1) in vec4 inColor;
-layout (location = 3) in vec2 inTexCoord;
-layout (location = 0) out vec4 outColor;
-layout (location = 1) out vec2 outTexCoord;
-out gl_PerVertex { vec4 gl_Position; };
-void main() {
-	vec3 hsv = rgb2hsv(inColor.xyz);
-	hsv.x += myBufferVals.TintSaturation.x;
-	hsv.y *= myBufferVals.TintSaturation.y;
-    outColor = vec4(hsv2rgb(hsv), inColor.w);
-	outTexCoord = inTexCoord;
-	gl_Position = myBufferVals.WorldViewProj * pos;
-}
-)"
-} };
-
 static_assert(SEM_TEXCOORD0 == 3, "Semantic shader hardcoded in glsl above.");
 
 const UniformBufferDesc vsTexColBufDesc{ sizeof(VsTexColUB),{
@@ -477,11 +371,70 @@ ShaderModule *CreateShader(DrawContext *draw, ShaderStage stage, const std::vect
 	return nullptr;
 }
 
+static const InputDef g_inputs[] = {
+	{ "vec3", "Position", Draw::SEM_POSITION },
+	{ "vec4", "Color0", Draw::SEM_COLOR0 },
+	{ "vec2", "TexCoord0", Draw::SEM_TEXCOORD0 },
+};
+
+static const VaryingDef g_varyings[] = {
+	{ "vec4", "oColor0", Draw::SEM_COLOR0, 0, "lowp" },
+};
+
+static const VaryingDef g_varyingsTex[] = {
+	{ "vec4", "oColor0", Draw::SEM_COLOR0, 0, "lowp" },
+	{ "vec2", "oTexCoord0", Draw::SEM_TEXCOORD0, 1, "highp" },
+};
+
+static const SamplerDef g_samplers[] = {
+	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
+};
+
+const UniformDef g_uniforms[] = {
+	{ "mat4", "WorldViewProj", 0 },
+	{ "vec2", "TintSaturation", 1 },
+};
+
+static ShaderModule *GenerateVShader(DrawContext *draw, VertexShaderPreset preset) {
+	const ShaderLanguageDesc &shaderLanguageDesc = draw->GetShaderLanguageDesc();
+	char code[2048];
+	ShaderWriter vsWriter(code, shaderLanguageDesc, ShaderStage::Vertex);
+
+	vsWriter.C(R"(
+vec3 rgb2hsv(vec3 c) {
+	vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+	vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));
+	vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));
+	float d = q.x - min(q.w, q.y);
+	float e = 1.0e-10;
+	return vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);
+}
+vec3 hsv2rgb(vec3 c) {
+	vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+	vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+	return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+)");
+
+	vsWriter.BeginVSMain(g_inputs, g_uniforms, g_varyingsTex);
+	vsWriter.C(R"(
+		gl_Position = mul(WorldViewProj, vec4(Position, 1.0));
+		vec3 hsv = rgb2hsv(Color0.xyz);
+		hsv.x += TintSaturation.x;
+		hsv.y *= TintSaturation.y;
+		oColor0 = vec4(hsv2rgb(hsv), Color0.w);
+		oTexCoord0 = TexCoord0;
+	)");
+	vsWriter.EndVSMain(g_varyingsTex);
+
+	return draw->CreateShaderModule(ShaderStage::Vertex, shaderLanguageDesc.shaderLanguage, (const uint8_t *)code, strlen(code));
+}
+
 bool DrawContext::CreatePresets() {
 	if (bugs_.Has(Bugs::RASPBERRY_SHADER_COMP_HANG)) {
 		vsPresets_[VS_TEXTURE_COLOR_2D] = CreateShader(this, ShaderStage::Vertex, vsTexColNoTint);
 	} else {
-		vsPresets_[VS_TEXTURE_COLOR_2D] = CreateShader(this, ShaderStage::Vertex, vsTexCol);
+		vsPresets_[VS_TEXTURE_COLOR_2D] = GenerateVShader(this, VS_TEXTURE_COLOR_2D);
 	}
 
 	vsPresets_[VS_COLOR_2D] = CreateShader(this, ShaderStage::Vertex, vsCol);

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -164,117 +164,6 @@ bool RefCountedObject::ReleaseAssertLast() {
 	return released;
 }
 
-// ================================== PIXEL/FRAGMENT SHADERS
-
-// The Vulkan ones can be re-used with modern GL later if desired, as they're just GLSL.
-
-static const std::vector<ShaderSource> fsTexCol = {
-	{ShaderLanguage::GLSL_1xx,
-	"#ifdef GL_ES\n"
-	"precision lowp float;\n"
-	"#endif\n"
-	"#if __VERSION__ >= 130\n"
-	"#define varying in\n"
-	"#define texture2D texture\n"
-	"#define gl_FragColor fragColor0\n"
-	"out vec4 fragColor0;\n"
-	"#endif\n"
-	"varying vec4 oColor0;\n"
-	"varying vec2 oTexCoord0;\n"
-	"uniform sampler2D Sampler0;\n"
-	"void main() { vec4 col = texture2D(Sampler0, oTexCoord0) * oColor0; col.rgb *= oColor0.a; gl_FragColor = col; }\n"
-	},
-	{ShaderLanguage::HLSL_D3D11,
-	"struct PS_INPUT { float4 color : COLOR0; float2 uv : TEXCOORD0; };\n"
-	"SamplerState samp : register(s0);\n"
-	"Texture2D<float4> tex : register(t0);\n"
-	"float4 main(PS_INPUT input) : SV_Target {\n"
-	"  float4 col = input.color * tex.Sample(samp, input.uv);\n"
-	"  col.rgb *= input.color.a;\n"
-	"  return col;\n"
-	"}\n"
-	},
-	{ShaderLanguage::GLSL_VULKAN,
-	"#version 140\n"
-	"#extension GL_ARB_separate_shader_objects : enable\n"
-	"#extension GL_ARB_shading_language_420pack : enable\n"
-	"layout(location = 0) in vec4 oColor0;\n"
-	"layout(location = 1) in vec2 oTexCoord0;\n"
-	"layout(location = 0) out vec4 fragColor0;\n"
-	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
-	"void main() { vec4 col = texture(Sampler0, oTexCoord0) * oColor0; col.rgb *= oColor0.a; fragColor0 = col; }\n"
-	}
-};
-
-static const std::vector<ShaderSource> fsTexColRBSwizzle = {
-	{GLSL_1xx,
-	"#ifdef GL_ES\n"
-	"precision lowp float;\n"
-	"#endif\n"
-	"#if __VERSION__ >= 130\n"
-	"#define varying in\n"
-	"#define texture2D texture\n"
-	"#define gl_FragColor fragColor0\n"
-	"out vec4 fragColor0;\n"
-	"#endif\n"
-	"varying vec4 oColor0;\n"
-	"varying vec2 oTexCoord0;\n"
-	"uniform sampler2D Sampler0;\n"
-	"void main() { vec4 col = texture2D(Sampler0, oTexCoord0).zyxw * oColor0; col.rgb *= oColor0.a; gl_FragColor = col; }\n"
-	},
-	{ShaderLanguage::HLSL_D3D11,
-	"struct PS_INPUT { float4 color : COLOR0; float2 uv : TEXCOORD0; };\n"
-	"SamplerState samp : register(s0);\n"
-	"Texture2D<float4> tex : register(t0);\n"
-	"float4 main(PS_INPUT input) : SV_Target {\n"
-	"  float4 col = input.color * tex.Sample(samp, input.uv).bgra;\n"
-	"  col.rgb *= input.color.a;\n"
-	"  return col;\n"
-	"}\n"
-	},
-	{ShaderLanguage::GLSL_VULKAN,
-	"#version 140\n"
-	"#extension GL_ARB_separate_shader_objects : enable\n"
-	"#extension GL_ARB_shading_language_420pack : enable\n"
-	"layout(location = 0) in vec4 oColor0;\n"
-	"layout(location = 1) in vec2 oTexCoord0;\n"
-	"layout(location = 0) out vec4 fragColor0\n;"
-	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
-	"void main() { vec4 col = texture(Sampler0, oTexCoord0).bgra * oColor0; col.rgb *= oColor0.a; fragColor0 = col; }\n"
-	}
-};
-
-static const std::vector<ShaderSource> fsCol = {
-	{ GLSL_1xx,
-	"#ifdef GL_ES\n"
-	"precision lowp float;\n"
-	"#endif\n"
-	"#if __VERSION__ >= 130\n"
-	"#define varying in\n"
-	"#define gl_FragColor fragColor0\n"
-	"out vec4 fragColor0;\n"
-	"#endif\n"
-	"varying vec4 oColor0;\n"
-	"void main() { vec4 col = oColor0; col.rgb *= oColor0.a; gl_FragColor = col; }\n"
-	},
-	{ ShaderLanguage::HLSL_D3D11,
-	"struct PS_INPUT { float4 color : COLOR0; };\n"
-	"float4 main(PS_INPUT input) : SV_Target {\n"
-	"  float4 col = input.color;\n"
-	"  col.rgb *= input.color.a;\n"
-	"  return col;\n"
-	"}\n"
-	},
-	{ ShaderLanguage::GLSL_VULKAN,
-	"#version 140\n"
-	"#extension GL_ARB_separate_shader_objects : enable\n"
-	"#extension GL_ARB_shading_language_420pack : enable\n"
-	"layout(location = 0) in vec4 oColor0;\n"
-	"layout(location = 0) out vec4 fragColor0;\n"
-	"void main() { vec4 col = oColor0; col.rgb *= oColor0.a; fragColor0 = col; }\n"
-	}
-};
-
 const UniformBufferDesc vsColBufDesc { sizeof(VsColUB), {
 	{ "WorldViewProj", 0, -1, UniformType::MATRIX4X4, 0 },
 	{ "TintSaturation", 4, -1, UniformType::FLOAT2, 64 },
@@ -313,7 +202,7 @@ static const VaryingDef g_varyingsTex[] = {
 };
 
 static const SamplerDef g_samplers[] = {
-	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
+	{ 0, "tex" },
 };
 
 const UniformDef g_uniforms[] = {
@@ -321,7 +210,7 @@ const UniformDef g_uniforms[] = {
 	{ "vec2", "TintSaturation", 1 },
 };
 
-static ShaderModule *GenerateVShader(DrawContext *draw, VertexShaderPreset preset, bool texCoords, bool tint) {
+static ShaderModule *GenerateVShader(DrawContext *draw, bool texCoords, bool tint) {
 	const ShaderLanguageDesc &shaderLanguageDesc = draw->GetShaderLanguageDesc();
 	char code[2048];
 	ShaderWriter vsWriter(code, shaderLanguageDesc, ShaderStage::Vertex);
@@ -363,18 +252,40 @@ vec3 hsv2rgb(vec3 c) {
 	return draw->CreateShaderModule(ShaderStage::Vertex, shaderLanguageDesc.shaderLanguage, (const uint8_t *)code, strlen(code));
 }
 
+static ShaderModule *GenerateFShader(DrawContext *draw, bool texturing, bool rbSwizzle) {
+	const ShaderLanguageDesc &shaderLanguageDesc = draw->GetShaderLanguageDesc();
+	char code[2048];
+	ShaderWriter fsWriter(code, shaderLanguageDesc, ShaderStage::Fragment);
+	fsWriter.DeclareSamplers(g_samplers);
+	fsWriter.BeginFSMain(g_uniforms, texturing ? Slice(g_varyingsTex) : Slice(g_varyings));
+	if (texturing) {
+		fsWriter.C("vec4 col = ");
+		fsWriter.SampleTexture2D("tex", "oTexCoord0");
+		if (rbSwizzle) {
+			fsWriter.C(".zyxw * oColor0;\n");
+		} else {
+			fsWriter.C(" * oColor0;\n");
+		}
+	} else {
+		fsWriter.C("vec4 col = oColor0;\n");
+	}
+	fsWriter.C("col.rgb *= oColor0.a;\n");  // premultiply alpha
+	fsWriter.EndFSMain("col");
+	return draw->CreateShaderModule(ShaderStage::Fragment, shaderLanguageDesc.shaderLanguage, (const uint8_t *)code, strlen(code));
+}
+
 bool DrawContext::CreatePresets() {
 	bool tintSupported = true;
 	if (bugs_.Has(Bugs::RASPBERRY_SHADER_COMP_HANG)) {
 		tintSupported = false;
 	}
 
-	vsPresets_[VS_TEXTURE_COLOR_2D] = GenerateVShader(this, VS_TEXTURE_COLOR_2D, true, tintSupported);
-	vsPresets_[VS_COLOR_2D] = GenerateVShader(this, VS_COLOR_2D, false, tintSupported);
+	vsPresets_[VS_TEXTURE_COLOR_2D] = GenerateVShader(this, true, tintSupported);
+	vsPresets_[VS_COLOR_2D] = GenerateVShader(this, false, tintSupported);
 
-	fsPresets_[FS_TEXTURE_COLOR_2D] = CreateShader(this, ShaderStage::Fragment, fsTexCol);
-	fsPresets_[FS_COLOR_2D] = CreateShader(this, ShaderStage::Fragment, fsCol);
-	fsPresets_[FS_TEXTURE_COLOR_2D_RB_SWIZZLE] = CreateShader(this, ShaderStage::Fragment, fsTexColRBSwizzle);
+	fsPresets_[FS_TEXTURE_COLOR_2D] = GenerateFShader(this, true, false);
+	fsPresets_[FS_COLOR_2D] = GenerateFShader(this, false, false);
+	fsPresets_[FS_TEXTURE_COLOR_2D_RB_SWIZZLE] = GenerateFShader(this, true, true);
 
 	return vsPresets_[VS_TEXTURE_COLOR_2D] && vsPresets_[VS_COLOR_2D] && fsPresets_[FS_TEXTURE_COLOR_2D] && fsPresets_[FS_COLOR_2D] && fsPresets_[FS_TEXTURE_COLOR_2D_RB_SWIZZLE];
 }

--- a/Common/System/Display.cpp
+++ b/Common/System/Display.cpp
@@ -116,7 +116,7 @@ void DisplayProperties::Print() {
 	rot_matrix.print();
 }
 
-Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordConvention) {
+Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordConvention, bool compensateYFlip) {
 	using namespace Lin;
 	// TODO: Should be able to share the y-flip logic here with the one in postprocessing/presentation, for example.
 	Matrix4x4 ortho;
@@ -124,21 +124,20 @@ Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordC
 	case CoordConvention::Vulkan:
 		ortho.setOrthoD3D(0.0f, xres, 0, yres, -1.0f, 1.0f);
 		break;
-	case CoordConvention::Direct3D9:
-		ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
-		Matrix4x4 translation;
-		// Account for the small window adjustment.
-		translation.setTranslation(Vec3(
-			-0.5f * g_display.dpi_scale_x / g_display.dpi_scale_real_x,
-			-0.5f * g_display.dpi_scale_y / g_display.dpi_scale_real_y, 0.0f));
-		ortho = translation * ortho;
-		break;
 	case CoordConvention::Direct3D11:
-		ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
+		if (compensateYFlip) {
+			ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
+		} else {
+			ortho.setOrthoD3D(0.0f, xres, 0, yres, -1.0f, 1.0f);
+		}
 		break;
 	case CoordConvention::OpenGL:
 	default:
-		ortho.setOrthoGL(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
+		if (compensateYFlip) {
+			ortho.setOrthoGL(0.0f, xres, 0, yres, -1.0f, 1.0f);
+		} else {
+			ortho.setOrthoGL(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
+		}
 		break;
 	}
 	// Compensate for rotated display if needed.

--- a/Common/System/Display.h
+++ b/Common/System/Display.h
@@ -61,7 +61,7 @@ struct DisplayRect {
 void RotateRectToDisplay(DisplayRect<float> &rect, float rtWidth, float rtHeight);
 void RotateRectToDisplay(DisplayRect<int> &rect, int rtWidth, int rtHeight);
 
-Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordConvention);
+Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordConvention, bool compensateYFlip);
 
 // Take this and run through translation. Returns "Portrait", "Landscape" or later "Square" (the latter being the square shape you get when you open a foldable phone).
 std::string_view DeviceOrientationToString(DeviceOrientation orientation);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1076,7 +1076,8 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 	g_breakpoints.Frame();
 
 	// Apply the UIContext bounds as a 2D transformation matrix.
-	Matrix4x4 ortho = ComputeOrthoMatrix(g_display.dp_xres, g_display.dp_yres, graphicsContext->GetDrawContext()->GetDeviceCaps().coordConvention);
+	// NOTE: We compensate for the Y convention in the shaders, so we can use the same matrices in all backends.
+	Matrix4x4 ortho = ComputeOrthoMatrix(g_display.dp_xres, g_display.dp_yres, g_draw->GetDeviceCaps().coordConvention, false);
 
 	// Can be overridden by sceDisplay which may pass true for the second argument.
 	g_frameTiming.ComputePresentMode(g_draw, false);

--- a/ext/imgui/imgui_impl_thin3d.cpp
+++ b/ext/imgui/imgui_impl_thin3d.cpp
@@ -73,7 +73,7 @@ void ImGui_ImplThin3d_RenderDrawData(ImDrawData* draw_data, Draw::DrawContext *d
 	viewport.MaxDepth = 1.0f;
 	draw->SetViewport(viewport);
 
-	Lin::Matrix4x4 mtx = ComputeOrthoMatrix(draw_data->DisplaySize.x, draw_data->DisplaySize.y, draw->GetDeviceCaps().coordConvention);
+	Lin::Matrix4x4 mtx = ComputeOrthoMatrix(draw_data->DisplaySize.x, draw_data->DisplaySize.y, draw->GetDeviceCaps().coordConvention, true);
 
 	Draw::VsTexColUB ub{};
 	memcpy(ub.WorldViewProj, mtx.getReadPtr(), sizeof(Lin::Matrix4x4));


### PR DESCRIPTION
A small refactoring I've wanted to do for ages. Makes it easier to update the shaders used for rendering UI (or adding more).

Will merge after the 1.20.4 release.