### PR TITLE
Texture replacement addition for Address Only case

### DIFF
--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -929,7 +929,16 @@ static typename std::unordered_map<Key, Value>::const_iterator LookupWildcard(co
 	// Anything with this data hash (a little dangerous.)
 	key.cachekey = 0;
 	key.hash = hash;
-	return map.find(key);
+	alias = map.find(key);
+	if (alias != map.end())
+		return alias;
+
+	if (!ignoreAddress) {
+		// Address Only.
+		key.cachekey = cachekey & ~0xFFFFFFFFULL;
+		key.hash = 0;
+		return map.find(key);
+	}
 }
 
 bool TextureReplacer::FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -926,19 +926,19 @@ static typename std::unordered_map<Key, Value>::const_iterator LookupWildcard(co
 			return alias;
 	}
 
-	// Anything with this data hash (a little dangerous.)
-	key.cachekey = 0;
-	key.hash = hash;
-	alias = map.find(key);
-	if (alias != map.end())
-		return alias;
-
 	if (!ignoreAddress) {
 		// Address Only.
 		key.cachekey = cachekey & ~0xFFFFFFFFULL;
 		key.hash = 0;
-		return map.find(key);
+		alias = map.find(key);
+		if (alias != map.end())
+			return alias;
 	}
+
+	// Anything with this data hash (a little dangerous.)
+	key.cachekey = 0;
+	key.hash = hash;
+	return map.find(key);
 }
 
 bool TextureReplacer::FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering) {


### PR DESCRIPTION
Allows for preventing textures generated by only including their address like [address][wildcard][wildcard] or replacing all instances, though the latter probably isn't useful for any cases but it uses the same function:

ABCDEFGH0000000000000000 = 
ABCDEFGH0000000000000000 = filename.png

confirmed in testing going from generating hundreds of files that I didn't need to dump to generating only a few that I am actually looking for from specific addresses. very useful for the creation of texture packs for certain games