### PR TITLE
Arm64Emitter: optimize MOV instr remove excess check upload_part

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -2026,15 +2026,13 @@ void ARM64XEmitter::MOVI2R(ARM64Reg Rd, u64 imm, bool optimize)
 
 	for (unsigned i = 0; i < parts; ++i)
 	{
-		if (use_movz && upload_part[i])
-		{
-			MOVZ(Rd, (imm >> (i * 16)) & 0xFFFF, (ShiftAmount)i);
-			use_movz = false;
-		}
-		else
-		{
-			if (upload_part[i] || !optimize)
+		if (upload_part[i] || !optimize) {
+			if (use_movz) {
+				MOVZ(Rd, (imm >> (i * 16)) & 0xFFFF, (ShiftAmount)i);
+				use_movz = false;
+			} else {
 				MOVK(Rd, (imm >> (i * 16)) & 0xFFFF, (ShiftAmount)i);
+			}
 		}
 	}
 }


### PR DESCRIPTION
@hrydgard,
while I was sorting through a lot of my local branches PR changes, I accidentally noticed that it is possible to optimize the logical branches CPU by reducing the number of conditional checks upload_part[i].

I can send a fully clang assembler listing, but judging by it, the number of instructions is greatly reduced.

Assembly analyse clang++ build params -O3
```
-DASSETS_DIR="/usr/local/share/ppsspp/assets/"
-DHAVE_GETAUXVAL
-DHTTPS_NOT_AVAILABLE
-DMINIUPNPC_SET_SOCKET_TIMEOUT
-DMINIUPNP_STATICLIB
-DPNG_ARM_NEON_OPT=0
-DSDL
-DSHARED_ZLIB
-DSTACK_LINE_READER_BUFFER_SIZE=1024
-DUSE_DISCORD=1
-DUSE_SDL2_TTF
-DUSE_SDL2_TTF_FONTCONFIG
-DVK_USE_PLATFORM_WAYLAND_KHR
-DVK_USE_PLATFORM_XLIB_KHR
-DWITH_UPNP
-DZ7_CRC_NUM_TABLES=1
-D_BSD_SOURCE
-D_DEFAULT_SOURCE
-D_FILE_OFFSET_BITS=64
-D_LARGEFILE64_SOURCE=1
-D_POSIX_C_SOURCE=200112L
-D_XOPEN_SOURCE=700
-D_XOPEN_SOURCE_EXTENDED
-D__BSD_VISIBLE=1
-D__STDC_CONSTANT_MACROS
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/glslang
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/glew
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/OpenXR-SDK/include
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/Common
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/libzip
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/lzma-sdk
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/zstd/lib
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/libchdr/include
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/cmake-build-release
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/miniupnp/miniupnpc/src
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/miniupnp/miniupnpc/include
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/snappy/.
-I/media/devuan/437889e5-f1cd-4f29-84a0-605eacc7cd49/GIT/ppsspp/ext/cmake/cpu_features/../../cpu_features/include
-O3
-DNDEBUG
-std=gnu++17
-Qunused-arguments
-Wall
-Werror=return-type
-Wno-unused-function
-Wno-sign-compare
-Wno-unused-but-set-variable
-Wno-reorder
-Wno-unknown-pragmas
-Wno-unused-value
-Wno-unused-variable
-Wno-error=incompatible-pointer-types
-Wno-deprecated-declarations
-Wno-missing-braces
-Wno-nullability-completeness
-Wno-tautological-pointer-compare
-Wno-deprecated-register
-Wno-sign-conversion
-Wno-shorten-64-to-32
-Wformat
-Wno-multichar
-fno-strict-aliasing
-fno-math-errno
-msse2
```

Before:
<img width="1526" height="928" alt="image" src="https://github.com/user-attachments/assets/af3d460a-51c9-49a2-ba9a-f7d105464445" />


After:
<img width="1519" height="922" alt="image" src="https://github.com/user-attachments/assets/7b9d0ab9-2c1f-4c00-b176-171ef9f8512a" />
