### PR TITLE
Core/UI: use clear() and empty() for std containers

### DIFF
--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -397,7 +397,7 @@ void PopupMultiChoice::UpdateText() {
 			}
 			valueText_ = std::move(text);
 		} else {
-			valueText_ = "";
+			valueText_.clear();
 		}
 	}
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1596,7 +1596,7 @@ void Config::PostLoadCleanup() {
 
 	// Remove a legacy value.
 	if (g_Config.sCustomDriver == "Default") {
-		g_Config.sCustomDriver = "";
+		g_Config.sCustomDriver.clear();
 	}
 
 	// Squash unsupported screen rotations.

--- a/Core/ConfigSettings.cpp
+++ b/Core/ConfigSettings.cpp
@@ -322,7 +322,7 @@ bool ConfigSetting::RestoreToDefault(ConfigBlock *configBlock, bool log) const {
 		} else if (default_.s != nullptr) {
 			*ptr_s = default_.s;
 		} else {
-			*ptr_s = "";
+			ptr_s->clear();
 		}
 		if (*ptr_s != origValue) {
 			if (log) {

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -225,7 +225,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader, std::string *errorStrin
 		Path filename = fileLoader->GetPath();
 		// There are a few elfs misnamed as pbp (like Trig Wars), accept that. Also accept extension-less paths.
 		if (extension == ".plf" || strstr(filename.GetFilename().c_str(), "BOOT.BIN") ||
-			extension == ".elf" || extension == ".prx" || extension == ".pbp" || extension == "") {
+			extension == ".elf" || extension == ".prx" || extension == ".pbp" || extension.empty()) {
 			return IdentifiedFileType::PSP_ELF;
 		}
 		return IdentifiedFileType::UNKNOWN_ELF;

--- a/UI/ImDebugger/ImStructViewer.cpp
+++ b/UI/ImDebugger/ImStructViewer.cpp
@@ -194,7 +194,7 @@ void ImStructViewer::WatchForm::Clear() {
 	memset(name, 0, sizeof(name));
 	memset(expression, 0, sizeof(expression));
 	dynamic = false;
-	error = "";
+	error.clear();
 	typeFilter.Clear();
 	// Not clearing the actual selected type on purpose here, user will have to reselect one anyway and
 	// maybe there is a chance they will reuse the current one
@@ -213,7 +213,7 @@ void ImStructViewer::WatchForm::SetFrom(const std::unordered_map<std::string, Gh
 		snprintf(expression, sizeof(expression), "%s", watch.expression.c_str());
 	}
 	dynamic = !watch.expression.empty();
-	error = "";
+	error.clear();
 }
 
 static constexpr int COLUMN_NAME = 0;


### PR DESCRIPTION
according to C++ std standard, special methods clear() and empty() must be used because it is readable and better optimized by C++ compilers.