### PR TITLE
adhoc: add json status page link for the sprawl relay

### DIFF
--- a/assets/adhoc-servers.json
+++ b/assets/adhoc-servers.json
@@ -182,7 +182,7 @@
 			"location-emoji": "🇧🇷",
 			"description": "For players looking to play any games",
 			"data_mode": "AemuPostoffice",
-			"status_data_json": ""
+			"status_data_json": "https://status-brazil-01.sprawl-relay.link?format=aemu"
 		}
 	]
 }


### PR DESCRIPTION
Adds the `status_data_json` url to the sprawl relay server. The json format conforms to the aemu status json structure. One thing that i'm omitting is the `pdp_ports` and `ptp_ports` as aemu-relay always report them as empty. Let me know if this is a problem.