### PR TITLE
More helpful error logs for the input sink

### DIFF
--- a/Common/Net/Sinks.cpp
+++ b/Common/Net/Sinks.cpp
@@ -209,7 +209,7 @@ void InputSink::AccountFill(int bytes) {
 		int err = socket_errno;
 		if (err == EWOULDBLOCK || err == EAGAIN)
 			return;
-		ERROR_LOG(Log::IO, "Error reading from socket");
+		ERROR_LOG(Log::IO, "Error reading from socket: %d", err);
 		return;
 	}
 


### PR DESCRIPTION
https://github.com/hrydgard/ppsspp/commit/c3aa0f745262b26e5ccc8471d4b0673356ee8a4a added errno logging to `OutputSink::AccountDrain`, but not to `InputSink::AccountFill`.
Now they're symmetrical.

<img width="743" height="55" alt="image" src="https://github.com/user-attachments/assets/5bd90b1f-a0eb-4141-8e39-7802b2575759" />

