### PR TITLE
Refactor display pre-rotation

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -441,6 +441,10 @@ public:
 		return winsys_;
 	}
 
+	bool SupportsPreRotation() const {
+		return surfCapabilities_.supportedTransforms != VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+	}
+
 private:
 	bool ChooseQueue();
 

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -128,11 +128,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		memcpy(&flippedMatrix, gstate.projMatrix, 16 * sizeof(float));
 
 		FlipProjMatrix(flippedMatrix);
-
 		ConvertProjMatrixToZeroToOneDepth(flippedMatrix);
-		if (!useBufferedRendering && g_display.rotation != DisplayRotation::ROTATE_0) {
-			flippedMatrix = flippedMatrix * g_display.rot_matrix;
-		}
 		CopyMatrix4x4(ub->proj, flippedMatrix.getReadPtr());
 
 		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
@@ -141,9 +137,6 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 	if (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX) {
 		Matrix4x4 proj_through;
 		proj_through.setOrthoVulkan(0.0f, gstate_c.curRTWidth, 0, gstate_c.curRTHeight, 0, 1);
-		if (!useBufferedRendering && g_display.rotation != DisplayRotation::ROTATE_0) {
-			proj_through = proj_through * g_display.rot_matrix;
-		}
 
 		// Negative RT offsets come from split framebuffers (Killzone)
 		if (gstate_c.curRTOffsetX < 0 || gstate_c.curRTOffsetY < 0) {
@@ -152,6 +145,8 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		}
 
 		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());
+
+		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
 	}
 
 	// Transform

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -85,7 +85,7 @@ static inline void FlipProjMatrix(Matrix4x4 & in) {
 }
 
 void UpdateRotation(float rotMatrix[4], bool useBufferedRendering) {
-	if (useBufferedRendering) {
+	if (!gstate_c.Use(GPU_USE_PRE_ROTATION) || useBufferedRendering) {
 		rotMatrix[0] = 1.0f;
 		rotMatrix[1] = 0.0f;
 		rotMatrix[2] = 0.0f;

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -67,7 +67,7 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 }
 
 // TODO: This will be removed later.
-static inline void FlipProjMatrix(Matrix4x4 &in) {
+static inline void FlipProjMatrix(Matrix4x4 & in) {
 	const bool invertedY = gstate_c.vpHeight < 0;
 	if (invertedY) {
 		in[1] = -in[1];
@@ -81,6 +81,22 @@ static inline void FlipProjMatrix(Matrix4x4 &in) {
 		in[4] = -in[4];
 		in[8] = -in[8];
 		in[12] = -in[12];
+	}
+}
+
+void UpdateRotation(float rotMatrix[4], bool useBufferedRendering) {
+	if (useBufferedRendering) {
+		rotMatrix[0] = 1.0f;
+		rotMatrix[1] = 0.0f;
+		rotMatrix[2] = 0.0f;
+		rotMatrix[3] = 1.0f;
+	} else {
+		const DisplayRotation rotation = g_display.rotation;
+		// The others are ROTATE_90 and so on.
+		rotMatrix[0] = rotation == DisplayRotation::ROTATE_0 ? 1.0 : (rotation == DisplayRotation::ROTATE_180 ? -1.0 : 0.0);
+		rotMatrix[1] = rotation == DisplayRotation::ROTATE_90 ? 1.0 : (rotation == DisplayRotation::ROTATE_270 ? -1.0 : 0.0);
+		rotMatrix[2] = rotation == DisplayRotation::ROTATE_270 ? 1.0 : (rotation == DisplayRotation::ROTATE_90 ? -1.0 : 0.0);
+		rotMatrix[3] = rotation == DisplayRotation::ROTATE_0 ? 1.0 : (rotation == DisplayRotation::ROTATE_180 ? -1.0 : 0.0);
 	}
 }
 
@@ -130,8 +146,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		FlipProjMatrix(flippedMatrix);
 		ConvertProjMatrixToZeroToOneDepth(flippedMatrix);
 		CopyMatrix4x4(ub->proj, flippedMatrix.getReadPtr());
-
-		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
+		UpdateRotation(ub->rotation, useBufferedRendering);  // TODO: This can be done a lot less often.
 	}
 
 	if (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX) {
@@ -145,8 +160,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		}
 
 		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());
-
-		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
+		UpdateRotation(ub->rotation, useBufferedRendering);  // TODO: This can be done a lot less often.
 	}
 
 	// Transform

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -146,7 +146,8 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		FlipProjMatrix(flippedMatrix);
 		ConvertProjMatrixToZeroToOneDepth(flippedMatrix);
 		CopyMatrix4x4(ub->proj, flippedMatrix.getReadPtr());
-		UpdateRotation(ub->rotation, useBufferedRendering);  // TODO: This can be done a lot less often.
+
+		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
 	}
 
 	if (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX) {
@@ -160,7 +161,8 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		}
 
 		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());
