### PR TITLE
Replace sceGe GeInterruptData_v1 std::list to std::vector

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -246,7 +246,7 @@ void __GeDoState(PointerWrap &p) {
 	if (s >= 2) {
 		Do(p, ge_pending_cb);
 	} else {
-		std::list<GeInterruptData_v1> old;
+		std::vector<GeInterruptData_v1> old;
 		Do(p, old);
 		ge_pending_cb.clear();
 		for (const auto &ge : old) {


### PR DESCRIPTION
Reasons:
- Cache efficiency:
std::vector stores elements in a continuous block of memory. This means that with sequential access to items, the processor can load several items into the cache at once, which significantly speeds up operations (the so-called spatial locality). In contrast, std::list stores items in separate nodes scattered across memory, which leads to more cache misses.
- Access performance:
Random access: std::vector provides access to an element by index in constant time (O(1)), since it is just an offset from the beginning of the memory block. std::list requires iteration from the beginning or the end of the list, which takes linear time (O(N)). Sequential iteration over std::vector is faster due to cache efficiency.
- Lower memory overhead:
Each element in the std::list is stored in a separate node, which, in addition to the element itself, contains pointers to the previous and next elements. This adds significant memory overhead for each element. std::vector stores only the elements themselves (and possibly a little overhead information about size and capacity), which makes it more compact.
- Performance predictability:
push_back operations in std::vectors are usually very fast (amortized O(1)), although they can sometimes cause the entire array to be relocated. Overall, its performance is more predictable for most operations than that of std::list.

References:
- https://fylux.github.io/2017/06/29/list_vs_vector/
- https://stackoverflow.com/questions/238008/relative-performance-of-stdvector-vs-stdlist-vs-stdslist
- https://softwareengineering.stackexchange.com/questions/185222/what-is-the-point-of-using-lists-over-vectors-in-c