### PR TITLE
Fixed weird log formatting due to trailing line breaks

### DIFF
--- a/Common/SysError.cpp
+++ b/Common/SysError.cpp
@@ -52,7 +52,8 @@ std::string GetStringErrorMsg(int errCode) {
 	snprintf(err_str, buff_size, "%s", ConvertWStringToUTF8(err_strw).c_str());
 
 	std::string err_string = err_str;
-	if (!err_string.empty() && err_string.back() == '\n') {
+	// Trim the trailing line breaks which can mess up the logs
+	while (!err_string.empty() && (err_string.back() == '\n' || err_string.back() == '\r')) {
 		err_string.pop_back();
 	}
 	return err_string;


### PR DESCRIPTION
I wouldn't be surprised if there are more places where the OS would return something with trailing line breaks (or maybe even with line breaks in the middle of the messages!).
The one I found was [here](https://github.com/hrydgard/ppsspp/blob/master/Core/FileSystems/DirectoryFileSystem.cpp#L649):

<img width="1626" height="64" alt="image" src="https://github.com/user-attachments/assets/b8565fa0-7318-40db-a362-e435adf5539f" />

This `\r` could jump to the start of the line, like on this pic, and cause the next symbols to continue from there... Or (if the log window size isn't stretched enough) it could get inside the message. And resizing doesn't change that:
<img width="1542" height="193" alt="image" src="https://github.com/user-attachments/assets/27174159-c2cf-4f05-b2cc-f9c03b966903" />

Now it's fine:
<img width="1213" height="53" alt="image" src="https://github.com/user-attachments/assets/2edc6a22-b056-4f28-8c4c-d603a672acd8" />


So yeah, if https://github.com/hrydgard/ppsspp/commit/0179cb18110f5ab5b32fb060c0d00c2b87c007ad calls the `\n` removal a minor improvement, I think this is a good follow-up.

UNLESS this breaks something more important than correct logs. In that case don't merge, plz.

P.S. Also removed a clearly outdated comment in `SysError.h` (the functions are now in `SysError.cpp`, which probably doesn't need explaining).