-		UpdateRotation(ub->rotation, useBufferedRendering);  // TODO: This can be done a lot less often.
+
+		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
 	}
 
 	// Transform

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -25,6 +25,7 @@ struct alignas(16) UB_VS_FS_Base {
 	float view[12];
 	float world[12];
 	float tex[12];
+	float rotation[4];
 	float uvScaleOffset[4];
 	float depthRange[4];
 	float matAmbient[4];
@@ -39,11 +40,11 @@ struct alignas(16) UB_VS_FS_Base {
 	float texClamp[4];
 	float texClampOffset[2]; float fogCoef[2];
 	float blendFixA[3]; float stencilReplaceValue;
-	float blendFixB[3]; float rotation;
+	float blendFixB[3]; float padding3;
 	// VR stuff is to go here, later. For normal drawing, we can then get away
 	// with just uploading the first 448 bytes of the struct (up to and including fogCoef).
 };
-static_assert(sizeof(UB_VS_FS_Base) == 480, "UB_VS_FS_Base should be 496 bytes");
+static_assert(sizeof(UB_VS_FS_Base) == 496, "UB_VS_FS_Base should be 496 bytes");
 
 static const char * const ub_baseStr =
 R"(  mat4 u_proj;
@@ -51,6 +52,7 @@ R"(  mat4 u_proj;
   mat3x4 u_view;
   mat3x4 u_world;
   mat3x4 u_texmtx;
+  vec4 u_rotation;
   vec4 u_uvscaleoffset;
   vec4 u_depthRange;
   vec4 u_matambientalpha;
@@ -66,7 +68,7 @@ R"(  mat4 u_proj;
   vec4 u_texclamp;
   vec2 u_texclampoff; vec2 u_fogcoef;
   vec3 u_blendFixA; float u_stencilReplaceValue;
-  vec3 u_blendFixB; float u_rotation;
+  vec3 u_blendFixB; float pad3;
 )";
 
 // 512 bytes. Would like to shrink more. Some colors only have 8-bit precision and we expand

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -17,7 +17,7 @@ enum : uint64_t {
 	DIRTY_MATDIFFUSE | DIRTY_MATSPECULAR | DIRTY_MATEMISSIVE | DIRTY_AMBIENT,
 };
 
