### PR TITLE
Remove through-mode projection matrix

### DIFF
--- a/Common/Math/lin/matrix4x4.cpp
+++ b/Common/Math/lin/matrix4x4.cpp
@@ -37,9 +37,9 @@ void Matrix4x4::setViewFrame(const Vec3 &pos, const Vec3 &vRight, const Vec3 &vV
 	yx = vRight.y; yy = vUp.y; yz=vView.y; yw = 0.0f;
 	zx = vRight.z; zy = vUp.z; zz=vView.z; zw = 0.0f;
 
-	wx = -pos * vRight;
-	wy = -pos * vUp;
-	wz = -pos * vView;
+	wx = dot(-pos, vRight);
+	wy = dot(-pos, vUp);
+	wz = dot(-pos, vView);
 	ww = 1.0f;
 }
 

--- a/Common/Math/lin/vec3.cpp
+++ b/Common/Math/lin/vec3.cpp
@@ -10,7 +10,6 @@ Vec3 Vec3::operator *(const Matrix4x4 &m) const {
 		x*m.xy + y*m.yy + z*m.zy + m.wy,
 		x*m.xz + y*m.yz + z*m.zz + m.wz);
 }
-
 Vec3 Vec3::rotatedBy(const Matrix4x4 &m) const {
 	return Vec3(x*m.xx + y*m.yx + z*m.zx,
 		x*m.xy + y*m.yy + z*m.zy,

--- a/Common/Math/lin/vec3.h
+++ b/Common/Math/lin/vec3.h
@@ -39,7 +39,7 @@ public:
 		x+=other.x; y+=other.y; z+=other.z;
 	}
 	Vec3 operator -(const Vec3 &v) const {
-		return Vec3(x-v.x,y-v.y,z-v.z);
+		return Vec3(x-v.x, y-v.y, z-v.z);
 	}
 	void operator -= (const Vec3 &other)
 	{
@@ -48,9 +48,8 @@ public:
 	Vec3 operator -() const {
 		return Vec3(-x,-y,-z);
 	}
-
-	Vec3 operator * (const float f) const {
-		return Vec3(x*f,y*f,z*f);
+	Vec3 operator *(const float f) const {
+		return Vec3(x * f, y * f, z * f);
 	}
 	Vec3 operator / (const float f) const {
 		float invf = (1.0f/f);
@@ -60,9 +59,6 @@ public:
 	{
 		*this = *this / f;
 	}
-	float operator * (const Vec3 &other) const {
-		return x*other.x + y*other.y + z*other.z;
-	}
 	void operator *= (const float f) {
 		*this = *this * f;
 	}
@@ -71,9 +67,6 @@ public:
 	}
 	Vec3 scaledBy(const Vec3 &other) const {
 		return Vec3(x*other.x, y*other.y, z*other.z);
-	}
-	Vec3 scaledByInv(const Vec3 &other) const {
-		return Vec3(x/other.x, y/other.y, z/other.z);
 	}
 	Vec3 operator *(const Matrix4x4 &m) const;
 	void operator *=(const Matrix4x4 &m) {
@@ -90,7 +83,7 @@ public:
 		return sqrtf(length2());
 	}
 	void setLength(const float l) {
-		(*this) *= l/length();
+		(*this) *= l / length();
 	}
 	Vec3 withLength(const float l) const {
 		return (*this) * l / length();
@@ -116,11 +109,13 @@ public:
 		return (*this)*(1-t) + other*t;
 	}
 	void setZero() {
-		memset((void *)this,0,sizeof(float)*3);
+		x = 0.0f;
+		y = 0.0f;
+		z = 0.0f;
 	}
 };
 
-inline Vec3 operator * (const float f, const Vec3 &v) {return v * f;}
+inline Vec3 operator * (const float f, const Vec3 &v) { return v * f; }
 
 // In new code, prefer these to the operators.
 

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -151,16 +151,10 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 	}
 
 	if (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX) {
-		Matrix4x4 proj_through;
-		proj_through.setOrthoVulkan(0.0f, gstate_c.curRTWidth, 0, gstate_c.curRTHeight, 0, 1);
-
-		// Negative RT offsets come from split framebuffers (Killzone)
-		if (gstate_c.curRTOffsetX < 0 || gstate_c.curRTOffsetY < 0) {
-			proj_through.wx += 2.0f * (float)gstate_c.curRTOffsetX / (float)gstate_c.curRTWidth;
-			proj_through.wy += 2.0f * (float)gstate_c.curRTOffsetY / (float)gstate_c.curRTHeight;
-		}
-
-		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());
+		ub->xywh[0] = (float)gstate_c.curRTOffsetX;
+		ub->xywh[1] = (float)gstate_c.curRTOffsetY;
+		ub->xywh[2] = (float)gstate_c.curRTWidth;
+		ub->xywh[3] = (float)gstate_c.curRTHeight;
 
 		ub->rotation = useBufferedRendering ? 0 : (float)g_display.rotation;
 	}

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -21,7 +21,7 @@ enum : uint64_t {
 // Every line here is a 4-float.
 struct alignas(16) UB_VS_FS_Base {
 	float proj[16];
-	float proj_through[16];
+	float xywh[4];  // later, we could invert w and h here to avoid division.
 	float view[12];
 	float world[12];
 	float tex[12];
@@ -43,11 +43,11 @@ struct alignas(16) UB_VS_FS_Base {
 	// VR stuff is to go here, later. For normal drawing, we can then get away
 	// with just uploading the first 448 bytes of the struct (up to and including fogCoef).
 };
-static_assert(sizeof(UB_VS_FS_Base) == 480, "UB_VS_FS_Base should be 480 bytes");
+static_assert(sizeof(UB_VS_FS_Base) == 432, "UB_VS_FS_Base should be 432 bytes");
 
 static const char * const ub_baseStr =
 R"(  mat4 u_proj;
-  mat4 u_proj_through;
+  vec4 u_xywh;
   mat3x4 u_view;
   mat3x4 u_world;
   mat3x4 u_texmtx;

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -410,7 +410,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		}
 
 		if (isModeThrough) {
-			WRITE(p, "uniform mat4 u_proj_through;\n");
+			WRITE(p, "uniform vec4 u_xywh;\n");
 			*uniformMask |= DIRTY_PROJTHROUGHMATRIX;
 		} else if (useHWTransform) {
 			if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
@@ -746,7 +746,12 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		WRITE(p, "  %sv_fogdepth = fog;\n", compat.vsOutPrefix);
 		if (isModeThrough)	{
 			// The proj_through matrix already has the rotation, if needed.
-			WRITE(p, "  vec4 outPos = mul(u_proj_through, vec4(position.xyz, 1.0));\n");
+			// NOTE: In through mode, we can ignore W, it's always 1.0. However,
+			// this transform will later be applied in all modes.
+			WRITE(p, "  vec4 outPos;\n");
+			WRITE(p, "  outPos.xy = ((position.xy - u_xywh.xy * position.w) / u_xywh.zw) * 2.0 - 1.0;\n");
+			WRITE(p, "  outPos.zw = position.zw;\n");
+			// WRITE(p, "  vec4 outPos = mul(u_proj_through, vec4(position.xyz, 1.0));\n");
 		} else {
 			// The viewport is used in this case, so need to compensate for that.
 			if (gstate_c.Use(GPU_ROUND_DEPTH_TO_16BIT)) {

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -105,7 +105,7 @@ LinkedShader::LinkedShader(GLRenderManager *render, VShaderID VSID, Shader *vs, 
 
 	queries.push_back({ &u_proj, "u_proj" });
 	queries.push_back({ &u_proj_lens, "u_proj_lens" });
-	queries.push_back({ &u_proj_through, "u_proj_through" });
+	queries.push_back({ &u_xywh, "u_xywh" });
 	queries.push_back({ &u_texenv, "u_texenv" });
 	queries.push_back({ &u_fogcolor, "u_fogcolor" });
 	queries.push_back({ &u_fogcoef, "u_fogcoef" });
@@ -443,15 +443,12 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 		render_->SetUniformM4x4(&u_proj, flippedMatrix.m);
 	}
 	if (dirty & DIRTY_PROJTHROUGHMATRIX) {
-		Matrix4x4 proj_through;
-		proj_through.setOrthoVulkan(0.0f, gstate_c.curRTWidth, 0.0f, gstate_c.curRTHeight, 0.0f, 1.0f);
-
-		// Negative RT offsets come from split framebuffers (Killzone)
-		if (gstate_c.curRTOffsetX < 0 || gstate_c.curRTOffsetY < 0) {
-			proj_through.wx += 2.0f * (float)gstate_c.curRTOffsetX / (float)gstate_c.curRTWidth;
-			proj_through.wy += 2.0f * (float)gstate_c.curRTOffsetY / (float)gstate_c.curRTHeight;
-		}
-		render_->SetUniformM4x4(&u_proj_through, proj_through.getReadPtr());
+		float xywh[4];
+		xywh[0] = (float)gstate_c.curRTOffsetX;
+		xywh[1] = (float)gstate_c.curRTOffsetY;
+		xywh[2] = (float)gstate_c.curRTWidth;
+		xywh[3] = (float)gstate_c.curRTHeight;
+		SetFloatUniform4(render_, &u_xywh, xywh);
 	}
 	if (dirty & DIRTY_TEXENV) {
 		SetColorUniform3(render_, &u_texenv, gstate.texenvcolor);

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -60,7 +60,7 @@ public:
 	int u_tex;
 	int u_proj;
 	int u_proj_lens;
-	int u_proj_through;
+	int u_xywh;
 	int u_texenv;
 	int u_view;
 	int u_texmtx;


### PR DESCRIPTION
This never really needed to be a matrix (well, at least not after #21675 but that could have been done earlier).

This is more prep for #20223 . Just want to get it in separately for easier bisection.