### PR TITLE
gpu: Preserve first-frame font render targets

### DIFF
--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -641,6 +641,11 @@ void PGF::DrawCharacter(const GlyphImage *image, int clipX, int clipY, int clipW
 	int renderX2 = std::min(clipX + clipWidth - x, glyph.w + (xFrac > 0 ? 1 : 0));
 	int renderY2 = std::min(clipY + clipHeight - y, glyph.h + (yFrac > 0 ? 1 : 0));
 
+	if (gpu && renderX1 < renderX2 && renderY1 < renderY2) {
+		// The game may reuse this glyph buffer as a texture immediately after drawing it.
+		gpu->Flush();
+	}
+
 	if (xFrac == 0 && yFrac == 0) {
 		for (int yy = renderY1; yy < renderY2; ++yy) {
 			for (int xx = renderX1; xx < renderX2; ++xx) {

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cfloat>
+#include <cmath>
 
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
@@ -588,6 +589,70 @@ bool DrawEngineCommon::TestBoundingBoxThrough(const void *vdata, int vertexCount
 		_dbg_assert_(false);
 		return true;
 	}
+}
+
+bool DrawEngineCommon::EstimateThroughPrimSafeSize(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, const VertexDecoder *dec, u32 vertType, int *safeWidth, int *safeHeight) {
+	if (prim != GE_PRIM_RECTANGLES && prim != GE_PRIM_TRIANGLES) {
+		return false;
+	}
+	if ((vertType & GE_VTYPE_THROUGH_MASK) == 0 || (vertType & (GE_VTYPE_WEIGHT_MASK | GE_VTYPE_MORPHCOUNT_MASK)) != 0) {
+		return false;
+	}
+
+	const int stride = dec->VertexSize();
+	const int posOffset = dec->posoff;
+	IndexConverter conv(vertType, inds);
+
+	float minX = FLT_MAX;
+	float minY = FLT_MAX;
+	float maxX = -FLT_MAX;
+	float maxY = -FLT_MAX;
+
+	for (int i = 0; i < vertexCount; ++i) {
+		const u8 *posPtr = (const u8 *)verts + conv(i) * stride + posOffset;
+		float x;
+		float y;
+
+		switch (vertType & GE_VTYPE_POS_MASK) {
+		case GE_VTYPE_POS_8BIT:
+			x = 0.0f;
+			y = 0.0f;
+			break;
+		case GE_VTYPE_POS_16BIT:
+		{
+			const s16_le *pos = (const s16_le *)posPtr;
+			x = (float)pos[0];
+			y = (float)pos[1];
+			break;
+		}
+		case GE_VTYPE_POS_FLOAT:
+		{
+			const float_le *pos = (const float_le *)posPtr;
+			x = pos[0];
+			y = pos[1];
+			break;
+		}
+		default:
+			return false;
+		}
+
+		minX = std::min(minX, x);
+		minY = std::min(minY, y);
+		maxX = std::max(maxX, x);
+		maxY = std::max(maxY, y);
+	}
+
+	const int scissorX1 = gstate.getScissorX1();
+	const int scissorY1 = gstate.getScissorY1();
+	const int scissorX2 = gstate.getScissorX2() + 1;
+	const int scissorY2 = gstate.getScissorY2() + 1;
+	if (maxX <= scissorX1 || maxY <= scissorY1 || minX >= scissorX2 || minY >= scissorY2) {
+		return false;
+	}
+
+	*safeWidth = std::clamp((int)ceilf(maxX), 0, scissorX2);
+	*safeHeight = std::clamp((int)ceilf(maxY), 0, scissorY2);
+	return *safeWidth > 0 && *safeHeight > 0;
 }
 
 void DrawEngineCommon::ApplyFramebufferRead(FBOTexState *fboTexState) {

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -106,6 +106,7 @@ public:
 	// Doesn't support indexing.
 	bool TestBoundingBoxFast(const void *control_points, int vertexCount, const VertexDecoder *dec, u32 vertType);
 	bool TestBoundingBoxThrough(const void *vdata, int vertexCount, const VertexDecoder *dec, u32 vertType, int *bytesRead);
+	bool EstimateThroughPrimSafeSize(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, const VertexDecoder *dec, u32 vertType, int *safeWidth, int *safeHeight);
 
 	void FlushPartialDecode() {
 		DecodeVerts(dec_, decoded_);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -540,6 +540,12 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(Framebuffer
 		}
 
 		// This is where we actually create the framebuffer. The true is "force".
+		// ResizeFramebufFBO() makes this framebuffer current, so save first-frame
+		// data from the previous render target before the switch.
+		VirtualFramebuffer *previousRenderVfb = currentRenderVfb_;
+		if (useBufferedRendering_ && previousRenderVfb) {
+			DownloadFramebufferOnSwitch(previousRenderVfb);
+		}
 		ResizeFramebufFBO(vfb, drawing_width, drawing_height, true);
 		NotifyRenderFramebufferCreated(vfb);
 
@@ -1022,8 +1028,6 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 	if (!useBufferedRendering_) {
 		// Let's ignore rendering to targets that have not (yet) been displayed.
 		gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
-	} else if (currentRenderVfb_) {
-		DownloadFramebufferOnSwitch(currentRenderVfb_);
 	}
 
 	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_CREATED);

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1015,6 +1015,16 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 	uint32_t vertTypeID = GetVertTypeID(vertexType, gstate.getUVGenMode(), g_Config.bSoftwareSkinning);
 	VertexDecoder *decoder = drawEngineCommon_->GetVertexDecoder(vertTypeID);
 
+	if (gstate.isModeThrough() && gstate.isTextureMapEnabled() && gstate.getColorMask() != 0xFFFFFFFF &&
+			gstate.getScissorX1() == 0 && gstate.getScissorY1() == 0 && Memory::IsVRAMAddress(gstate.getFrameBufAddress())) {
+		int safeWidth;
+		int safeHeight;
+		// First-frame readback can happen before queued draws reach backend transform.
+		if (drawEngineCommon_->EstimateThroughPrimSafeSize(verts, inds, prim, count, decoder, vertexType, &safeWidth, &safeHeight)) {
+			framebufferManager_->SetSafeSize(safeWidth, safeHeight);
+		}
+	}
+
 	// Through mode early-out for simple float 2D draws, like in Fate Extra CCC (very beneficial there due to avoiding texture loads)
 	if ((vertexType & (GE_VTYPE_THROUGH_MASK | GE_VTYPE_POS_MASK | GE_VTYPE_IDX_MASK)) == (GE_VTYPE_THROUGH_MASK | GE_VTYPE_POS_FLOAT | GE_VTYPE_IDX_NONE)) {
 		int bytesRead = 0;


### PR DESCRIPTION
Some games render HLE sceFont glyphs into small VRAM-backed framebuffers and immediately sample them as textures. Evangelion JO was missing menu text because this path needed both the glyph source buffer and the temporary render target preserved before later commands overwrite or rebind them.

This PR:

- saves first-frame data from the previous render target before creating/binding a new framebuffer, since ResizeFramebufFBO() makes the new framebuffer current
- flushes pending draws before PGF writes over a glyph buffer that may still be referenced by queued texture draws
- estimates through-mode rectangle/triangle safe bounds before SubmitPrim(), using actual vertices clamped to scissor, so first-frame readback has safe dimensions before queued draws reach backend transform

Tested:

- Built Windows PPSSPP Release x64: 0 errors, 6 existing warnings
- Tested Evangelion JO text rendering locally

CC: @hrydgard 