-// Currently 496 bytes.
+// Currently 480 bytes.
 // Every line here is a 4-float.
 struct alignas(16) UB_VS_FS_Base {
 	float proj[16];
@@ -43,6 +43,7 @@ struct alignas(16) UB_VS_FS_Base {
 	// VR stuff is to go here, later. For normal drawing, we can then get away
 	// with just uploading the first 448 bytes of the struct (up to and including fogCoef).
 };
+static_assert(sizeof(UB_VS_FS_Base) == 480, "UB_VS_FS_Base should be 496 bytes");
 
 static const char * const ub_baseStr =
 R"(  mat4 u_proj;
@@ -84,6 +85,7 @@ struct alignas(16) UB_VS_Lights {
 	float lightDiffuse[4][4];
 	float lightSpecular[4][4];
 };
+static_assert(sizeof(UB_VS_Lights) == 512);  // it's ok to optimize this, it's just an assumption check.
 
 static const char * const ub_vs_lightsStr =
 R"(  vec4 u_ambient;
@@ -105,6 +107,7 @@ R"(  vec4 u_ambient;
 struct alignas(16) UB_VS_Bones {
 	float bones[8][12];
 };
+static_assert(sizeof(UB_VS_Bones) == 384);  // No way to optimize this further.
 
 static const char * const ub_vs_bonesStr =
 R"(	mat3x4 u_bone0; mat3x4 u_bone1; mat3x4 u_bone2; mat3x4 u_bone3; mat3x4 u_bone4; mat3x4 u_bone5; mat3x4 u_bone6; mat3x4 u_bone7; mat3x4 u_bone8;

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -25,7 +25,6 @@ struct alignas(16) UB_VS_FS_Base {
 	float view[12];
 	float world[12];
 	float tex[12];
-	float rotation[4];
 	float uvScaleOffset[4];
 	float depthRange[4];
 	float matAmbient[4];
@@ -40,11 +39,11 @@ struct alignas(16) UB_VS_FS_Base {
 	float texClamp[4];
 	float texClampOffset[2]; float fogCoef[2];
 	float blendFixA[3]; float stencilReplaceValue;
-	float blendFixB[3]; float padding3;
+	float blendFixB[3]; float rotation;
 	// VR stuff is to go here, later. For normal drawing, we can then get away
 	// with just uploading the first 448 bytes of the struct (up to and including fogCoef).
 };
-static_assert(sizeof(UB_VS_FS_Base) == 496, "UB_VS_FS_Base should be 496 bytes");
+static_assert(sizeof(UB_VS_FS_Base) == 480, "UB_VS_FS_Base should be 480 bytes");
 
 static const char * const ub_baseStr =
 R"(  mat4 u_proj;
@@ -52,7 +51,6 @@ R"(  mat4 u_proj;
   mat3x4 u_view;
   mat3x4 u_world;
   mat3x4 u_texmtx;
-  vec4 u_rotation;
   vec4 u_uvscaleoffset;
   vec4 u_depthRange;
   vec4 u_matambientalpha;
@@ -68,7 +66,7 @@ R"(  mat4 u_proj;
   vec4 u_texclamp;
   vec2 u_texclampoff; vec2 u_fogcoef;
   vec3 u_blendFixA; float u_stencilReplaceValue;
-  vec3 u_blendFixB; float pad3;
+  vec3 u_blendFixB; float u_rotation;
 )";
 
 // 512 bytes. Would like to shrink more. Some colors only have 8-bit precision and we expand

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1262,9 +1262,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		}
 	}
 
