### PR TITLE
Rendering: Unify Y-flip handling across backends

### DIFF
--- a/Common/GPU/Shader.cpp
+++ b/Common/GPU/Shader.cpp
@@ -50,6 +50,7 @@ void ShaderLanguageDesc::Init(ShaderLanguage lang) {
 		lastFragData = nullptr;
 		gles = false;
 		forceMatrix4x4 = true;
+		depthMinusOneToOne = true;
 		break;
 	case GLSL_3xx:
 		// Just used in the shader test.
@@ -67,6 +68,7 @@ void ShaderLanguageDesc::Init(ShaderLanguage lang) {
 		gles = true;
 		forceMatrix4x4 = true;
 		glslES30 = true;
+		depthMinusOneToOne = true;
 		break;
 	case GLSL_VULKAN:
 		fragColor0 = "fragColor0";
@@ -86,6 +88,7 @@ void ShaderLanguageDesc::Init(ShaderLanguage lang) {
 		forceMatrix4x4 = false;
 		coefsFromBuffers = true;
 		vertexIndex = true;
+		depthMinusOneToOne = false;
 		break;
 	case HLSL_D3D11:
 		fragColor0 = "outfragment.target";
@@ -107,6 +110,7 @@ void ShaderLanguageDesc::Init(ShaderLanguage lang) {
 		coefsFromBuffers = true;
 		vsOutPrefix = "Out.";
 		viewportYSign = "-";
+		depthMinusOneToOne = false;
 		break;
 	}
 }

--- a/Common/GPU/Shader.h
+++ b/Common/GPU/Shader.h
@@ -57,6 +57,7 @@ struct ShaderLanguageDesc {
 	const char *vsOutPrefix = "";
 	const char *viewportYSign = "";
 
+	bool depthMinusOneToOne = false;
 	bool vertexIndex = false;
 	bool glslES30 = false;  // really glslES30Features. TODO: Clean this up.
 	bool bitwiseOps = false;

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -361,6 +361,9 @@ void ShaderWriter::EndVSMain(Slice<VaryingDef> varyings) {
 		if (strlen(lang_.viewportYSign)) {
 			F("  gl_Position.y *= %s1.0;\n", lang_.viewportYSign);
 		}
+		if (lang_.depthMinusOneToOne) {
+			F("  gl_Position.z = gl_Position.z * 2.0 - gl_Position.w;\n");  // homogenous math... looks confusing.
+		}
 		C("  vs_out.pos = gl_Position;\n");
 		for (auto &varying : varyings) {
 			F("  vs_out.%s = %s;\n", varying.name, varying.name);

--- a/Common/Math/lin/matrix4x4.cpp
+++ b/Common/Math/lin/matrix4x4.cpp
@@ -43,7 +43,7 @@ void Matrix4x4::setViewFrame(const Vec3 &pos, const Vec3 &vRight, const Vec3 &vV
 	ww = 1.0f;
 }
 
-void Matrix4x4::setOrtho(float left, float right, float bottom, float top, float near, float far) {
+void Matrix4x4::setOrthoGL(float left, float right, float bottom, float top, float near, float far) {
 	empty();
 	xx = 2.0f / (right - left);
 	yy = 2.0f / (top - bottom);

--- a/Common/Math/lin/matrix4x4.h
+++ b/Common/Math/lin/matrix4x4.h
@@ -87,7 +87,7 @@ public:
 		ww = 1.0f;
 	}
 
-	void setOrtho(float left, float right, float bottom, float top, float near, float far);
+	void setOrthoGL(float left, float right, float bottom, float top, float near, float far);
 	void setOrthoD3D(float left, float right, float bottom, float top, float near, float far);
 	void setOrthoVulkan(float left, float right, float top, float bottom, float near, float far);
 

--- a/Common/System/Display.cpp
+++ b/Common/System/Display.cpp
@@ -138,7 +138,7 @@ Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordC
 		break;
 	case CoordConvention::OpenGL:
 	default:
-		ortho.setOrtho(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
+		ortho.setOrthoGL(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
 		break;
 	}
 	// Compensate for rotated display if needed.

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -3185,9 +3185,9 @@ bool GetOutputFramebuffer(Draw::DrawContext *draw, GPUDebugBuffer &buffer) {
 	if (fmt != Draw::DataFormat::B8G8R8A8_UNORM)
 		fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 
-	bool flipped = g_Config.iGPUBackend == (int)GPUBackend::OPENGL;
+	bool flipY = g_Config.iGPUBackend == (int)GPUBackend::OPENGL;
 
-	buffer.Allocate(w, h, fmt == Draw::DataFormat::R8G8B8A8_UNORM ? GPU_DBG_FORMAT_8888 : GPU_DBG_FORMAT_8888_BGRA, flipped);
+	buffer.Allocate(w, h, fmt == Draw::DataFormat::R8G8B8A8_UNORM ? GPU_DBG_FORMAT_8888 : GPU_DBG_FORMAT_8888_BGRA, flipY);
 	buffer.SetIsBackbuffer(true);
 	return draw->CopyFramebufferToMemory(nullptr, Draw::Aspect::COLOR_BIT, 0, 0, w, h, fmt, buffer.GetData(), w, Draw::ReadbackMode::BLOCK, "GetOutputFramebuffer");
 }

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -14,15 +14,9 @@
 
 using namespace Lin;
 
-static void ConvertProjMatrixToVulkan(Matrix4x4 &in) {
+static void ConvertProjMatrixToZeroToOneDepth(Matrix4x4 &in) {
 	const Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
 	const Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
-	in.translateAndScale(trans, scale);
-}
-
-static void ConvertProjMatrixToD3D11(Matrix4x4 &in) {
-	const Vec3 trans(gstate_c.vpXOffset, -gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
-	const Vec3 scale(gstate_c.vpWidthScale, -gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
 	in.translateAndScale(trans, scale);
 }
 
@@ -72,6 +66,24 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 	maxValues[3] = NAN;
 }
 
+// TODO: This will be removed later.
+static inline void FlipProjMatrix(Matrix4x4 &in) {
+	const bool invertedY = gstate_c.vpHeight < 0;
+	if (invertedY) {
+		in[1] = -in[1];
+		in[5] = -in[5];
+		in[9] = -in[9];
+		in[13] = -in[13];
+	}
+	const bool invertedX = gstate_c.vpWidth < 0;
+	if (invertedX) {
+		in[0] = -in[0];
+		in[4] = -in[4];
+		in[8] = -in[8];
+		in[12] = -in[12];
+	}
+}
+
 void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipViewport, bool useBufferedRendering) {
 	if (dirtyUniforms & DIRTY_TEXENV) {
 		Uint8x3ToFloat3(ub->texEnvColor, gstate.texenvcolor);
@@ -115,26 +127,9 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		Matrix4x4 flippedMatrix;
 		memcpy(&flippedMatrix, gstate.projMatrix, 16 * sizeof(float));
 
-		const bool invertedY = gstate_c.vpHeight < 0;
-		if (invertedY) {
-			flippedMatrix[1] = -flippedMatrix[1];
-			flippedMatrix[5] = -flippedMatrix[5];
-			flippedMatrix[9] = -flippedMatrix[9];
-			flippedMatrix[13] = -flippedMatrix[13];
-		}
-		const bool invertedX = gstate_c.vpWidth < 0;
-		if (invertedX) {
-			flippedMatrix[0] = -flippedMatrix[0];
-			flippedMatrix[4] = -flippedMatrix[4];
-			flippedMatrix[8] = -flippedMatrix[8];
-			flippedMatrix[12] = -flippedMatrix[12];
-		}
-		if (flipViewport) {
-			ConvertProjMatrixToD3D11(flippedMatrix);
-		} else {
-			ConvertProjMatrixToVulkan(flippedMatrix);
-		}
+		FlipProjMatrix(flippedMatrix);
 
+		ConvertProjMatrixToZeroToOneDepth(flippedMatrix);
 		if (!useBufferedRendering && g_display.rotation != DisplayRotation::ROTATE_0) {
 			flippedMatrix = flippedMatrix * g_display.rot_matrix;
 		}
@@ -145,11 +140,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 
 	if (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX) {
 		Matrix4x4 proj_through;
-		if (flipViewport) {
-			proj_through.setOrthoD3D(0.0f, gstate_c.curRTWidth, gstate_c.curRTHeight, 0, 0, 1);
-		} else {
-			proj_through.setOrthoVulkan(0.0f, gstate_c.curRTWidth, 0, gstate_c.curRTHeight, 0, 1);
-		}
+		proj_through.setOrthoVulkan(0.0f, gstate_c.curRTWidth, 0, gstate_c.curRTHeight, 0, 1);
 		if (!useBufferedRendering && g_display.rotation != DisplayRotation::ROTATE_0) {
 			proj_through = proj_through * g_display.rot_matrix;
 		}

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -65,27 +65,15 @@ static void SwapUVs(TransformedVertex &a, TransformedVertex &b) {
 
 // Note: 0 is BR and 2 is TL.
 
-static void RotateUV(TransformedVertex v[4], bool flippedY) {
-	// We use the transformed tl/br coordinates to figure out whether they're flipped or not.
-	float ySign = flippedY ? -1.0 : 1.0;
-
+static void RotateUV(TransformedVertex v[4]) {
 	const float x1 = v[2].x;
 	const float x2 = v[0].x;
-	const float y1 = v[2].y * ySign;
-	const float y2 = v[0].y * ySign;
+	const float y1 = v[2].y;
+	const float y2 = v[0].y;
 
-	if ((x1 < x2 && y1 < y2) || (x1 > x2 && y1 > y2))
+	if ((x1 < x2 && y1 > y2) || (x1 > x2 && y1 < y2)) {
 		SwapUVs(v[1], v[3]);
-}
-
-static void RotateUVThrough(TransformedVertex v[4]) {
-	float x1 = v[2].x;
-	float x2 = v[0].x;
-	float y1 = v[2].y;
-	float y2 = v[0].y;
-
-	if ((x1 < x2 && y1 > y2) || (x1 > x2 && y1 < y2))
-		SwapUVs(v[1], v[3]);
+	}
 }
 
 // Clears on the PSP are best done by drawing a series of vertical strips
@@ -658,11 +646,7 @@ bool SoftwareTransform::ExpandRectangles(int vertexCount, int &numDecodedVerts, 
 		trans[3].v = transVtxBR.v * vscale;
 
 		// That's the four corners. Now process UV rotation.
-		if (throughmode) {
-			RotateUVThrough(trans);
-		} else {
-			RotateUV(trans, params_.flippedY);
-		}
+		RotateUV(trans);
 
 		// Triangle: BR-TR-TL
 		indsOut[0] = i * 2 + 0;

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1276,6 +1276,14 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		}
 	}
 
+	bool flipY = strlen(compat.viewportYSign) > 0;
+	if (gstate_c.Use(GPU_USE_NONBUFFERED_FLIP)) {
+		flipY = !flipY;
+	}
+	if (flipY) {
+		WRITE(p, "  outPos.y *= -1.0;\n");
+	}
+
 	// We've named the output gl_Position in HLSL as well.
 	WRITE(p, "  %sgl_Position = outPos;\n", compat.vsOutPrefix);
 

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -436,8 +436,8 @@ void DrawEngineD3D11::Flush() {
 
 		SoftwareTransform swTransform(params);
 
-		const Lin::Vec3 trans(gstate_c.vpXOffset, -gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
-		const Lin::Vec3 scale(gstate_c.vpWidthScale, -gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
+		const Lin::Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
+		const Lin::Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
 		swTransform.SetProjMatrix(gstate.projMatrix, gstate_c.vpWidth < 0, gstate_c.vpHeight < 0, trans, scale);
 
 		swTransform.Transform(prim, swDec->VertexType(), swDec->GetDecVtxFmt(), numDecodedVerts_, &result);

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -387,8 +387,7 @@ void DrawEngineGLES::Flush() {
 
 		const Lin::Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, gstate_c.vpZOffset);
 		const Lin::Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale);
-		const bool invertedY = gstate_c.vpHeight * (params.flippedY ? 1.0 : -1.0f) < 0;
-		swTransform.SetProjMatrix(gstate.projMatrix, gstate_c.vpWidth < 0, invertedY, trans, scale);
+		swTransform.SetProjMatrix(gstate.projMatrix, gstate_c.vpWidth < 0, gstate_c.vpHeight < 0, trans, scale);
 
 		swTransform.Transform(prim, swDec->VertexType(), swDec->GetDecVtxFmt(), numDecodedVerts_, &result);
 		// Non-zero depth clears are unusual, but some drivers don't match drawn depth values to cleared values.

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -191,8 +191,8 @@ u32 GPU_GLES::CheckGPUFeatures() const {
 		}
 	}
 
-	if (!g_Config.bSkipBufferEffects) {
-		features |= GPU_USE_BUFFERED_FLIP;
+	if (g_Config.bSkipBufferEffects) {
+		features |= GPU_USE_NONBUFFERED_FLIP;
 	}
 
 	return features;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -190,6 +190,11 @@ u32 GPU_GLES::CheckGPUFeatures() const {
 			features |= GPU_ROUND_DEPTH_TO_16BIT;
 		}
 	}
+
+	if (!g_Config.bSkipBufferEffects) {
+		features |= GPU_USE_BUFFERED_FLIP;
+	}
+
 	return features;
 }
 

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -309,20 +309,14 @@ static void SetMatrix4x3(GLRenderManager *render, GLint *uniform, const float *m
 	render->SetUniformM4x4(uniform, m4x4);
 }
 
-static inline void ScaleProjMatrix(Matrix4x4 &in, bool useBufferedRendering) {
-	float yOffset = gstate_c.vpYOffset;
-	if (!useBufferedRendering) {
-		// GL upside down is a pain as usual.
-		yOffset = -yOffset;
-	}
-	const Vec3 trans(gstate_c.vpXOffset, yOffset, gstate_c.vpZOffset);
+static inline void ConvertProjMatrixToGL(Matrix4x4 &in) {
+	const Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, gstate_c.vpZOffset);
 	const Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale);
 	in.translateAndScale(trans, scale);
 }
 
-static inline void FlipProjMatrix(Matrix4x4 &in, bool useBufferedRendering) {
-
-	const bool invertedY = useBufferedRendering ? (gstate_c.vpHeight < 0) : (gstate_c.vpHeight > 0);
+static inline void FlipProjMatrix(Matrix4x4 &in) {
+	const bool invertedY = gstate_c.vpHeight < 0;
 	if (invertedY) {
 		in[1] = -in[1];
 		in[5] = -in[5];
@@ -435,8 +429,8 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 			}
 			UpdateVRParams(gstate.projMatrix);
 
-			FlipProjMatrix(vrProjection, useBufferedRendering);
-			ScaleProjMatrix(vrProjection, useBufferedRendering);
+			FlipProjMatrix(vrProjection);
+			ConvertProjMatrixToGL(vrProjection);
 
 			render_->SetUniformM4x4(&u_proj_lens, vrProjection.m);
 		}
@@ -444,19 +438,15 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 		Matrix4x4 flippedMatrix;
 		memcpy(&flippedMatrix, gstate.projMatrix, 16 * sizeof(float));
 
-		FlipProjMatrix(flippedMatrix, useBufferedRendering);
-		ScaleProjMatrix(flippedMatrix, useBufferedRendering);
+		FlipProjMatrix(flippedMatrix);
+		ConvertProjMatrixToGL(flippedMatrix);
 
 		render_->SetUniformM4x4(&u_proj, flippedMatrix.m);
 		render_->SetUniformF1(&u_rotation, useBufferedRendering ? 0 : (float)g_display.rotation);
 	}
 	if (dirty & DIRTY_PROJTHROUGHMATRIX) {
 		Matrix4x4 proj_through;
-		if (useBufferedRendering) {
-			proj_through.setOrtho(0.0f, gstate_c.curRTWidth, 0.0f, gstate_c.curRTHeight, 0.0f, 1.0f);
-		} else {
-			proj_through.setOrtho(0.0f, gstate_c.curRTWidth, gstate_c.curRTHeight, 0.0f, 0.0f, 1.0f);
-		}
+		proj_through.setOrthoGL(0.0f, gstate_c.curRTWidth, 0.0f, gstate_c.curRTHeight, 0.0f, 1.0f);
 		render_->SetUniformM4x4(&u_proj_through, proj_through.getReadPtr());
 	}
 	if (dirty & DIRTY_TEXENV) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -480,7 +480,7 @@ enum {
 	GPU_USE_CLIP_DISTANCE = FLAG_BIT(24),
 	GPU_USE_CULL_DISTANCE = FLAG_BIT(25),
 	GPU_USE_SHADER_BLENDING = FLAG_BIT(26),  // This is set to false when skip buffer effects is enabled and GPU_USE_FRAMEBUFFER_FETCH is not.
-	GPU_USE_BUFFERED_FLIP = FLAG_BIT(27),  // We use a flip hack to pretend the coordinate system is right-side-up, except if buffered rendering is off.
+	GPU_USE_NONBUFFERED_FLIP = FLAG_BIT(27),  // We use a flip hack to pretend the coordinate system is right-side-up, except if buffered rendering is off.
 
 	// VR flags (reserved or in-use)
 	GPU_USE_VIRTUAL_REALITY = FLAG_BIT(29),

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -480,6 +480,7 @@ enum {
 	GPU_USE_CLIP_DISTANCE = FLAG_BIT(24),
 	GPU_USE_CULL_DISTANCE = FLAG_BIT(25),
 	GPU_USE_SHADER_BLENDING = FLAG_BIT(26),  // This is set to false when skip buffer effects is enabled and GPU_USE_FRAMEBUFFER_FETCH is not.
+	GPU_USE_BUFFERED_FLIP = FLAG_BIT(27),  // We use a flip hack to pretend the coordinate system is right-side-up, except if buffered rendering is off.
 
 	// VR flags (reserved or in-use)
 	GPU_USE_VIRTUAL_REALITY = FLAG_BIT(29),

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -488,6 +488,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 		}
 
 		System_PostUIMessage(UIMessage::GPU_RENDER_RESIZED);
+		System_PostUIMessage(UIMessage::GPU_CONFIG_CHANGED);
 	});
 	skipBufferEffects->SetDisabledPtr(&g_Config.bSoftwareRendering);
 

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -237,7 +237,7 @@ void SimpleGLWindow::DrawChecker() {
 	const GLubyte indices[4] = {0,1,3,2};
 
 	Matrix4x4 ortho;
-	ortho.setOrtho(0, (float)w_, (float)h_, 0, -1, 1);
+	ortho.setOrthoGL(0, (float)w_, (float)h_, 0, -1, 1);
 	glUniformMatrix4fv(drawProgram_->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 	if (vao_) {
 		glBufferData(GL_ARRAY_BUFFER, sizeof(pos) + sizeof(texCoords), nullptr, GL_DYNAMIC_DRAW);
@@ -429,7 +429,7 @@ void SimpleGLWindow::Redraw(bool andSwap) {
 	const float *texCoords = tflipped_ ? texCoordsFlipped : texCoordsNormal;
 
 	Matrix4x4 ortho;
-	ortho.setOrtho(0, (float)w_, (float)h_, 0, -1, 1);
+	ortho.setOrthoGL(0, (float)w_, (float)h_, 0, -1, 1);
 	glUniformMatrix4fv(drawProgram_->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 	if (vao_) {
 		glBufferData(GL_ARRAY_BUFFER, sizeof(pos) + sizeof(texCoordsNormal), nullptr, GL_DYNAMIC_DRAW);

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -153,7 +153,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 		};
 
 		Lin::Matrix4x4 ortho;
-		ortho.setOrtho(-(float)gstate_c.curRTOffsetX, (primaryWindow->TexWidth() - (int)gstate_c.curRTOffsetX) * scale[0], primaryWindow->TexHeight() * scale[1], 0, -1, 1);
+		ortho.setOrthoGL(-(float)gstate_c.curRTOffsetX, (primaryWindow->TexWidth() - (int)gstate_c.curRTOffsetX) * scale[0], primaryWindow->TexHeight() * scale[1], 0, -1, 1);
 		glUniformMatrix4fv(previewProgram->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 		if (previewVao != 0) {
 			glBindVertexArray(previewVao);
@@ -216,7 +216,7 @@ void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 		}
 
 		Lin::Matrix4x4 ortho;
-		ortho.setOrtho(0.0f - (float)gstate_c.curTextureXOffset * invRealTexWidth, 1.0f - (float)gstate_c.curTextureXOffset * invRealTexWidth, 1.0f - (float)gstate_c.curTextureYOffset * invRealTexHeight, 0.0f - (float)gstate_c.curTextureYOffset * invRealTexHeight, -1.0f, 1.0f);
+		ortho.setOrthoGL(0.0f - (float)gstate_c.curTextureXOffset * invRealTexWidth, 1.0f - (float)gstate_c.curTextureXOffset * invRealTexWidth, 1.0f - (float)gstate_c.curTextureYOffset * invRealTexHeight, 0.0f - (float)gstate_c.curTextureYOffset * invRealTexHeight, -1.0f, 1.0f);
 		glUniformMatrix4fv(texPreviewProgram->u_viewproj, 1, GL_FALSE, ortho.getReadPtr());
 		if (texPreviewVao != 0) {
 			glBindVertexArray(texPreviewVao);


### PR DESCRIPTION
This is prep for #20223 .

This eliminates a lot of icky special cases and matrix manipulation, and moves the responsibility for applying the appropriate Y-flip (for the API and rendering mode) to the generated vertex shaders.

Also includes some prep for step 2 of this, which will be to unify the depth handling of the projection matrices.

