### PR TITLE
Remove 2 cases for fast path for soft gpu by Deepseek

### DIFF
--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -172,6 +172,8 @@ static bool UseDrawSinglePixel(const PixelFuncID &pixelID) {
 		if (pixelID.AlphaBlendDst() != PixelBlendFactor::INVSRCALPHA)
 			return false;
 	}
+	if (pixelID.depthWrite || pixelID.applyFog)
+		return false;
 	if (pixelID.dithering || pixelID.applyLogicOp || pixelID.applyColorWriteMask)
 		return false;
 


### PR DESCRIPTION
Fix #21363
https://chat.deepseek.com/share/980xe4c2ue35te8cy2 
Performance impact is minimal because sprites that require depth/fog are relatively rare, and the fallback still uses the per-pixel rectangle loop (not the full triangle rasterizer)