-	if (compat.shaderLanguage == GLSL_VULKAN) {
+	if (compat.shaderLanguage == GLSL_VULKAN && gstate_c.Use(GPU_USE_PRE_ROTATION)) {
 		// Apply rotation from the uniform.
-		// NOTE: This is only needed on platforms that support pre-rotation.
+		// TODO: This is only needed on platforms that support pre-rotation, and only in skip buffer effects mode.
 		WRITE(p, "  outPos.xy = mul(mat2(u_rotation), outPos.xy);\n");
 	}
 

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1264,8 +1264,12 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 
 	if (compat.shaderLanguage == GLSL_VULKAN && gstate_c.Use(GPU_USE_PRE_ROTATION)) {
 		// Apply rotation from the uniform.
-		// TODO: This is only needed on platforms that support pre-rotation, and only in skip buffer effects mode.
-		WRITE(p, "  outPos.xy = mul(mat2(u_rotation), outPos.xy);\n");
+		WRITE(p, "  mat2 displayRotation = mat2(\n");
+		WRITE(p, "    u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0), u_rotation == 1.0 ? 1.0 : (u_rotation == 3.0 ? -1.0 : 0.0),\n");
+		WRITE(p, "    u_rotation == 3.0 ? 1.0 : (u_rotation == 1.0 ? -1.0 : 0.0), u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0)\n");
+		WRITE(p, "  );\n");
+
+		WRITE(p, "  outPos.xy = mul(displayRotation, outPos.xy);\n");
 	}
 
 	bool flipY = strlen(compat.viewportYSign) > 0;

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -363,6 +363,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		}
 		WRITE(p, "};\n");
 	} else {
+		// Non-Vulkan GLSL.
 		if (enableBones) {
 			const char * const * boneWeightDecl = boneWeightAttrDecl;
 			if (!strcmp(compat.attribute, "in")) {
@@ -479,8 +480,6 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				WRITE(p, "uniform lowp vec3 u_matemissive;\n");
 				*uniformMask |= DIRTY_MATSPECULAR | DIRTY_MATEMISSIVE;
 			}
-		} else {
-			WRITE(p, "uniform lowp float u_rotation;\n");
 		}
 
 		if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
@@ -749,24 +748,11 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			// The proj_through matrix already has the rotation, if needed.
 			WRITE(p, "  vec4 outPos = mul(u_proj_through, vec4(position.xyz, 1.0));\n");
 		} else {
-			if (compat.shaderLanguage == GLSL_VULKAN) {
-				// Apply rotation from the uniform.
-				WRITE(p, "  mat2 displayRotation = mat2(\n");
-				WRITE(p, "    u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0), u_rotation == 1.0 ? 1.0 : (u_rotation == 3.0 ? -1.0 : 0.0),\n");
-				WRITE(p, "    u_rotation == 3.0 ? 1.0 : (u_rotation == 1.0 ? -1.0 : 0.0), u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0)\n");
-				WRITE(p, "  );\n");
-
-				WRITE(p, "  vec4 pos = position;\n");
-				WRITE(p, "  pos.xy = mul(displayRotation, pos.xy);\n");
-			} else {
-				WRITE(p, "  vec4 pos = position;\n");
-			}
-
 			// The viewport is used in this case, so need to compensate for that.
 			if (gstate_c.Use(GPU_ROUND_DEPTH_TO_16BIT)) {
-				WRITE(p, "  vec4 outPos = depthRoundZVP(pos);\n");
+				WRITE(p, "  vec4 outPos = depthRoundZVP(position);\n");
 			} else {
-				WRITE(p, "  vec4 outPos = pos;\n");
+				WRITE(p, "  vec4 outPos = position;\n");
 			}
 		}
 	} else {
@@ -1274,6 +1260,16 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			WRITE(p, "    %sgl_CullDistance%s = 0.0;\n", compat.vsOutPrefix, cull1);
 			WRITE(p, "  }\n");
 		}
