### PR TITLE
Critical bug in the remote debugger

### DIFF
--- a/Core/Debugger/WebSocket/GPUStatsSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GPUStatsSubscriber.cpp
@@ -129,8 +129,8 @@ void WebSocketGPUStatsState::FlipListener() {
 	stats.frameTimes.resize(valid);
 	stats.sleepTimes.resize(valid);
 	if (valid > 0) {
-		memcpy(&stats.frameTimes[0], history, sizeof(double) * valid);
-		memcpy(&stats.sleepTimes[0], sleepHistory, sizeof(double) * valid);
+		memcpy(&stats.frameTimes[0], history, sizeof(float) * valid);
+		memcpy(&stats.sleepTimes[0], sleepHistory, sizeof(float) * valid);
 	}
 
 	sendNext_ = false;


### PR DESCRIPTION
https://github.com/hrydgard/ppsspp/commit/cc3fbb22e495021145c71875017d3403aeee7d3b actually broke the `gpu.stats.feed` method. It's a solid heap buffer overflow, but with a `memcpy`.