+	}
+
+	if (compat.shaderLanguage == GLSL_VULKAN) {
+		// Apply rotation from the uniform.
+		WRITE(p, "  mat2 displayRotation = mat2(\n");
+		WRITE(p, "    u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0), u_rotation == 1.0 ? 1.0 : (u_rotation == 3.0 ? -1.0 : 0.0),\n");
+		WRITE(p, "    u_rotation == 3.0 ? 1.0 : (u_rotation == 1.0 ? -1.0 : 0.0), u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0)\n");
+		WRITE(p, "  );\n");
+
+		WRITE(p, "  outPos.xy = mul(displayRotation, outPos.xy);\n");
 	}
 
 	bool flipY = strlen(compat.viewportYSign) > 0;

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1264,12 +1264,8 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 
 	if (compat.shaderLanguage == GLSL_VULKAN) {
 		// Apply rotation from the uniform.
-		WRITE(p, "  mat2 displayRotation = mat2(\n");
-		WRITE(p, "    u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0), u_rotation == 1.0 ? 1.0 : (u_rotation == 3.0 ? -1.0 : 0.0),\n");
-		WRITE(p, "    u_rotation == 3.0 ? 1.0 : (u_rotation == 1.0 ? -1.0 : 0.0), u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0)\n");
-		WRITE(p, "  );\n");
-
-		WRITE(p, "  outPos.xy = mul(displayRotation, outPos.xy);\n");
+		// NOTE: This is only needed on platforms that support pre-rotation.
+		WRITE(p, "  outPos.xy = mul(mat2(u_rotation), outPos.xy);\n");
 	}
 
 	bool flipY = strlen(compat.viewportYSign) > 0;

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -129,7 +129,6 @@ LinkedShader::LinkedShader(GLRenderManager *render, VShaderID VSID, Shader *vs, 
 	queries.push_back({ &u_depthRange, "u_depthRange" });
 	queries.push_back({ &u_cullRangeMin, "u_cullRangeMin" });
 	queries.push_back({ &u_cullRangeMax, "u_cullRangeMax" });
-	queries.push_back({ &u_rotation, "u_rotation" });
 
 	// These two are only used for VR, but let's always query them for simplicity.
 	queries.push_back({ &u_scaleX, "u_scaleX" });
@@ -442,7 +441,6 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 		ConvertProjMatrixToGL(flippedMatrix);
 
 		render_->SetUniformM4x4(&u_proj, flippedMatrix.m);
-		render_->SetUniformF1(&u_rotation, useBufferedRendering ? 0 : (float)g_display.rotation);
 	}
 	if (dirty & DIRTY_PROJTHROUGHMATRIX) {
 		Matrix4x4 proj_through;

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -68,7 +68,6 @@ public:
 	int u_depthRange;   // x,y = viewport xscale/xcenter. z,w=clipping minz/maxz (?)
 	int u_cullRangeMin;
 	int u_cullRangeMax;
-	int u_rotation;
 	int u_mipBias;
 	int u_scaleX;
 	int u_scaleY;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -481,7 +481,7 @@ enum {
 	GPU_USE_CULL_DISTANCE = FLAG_BIT(25),
 	GPU_USE_SHADER_BLENDING = FLAG_BIT(26),  // This is set to false when skip buffer effects is enabled and GPU_USE_FRAMEBUFFER_FETCH is not.
 	GPU_USE_NONBUFFERED_FLIP = FLAG_BIT(27),  // We use a flip hack to pretend the coordinate system is right-side-up, except if buffered rendering is off.
-
+	GPU_USE_PRE_ROTATION = FLAG_BIT(28),
 	// VR flags (reserved or in-use)
 	GPU_USE_VIRTUAL_REALITY = FLAG_BIT(29),
 	GPU_USE_SINGLE_PASS_STEREO = FLAG_BIT(30),

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -244,6 +244,10 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 		break;
 	}
 
+	if (vulkan->SupportsPreRotation() && g_Config.bSkipBufferEffects) {
+		features |= GPU_USE_PRE_ROTATION;
+	}
+
 	// Might enable this later - in the first round we are mostly looking at depth/stencil/discard.
 	// if (!g_Config.bEnableVendorBugChecks)
 	// 	features |= GPU_USE_ACCURATE_DEPTH;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -152,7 +152,6 @@ private:
 	Path cbufferPath_;
 	VulkanBuffer textureScaleCBuffer_;
 	bool cbufferInited_ = true;
-	bool cbufferFailed_ = false;
 };
 
 VkFormat getClutDestFormatVulkan(GEPaletteFormat format);

--- a/UI/SystemInfoScreen.cpp
+++ b/UI/SystemInfoScreen.cpp
@@ -504,10 +504,15 @@ void SystemInfoScreen::CreateVulkanExtsTab(UI::LinearLayout *gpuExtensions) {
 
 	auto si = GetI18NCategory(I18NCat::SYSINFO);
 	auto di = GetI18NCategory(I18NCat::DIALOG);
+	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
 
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
 	CollapsibleSection *vulkanFeatures = gpuExtensions->Add(new CollapsibleSection(si->T("Vulkan Features")));
+
+	// TODO: This one belongs under its own header. And this is Vulkan "pre-rotation" really.
+	vulkanFeatures->Add(new InfoItem(gr->T("Display rotation"), StringFromFormat("%d°", (int)g_display.rotation * 90)));
+
 	std::vector<std::string> features = draw->GetFeatureList();
 	for (const auto &feature : features) {
 		vulkanFeatures->Add(new TextView(feature, FLAG_DYNAMIC_ASCII, true, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);


### PR DESCRIPTION
Pre-rotation is a Vulkan feature that lets us handle the screen rotation on mobile screens, so the OS doesn't have to rotate the output 90 degrees. 

This is another prerequisite for #20223 .

We will no longer always have a projection matrix (not in through mode) so it's better to keep the pre-rotation support separate. Additionally, this optimizes things so we don't even generate the shader code when it's not needed, which is most of the time (it's only needed on mobile with "skip buffer effects" on).