### PR TITLE
Use trivial keyword default de/constructors C++11 for optimize codegeneration

### DIFF
--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -61,7 +61,7 @@ private:
 	virtual void PoisonMemory(int offset) = 0;
 
 public:
-	CodeBlock() {}
+	CodeBlock() = default;
 	~CodeBlock() {
 		if (region)
 			FreeCodeSpace();

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -14,7 +14,7 @@
 template<class T>
 class FastVec {
 public:
-	FastVec() {}
+	FastVec() = default;
 	FastVec(size_t initialCapacity) {
 		capacity_ = initialCapacity;
 		data_ = (T *)malloc(initialCapacity * sizeof(T));

--- a/Common/Data/Collections/TinySet.h
+++ b/Common/Data/Collections/TinySet.h
@@ -155,7 +155,7 @@ private:
 
 template <class T, int MaxSize>
 struct FixedVec {
-	~FixedVec() {}
+	~FixedVec() = default;
 	// WARNING: Can fail if you exceed MaxSize!
 	inline bool push_back(const T &t) {
 		if (count_ < MaxSize) {

--- a/Common/Data/Format/IniFile.h
+++ b/Common/Data/Format/IniFile.h
@@ -52,7 +52,7 @@ class Section {
 	friend class IniFile;
 
 public:
-	Section() {}
+	Section() = default;
 	Section(std::string_view name) : name_(name) {}
 
 	bool HasKey(std::string_view key) const;

--- a/Common/Data/Format/JSONWriter.cpp
+++ b/Common/Data/Format/JSONWriter.cpp
@@ -14,8 +14,7 @@ JsonWriter::JsonWriter(int flags) {
 	str_.precision(53);
 }
 
-JsonWriter::~JsonWriter() {
-}
+JsonWriter::~JsonWriter() = default;
 
 void JsonWriter::begin() {
 	str_ << "{";

--- a/Common/Data/Text/I18n.h
+++ b/Common/Data/Text/I18n.h
@@ -72,7 +72,7 @@ struct I18NEntry {
 
 class I18NCategory {
 public:
-	I18NCategory() {}
+	I18NCategory() = default;
 	explicit I18NCategory(const Section &section);
 
 	// Faster since the string lengths don't need to be recomputed.

--- a/Common/FakeEmitter.h
+++ b/Common/FakeEmitter.h
@@ -144,7 +144,7 @@ public:
 	{
 		return Type;
 	}
-	Operand2() {} 
+	Operand2() = default;
 	Operand2(u32 imm, OpType type = TYPE_IMM) : IndexOrShift(), Shift()
 	{ 
 		Type = type; 

--- a/Common/File/AndroidContentURI.h
+++ b/Common/File/AndroidContentURI.h
@@ -22,7 +22,7 @@ private:
 	std::string root;
 	std::string file;
 public:
-	AndroidContentURI() {}
+	AndroidContentURI() = default;
 	explicit AndroidContentURI(std::string_view path) {
 		Parse(path);
 	}

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -154,7 +154,7 @@ int64_t Ftell(FILE *file);
 // and make forgetting an fclose() harder
 class IOFile {
 public:
-	IOFile() {}
+	IOFile() = default;
 	IOFile(const Path &filename, const char openmode[]);
 	~IOFile();
 

--- a/Common/File/PathBrowser.h
+++ b/Common/File/PathBrowser.h
@@ -16,7 +16,7 @@
 // listing "/" will yield drives.
 class PathBrowser {
 public:
-	PathBrowser() {}
+	PathBrowser() = default;
 	~PathBrowser();
 
 	void SetPath(const Path &path);

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -342,7 +342,7 @@ struct GLRStep {
 
 class GLQueueRunner {
 public:
-	GLQueueRunner() {}
+	GLQueueRunner() = default;
 
 	void SetErrorCallback(ErrorCallbackFn callback, void *userdata) {
 		errorCallback_ = callback;

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -90,9 +90,7 @@ const char *VulkanImageLayoutToString(VkImageLayout imageLayout) {
 	}
 }
 
-VulkanContext::VulkanContext() {
-	// Do nothing here.
-}
+VulkanContext::VulkanContext() = default;
 
 VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 	if (!vkCreateInstance) {
@@ -322,9 +320,13 @@ VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 	return VK_SUCCESS;
 }
 
+#if defined(NDEBUG)
 VulkanContext::~VulkanContext() {
 	_dbg_assert_(instance_ == VK_NULL_HANDLE);
 }
+#else
+VulkanContext::~VulkanContext() = default;
+#endif
 
 void VulkanContext::DestroyInstance() {
 	if (extensionsLookup_.EXT_debug_utils) {

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -509,7 +509,7 @@ private:
 	int inflightFrames_ = MAX_INFLIGHT_FRAMES;
 
 	struct FrameData {
-		FrameData() {}
+		FrameData() = default;
 		VulkanDeleteList deleteList;
 		VulkanProfiler profiler;
 	};

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -139,7 +139,7 @@ class VKRRenderPass;
 
 struct VKRStep {
 	VKRStep(VKRStepType _type) : stepType(_type) {}
-	~VKRStep() {}
+	~VKRStep() = default;
 
 	VKRStepType stepType;
 	FastVec<VkRenderData> commands;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -384,7 +384,7 @@ private:
 
 template <typename T>
 struct AutoRef {
-	AutoRef() {}
+	AutoRef() = default;
 	explicit AutoRef(T *p) {
 		ptr = p;
 		if (ptr)

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -187,7 +187,7 @@ enum class KeyInputFlags {
 ENUM_CLASS_BITOPS(KeyInputFlags);
 
 struct KeyInput {
-	KeyInput() {}
+	KeyInput() = default;
 	KeyInput(InputDeviceID devId, InputKeyCode code, KeyInputFlags fl) : deviceId(devId), keyCode(code), flags(fl) {}
 	KeyInput(InputDeviceID devId, int unicode) : deviceId(devId), unicodeChar(unicode), flags(KeyInputFlags::CHAR) {}
 	InputDeviceID deviceId;

--- a/Common/LoongArch64Emitter.h
+++ b/Common/LoongArch64Emitter.h
@@ -118,7 +118,7 @@ static inline bool IsFCSR(LoongArch64FCSR fcsr) { return ((int)fcsr < 4); }
 inline LoongArch64Reg EncodeRegToV(LoongArch64Reg reg) { return (LoongArch64Reg)(DecodeReg(reg) + V0); }
 
 struct FixupBranch {
-	FixupBranch() {}
+	FixupBranch() = default;
 	FixupBranch(const u8 *p, FixupBranchType t) : ptr(p), type(t) {}
 	FixupBranch(FixupBranch &&other);
 	FixupBranch(const FixupBranch &) = delete;

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -16,7 +16,7 @@
 // The point of this, as opposed to a float4 array, is to almost force the compiler
 // to keep the matrix in registers, rather than loading on every access.
 struct Mat4F32 {
-	Mat4F32() {}
+	Mat4F32() = default;
 	Mat4F32(const float *matrix) {
 		col0 = _mm_loadu_ps(matrix);
 		col1 = _mm_loadu_ps(matrix + 4);

--- a/Common/Math/Statistics.h
+++ b/Common/Math/Statistics.h
@@ -32,7 +32,7 @@ struct SimpleStat {
 	void Format(char *buffer, size_t sz);
 
 private:
-	SimpleStat() {}
+	SimpleStat() = default;
 	const char *name_;
 
 	// These are initialized in Reset().

--- a/Common/Math/lin/vec3.h
+++ b/Common/Math/lin/vec3.h
@@ -12,7 +12,7 @@ class Matrix4x4;
 class Vec4 {
 public:
 	float x,y,z,w;
-	Vec4(){}
+	Vec4() = default;
 	Vec4(float a, float b, float c, float d) {x=a;y=b;z=c;w=d;}
 };
 
@@ -20,7 +20,7 @@ class Vec3 {
 public:
 	float x,y,z;
 
-	Vec3() { }
+	Vec3() = default;
 	explicit Vec3(float f) {x=y=z=f;}
 
 	float operator [] (int i) const { return (&x)[i]; }

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -53,7 +53,7 @@ bool GetHeaderValue(const std::vector<std::string> &responseHeaders, std::string
 
 class RequestParams {
 public:
-	RequestParams() {}
+	RequestParams() = default;
 	explicit RequestParams(const char *r) : resource(r) {}
 	RequestParams(const std::string &r, const char *a) : resource(r), acceptMime(a) {}
 

--- a/Common/Net/HTTPHeaders.cpp
+++ b/Common/Net/HTTPHeaders.cpp
@@ -12,8 +12,7 @@
 
 namespace http {
 
-RequestHeader::RequestHeader() {
-}
+RequestHeader::RequestHeader() = default;
 
 RequestHeader::~RequestHeader() {
 	delete [] referer;

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -58,10 +58,14 @@ private:
 	ManagedTexture::LoadState *state_;
 };
 
+#if defined(NDEBUG)
 TempImage::~TempImage() {
 	// Make sure you haven't forgotten to call Free.
 	_dbg_assert_(levels[0] == nullptr);
 }
+#else
+TempImage::~TempImage() = default;
+#endif
 
 static Draw::DataFormat ZimToT3DFormat(int zim) {
 	switch (zim) {

--- a/Common/Render/Text/Font.h
+++ b/Common/Render/Text/Font.h
@@ -25,7 +25,7 @@ enum class FontFamily : u8 {
 };
 
 struct FontStyle {
-	FontStyle() {}
+	FontStyle() = default;
 	constexpr FontStyle(FontFamily _family, int size, FontStyleFlags _flags) : family(_family), sizePts(size), flags(_flags) {}
 
 	u16 sizePts = 0;

--- a/Common/Render/TextureAtlas.h
+++ b/Common/Render/TextureAtlas.h
@@ -23,7 +23,7 @@ struct Atlas;
 
 struct ImageID {
 public:
-	ImageID() {}
+	ImageID() = default;
 	explicit ImageID(std::string_view _id) : id(_id) {}
 
 	static inline ImageID invalid() {

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -180,7 +180,7 @@ enum class VUseMask {
 };
 
 struct FixupBranch {
-	FixupBranch() {}
+	FixupBranch() = default;
 	FixupBranch(const u8 *p, FixupBranchType t) : ptr(p), type(t) {}
 	FixupBranch(FixupBranch &&other);
 	FixupBranch(const FixupBranch &) = delete;

--- a/Common/Thread/Promise.h
+++ b/Common/Thread/Promise.h
@@ -175,7 +175,7 @@ public:
 	}
 
 private:
-	Promise() {}
+	Promise() = default;
 
 	// Promise can only be constructed in Spawn (or AlreadyDone).
 	T data_{};

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -157,7 +157,7 @@ class XEmitter;
 // RIP addressing does not benefit from micro op fusion on Core arch
 struct OpArg
 {
-	OpArg() {}  // dummy op arg, used for storage
+	OpArg() = default;  // dummy op arg, used for storage
 	OpArg(u64 _offset, int _scale, X64Reg rmReg = RAX, X64Reg scaledReg = RAX)
 	{
 		operandReg = 0;

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -392,8 +392,7 @@ u32 DisassemblyManager::getNthNextAddress(u32 address, int n)
 	return (address + n * 4) & ~3;
 }
 
-DisassemblyManager::~DisassemblyManager() {
-}
+DisassemblyManager::~DisassemblyManager() = default;
 
 void DisassemblyManager::clear()
 {

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -65,7 +65,7 @@ typedef struct HWND__ *HWND;
 
 class SymbolMap {
 public:
-	SymbolMap() {}
+	SymbolMap() = default;
 
 	void Clear();
 	void SortSymbols();

--- a/Core/Debugger/WebSocket/InputBroadcaster.h
+++ b/Core/Debugger/WebSocket/InputBroadcaster.h
@@ -26,8 +26,7 @@ class WebSocketServer;
 
 struct InputBroadcaster {
 public:
-	InputBroadcaster() {
-	}
+	InputBroadcaster() = default;
 
 	void Broadcast(net::WebSocketServer *ws);
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -45,7 +45,7 @@ DebuggerSubscriber *WebSocketMemoryInit(DebuggerEventHandlerMap &map) {
 }
 
 struct AutoDisabledReplacements {
-	AutoDisabledReplacements() {}
+	AutoDisabledReplacements() = default;
 	AutoDisabledReplacements(AutoDisabledReplacements &&other);
 	AutoDisabledReplacements(const AutoDisabledReplacements &) = delete;
 	AutoDisabledReplacements &operator =(const AutoDisabledReplacements &) = delete;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -207,7 +207,7 @@ void SaveFileInfo::DoState(PointerWrap &p)
 	}
 }
 
-SavedataParam::SavedataParam() { }
+SavedataParam::SavedataParam() = default;
 
 void SavedataParam::Init() {
 	// If the folder already exists, this is a no-op.

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -46,7 +46,7 @@ struct DirectoryFileHandle {
 	bool inGameDir_ = false;
 	FileSystemFlags fileSystemFlags_ = (FileSystemFlags)0;
 
-	DirectoryFileHandle() {}
+	DirectoryFileHandle() = default;
 
 	DirectoryFileHandle(Flags flags, FileSystemFlags fileSystemFlags)
 		: replay_(flags != SKIP_REPLAY), fileSystemFlags_(fileSystemFlags) {}

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -110,8 +110,7 @@ private:
 };
 
 struct PSPFileInfo {
-	PSPFileInfo() {
-	}
+	PSPFileInfo() = default;
 
 	void DoState(PointerWrap &p);
 

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -136,7 +136,7 @@ private:
 	typedef enum { VFILETYPE_NORMAL, VFILETYPE_LBN, VFILETYPE_ISO } VirtualFileType;
 
 	struct OpenFileEntry {
-		OpenFileEntry() {}
+		OpenFileEntry() = default;
 		OpenFileEntry(FileSystemFlags fileSystemFlags) {
 			hFile = DirectoryFileHandle(DirectoryFileHandle::SKIP_REPLAY, fileSystemFlags);
 		}

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -264,7 +264,7 @@ private:
 class LoadedFont {
 public:
 	// For savestates only.
-	LoadedFont() {}
+	LoadedFont() = default;
 
 	LoadedFont(Font *font, FontOpenMode mode, u32 fontLibID, u32 handle)
 		: fontLibID_(fontLibID), font_(font), handle_(handle), mode_(mode), open_(true) {}
@@ -361,7 +361,7 @@ private:
 
 class PostAllocCallback : public PSPAction {
 public:
-	PostAllocCallback() {}
+	PostAllocCallback() = default;
 	static PSPAction *Create() { return new PostAllocCallback(); }
 	void DoState(PointerWrap &p) override {
 		auto s = p.Section("PostAllocCallback", 1, 2);
@@ -387,7 +387,7 @@ private:
 
 class PostOpenCallback : public PSPAction {
 public:
-	PostOpenCallback() {}
+	PostOpenCallback() = default;
 	static PSPAction *Create() { return new PostOpenCallback(); }
 	void DoState(PointerWrap &p) override {
 		auto s = p.Section("PostOpenCallback", 1);
@@ -407,7 +407,7 @@ private:
 
 class PostOpenAllocCallback : public PSPAction {
 public:
-	PostOpenAllocCallback() {}
+	PostOpenAllocCallback() = default;
 	static PSPAction *Create() { return new PostOpenAllocCallback(); }
 	void DoState(PointerWrap &p) override {
 		auto s = p.Section("PostOpenAllocCallback", 1);
@@ -432,7 +432,7 @@ private:
 
 class PostCharInfoAllocCallback : public PSPAction {
 public:
-	PostCharInfoAllocCallback() {}
+	PostCharInfoAllocCallback() = default;
 	static PSPAction *Create() { return new PostCharInfoAllocCallback(); }
 	void DoState(PointerWrap &p) override {
 		auto s = p.Section("PostCharInfoAllocCallback", 1);
@@ -452,7 +452,7 @@ private:
 
 class PostCharInfoFreeCallback : public PSPAction {
 public:
-	PostCharInfoFreeCallback() {}
+	PostCharInfoFreeCallback() = default;
 	static PSPAction *Create() { return new PostCharInfoFreeCallback(); }
 	void DoState(PointerWrap &p) override {
 		auto s = p.Section("PostCharInfoFreeCallback", 1);
@@ -497,9 +497,8 @@ struct FontImageRect {
 // One can open either "internal" fonts or load custom fonts into a fontlib.
 class FontLib {
 public:
-	FontLib() {
-		// For save states only.
-	}
+	FontLib() = default;
+	// For save states only.
 
 	FontLib(FontNewLibParams *params, u32 errorCodePtr) {
 		params_ = *params;

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -144,7 +144,7 @@ public:
 class KernelObjectPool {
 public:
 	KernelObjectPool();
-	~KernelObjectPool() {}
+	~KernelObjectPool() = default;
 
 	// Allocates a UID within the range and inserts the object into the map.
 	SceUID Create(KernelObject *obj, int rangeBottom = initialNextID, int rangeTop = 0x7fffffff);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -147,7 +147,7 @@ typedef std::map<int, PsmfStream *> PsmfStreamMap;
 class Psmf {
 public:
 	// For savestates only.
-	Psmf() {}
+	Psmf() = default;
 	Psmf(const u8 *ptr, u32 data);
 	~Psmf();
 	void DoState(PointerWrap &p);

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -470,8 +470,7 @@ bool IsValidCodec(PSPAudioType codec){
 
 // sceAu module starts from here
 
-AuCtx::AuCtx() {
-}
+AuCtx::AuCtx() = default;
 
 AuCtx::~AuCtx() {
 	if (decoder) {

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -113,7 +113,7 @@ class IniFile;
 namespace KeyMap {
 	// Combo of InputMappings.
 	struct MultiInputMapping {
-		MultiInputMapping() {}
+		MultiInputMapping() = default;
 		explicit MultiInputMapping(const InputMapping &mapping) {
 			mappings.push_back(mapping);
 		}

--- a/Core/MIPS/ARM/ArmRegCache.h
+++ b/Core/MIPS/ARM/ArmRegCache.h
@@ -84,7 +84,7 @@ namespace MIPSComp {
 class ArmRegCache {
 public:
 	ArmRegCache(MIPSState *mipsState, MIPSComp::JitState *js, MIPSComp::JitOptions *jo);
-	~ArmRegCache() {}
+	~ArmRegCache() = default;
 
 	void Init(ArmGen::ARMXEmitter *emitter);
 	void Start();

--- a/Core/MIPS/ARM/ArmRegCacheFPU.h
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.h
@@ -79,7 +79,7 @@ namespace MIPSComp {
 class ArmRegCacheFPU {
 public:
 	ArmRegCacheFPU(MIPSState *mipsState, MIPSComp::JitState *js, MIPSComp::JitOptions *jo);
-	~ArmRegCacheFPU() {}
+	~ArmRegCacheFPU() = default;
 
 	void Init(ArmGen::ARMXEmitter *emitter);
 

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -49,7 +49,7 @@ namespace MIPSComp {
 // TODO : Use arena allocators. For now let's just malloc.
 class IRBlock {
 public:
-	IRBlock() {}
+	IRBlock() = default;
 	IRBlock(u32 emAddr, u32 origSize, int instOffset, u32 numInstructions)
 		: origAddr_(emAddr), origSize_(origSize), arenaOffset_(instOffset), numIRInstructions_(numInstructions) {}
 	IRBlock(IRBlock &&b) noexcept {
@@ -63,7 +63,7 @@ public:
 		b.arenaOffset_ = 0xFFFFFFFF;
 	}
 
-	~IRBlock() {}
+	~IRBlock() = default;
 
 	u32 GetIRArenaOffset() const { return arenaOffset_; }
 	int GetNumIRInstructions() const { return numIRInstructions_; }

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -157,8 +157,7 @@ MIPSState::MIPSState() {
 	}
 }
 
-MIPSState::~MIPSState() {
-}
+MIPSState::~MIPSState() = default;
 
 void MIPSState::Shutdown() {
 	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -54,8 +54,7 @@ void GPRRegCache::FlushBeforeCall() {
 	Flush();
 }
 
-GPRRegCache::GPRRegCache() {
-}
+GPRRegCache::GPRRegCache() = default;
 
 void GPRRegCache::Start(MIPSState *mipsState, MIPSComp::JitState *js, MIPSComp::JitOptions *jo) {
 #if PPSSPP_ARCH(AMD64)

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -68,7 +68,7 @@ class GPRRegCache
 {
 public:
 	GPRRegCache();
-	~GPRRegCache() {}
+	~GPRRegCache() = default;
 	void Start(MIPSState *mipsState, MIPSComp::JitState *js, MIPSComp::JitOptions *jo);
 
 	void DiscardRegContentsIfCached(MIPSGPReg preg);

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -96,7 +96,7 @@ class FPURegCache
 {
 public:
 	FPURegCache();
-	~FPURegCache() {}
+	~FPURegCache() = default;
 
 	void Start(MIPSState *mipsState, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, bool useRip);
 	void MapReg(int preg, bool doLoad = true, bool makeDirty = true);

--- a/Core/Opcode.h
+++ b/Core/Opcode.h
@@ -24,8 +24,7 @@
 namespace Memory {
 
 struct Opcode {
-	Opcode() {
-	}
+	Opcode() = default;
 
 	explicit Opcode(u32 v) : encoding(v) {
 	}

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -56,8 +56,7 @@
 
 GameManager g_GameManager;
 
-GameManager::GameManager() {
-}
+GameManager::GameManager() = default;
 
 Path GameManager::GetTempFilename() const {
 #ifdef _WIN32

--- a/Core/Util/PortManager.cpp
+++ b/Core/Util/PortManager.cpp
@@ -55,9 +55,8 @@ PortManager::PortManager():
 	// Don't call net::Init or similar here, we don't want stuff like that to happen before main.
 }
 
-PortManager::~PortManager() {
-	// FIXME: On Windows it seems using any UPnP functions in this destructor that gets triggered when exiting PPSSPP will resulting to UPNPCOMMAND_HTTP_ERROR due to early WSACleanup (miniupnpc was getting WSANOTINITIALISED internally)
-}
+PortManager::~PortManager() = default;
+// FIXME: On Windows it seems using any UPnP functions in this destructor that gets triggered when exiting PPSSPP will resulting to UPNPCOMMAND_HTTP_ERROR due to early WSACleanup (miniupnpc was getting WSANOTINITIALISED internally)
 
 void PortManager::Shutdown() {
 	Clear();

--- a/Core/Util/RecentFiles.cpp
+++ b/Core/Util/RecentFiles.cpp
@@ -15,7 +15,7 @@
 
 RecentFilesManager g_recentFiles;
 
-RecentFilesManager::RecentFilesManager() {}
+RecentFilesManager::RecentFilesManager() = default;
 
 RecentFilesManager::~RecentFilesManager() {
 	if (thread_.joinable()) {

--- a/Core/WaveFile.cpp
+++ b/Core/WaveFile.cpp
@@ -8,7 +8,7 @@
 
 constexpr size_t WaveFileWriter::BUFFER_SIZE;
 
-WaveFileWriter::WaveFileWriter() {}
+WaveFileWriter::WaveFileWriter() = default;
 
 WaveFileWriter::~WaveFileWriter()
 {

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -95,8 +95,7 @@ inline GPUDebugBufferFormat &operator |=(GPUDebugBufferFormat &lhs, const GPUDeb
 }
 
 struct GPUDebugBuffer {
-	GPUDebugBuffer() {
-	}
+	GPUDebugBuffer() = default;
 
 	GPUDebugBuffer(void *data, u32 stride, u32 height, GEBufferFormat fmt, bool reversed = false)
 		: alloc_(false), data_((u8 *)data), stride_(stride), height_(height), fmt_(GPUDebugBufferFormat(fmt)), flipped_(false) {

--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -179,7 +179,7 @@ struct ControlPoints {
 	Vec4f *col = nullptr;
 	u32_le defcolor;
 
-	ControlPoints() {}
+	ControlPoints() = default;
 	ControlPoints(const SimpleVertex *const *points, int size, SimpleBufferManager &managedBuf);
 	void Convert(const SimpleVertex *const *points, int size);
 	bool IsValid() const {

--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -540,12 +540,9 @@ void bilinearV(int factor, const u32 *data, u32 *out, int w, int gl, int gu, int
 
 /////////////////////////////////////// Texture Scaler
 
-TextureScalerCommon::TextureScalerCommon() {
-	// initBicubicWeights() used to be here.
-}
+TextureScalerCommon::TextureScalerCommon() = default;
 
-TextureScalerCommon::~TextureScalerCommon() {
-}
+TextureScalerCommon::~TextureScalerCommon() = default;
 
 bool TextureScalerCommon::IsEmptyOrFlat(const u32 *data, int pixels) {
 	u32 ref = data[0];

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -78,7 +78,7 @@ public:
 	T* AsArray() { return &x; }
 	const T* AsArray() const { return &x; }
 
-	Vec2() {}
+	Vec2() = default;
 	Vec2(const T a[2]) : x(a[0]), y(a[1]) {}
 	Vec2(const T& _x, const T& _y) : x(_x), y(_y) {}
 
@@ -217,7 +217,7 @@ public:
 	T* AsArray() { return &x; }
 	const T* AsArray() const { return &x; }
 
-	Vec3() {}
+	Vec3() = default;
 	Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	constexpr Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 	Vec3(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
@@ -403,7 +403,7 @@ public:
 	T* AsArray() { return &x; }
 	const T* AsArray() const { return &x; }
 
-	Vec3Packed() {}
+	Vec3Packed() = default;
 	Vec3Packed(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
 	Vec3Packed(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 	Vec3Packed(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
@@ -576,7 +576,7 @@ public:
 	T* AsArray() { return &x; }
 	const T* AsArray() const { return &x; }
 
-	Vec4() {}
+	Vec4() = default;
 	Vec4(const T a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
 	Vec4(const T& _x, const T& _y, const T& _z, const T& _w) : x(_x), y(_y), z(_z), w(_w) {}
 	Vec4(const Vec2<T>& _xy, const T& _z, const T& _w) : x(_xy.x), y(_xy.y), z(_z), w(_w) {}

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -44,8 +44,7 @@ enum class PixelBlendFactor {
 #pragma pack(push, 1)
 
 struct PixelFuncID {
-	PixelFuncID() {
-	}
+	PixelFuncID() = default;
 
 	struct {
 		// Warning: these are not hashed or compared for equal.  Just cached values.

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -45,7 +45,7 @@ enum class CullType {
 
 struct ScreenCoords
 {
-	ScreenCoords() {}
+	ScreenCoords() = default;
 	ScreenCoords(int x, int y, u16 z) : x(x), y(y), z(z) {}
 
 	int x;
@@ -71,7 +71,7 @@ struct ScreenCoords
 };
 
 struct DrawingCoords {
-	DrawingCoords() {}
+	DrawingCoords() = default;
 	DrawingCoords(s16 x, s16 y) : x(x), y(y) {}
 
 	s16 x;

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -108,7 +108,7 @@ VkShaderModule CompileShaderModule(VulkanContext *vulkan, VkShaderStageFlagBits 
 }
 
 VulkanComputeShaderManager::VulkanComputeShaderManager(VulkanContext *vulkan) : vulkan_(vulkan), pipelines_(8) {}
-VulkanComputeShaderManager::~VulkanComputeShaderManager() {}
+VulkanComputeShaderManager::~VulkanComputeShaderManager() = default;
 
 void VulkanComputeShaderManager::InitDeviceObjects(Draw::DrawContext *draw) {
 	VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2013- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
@@ -946,8 +945,7 @@ private:
 	DISALLOW_COPY_AND_ASSIGN(GameInfoWorkItem);
 };
 
-GameInfoCache::GameInfoCache() {
-}
+GameInfoCache::GameInfoCache() = default;
 
 GameInfoCache::~GameInfoCache() {
 	Clear();

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -2039,7 +2039,7 @@ static void DrawSymbols(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 	ImGui::End();
 }
 
-ImWatchWindow::ImWatchWindow() {}
+ImWatchWindow::ImWatchWindow() = default;
 
 void ImWatchWindow::Draw(ImConfig &cfg, ImControl &control, MIPSDebugInterface *mipsDebug) {
 	if (!ImGui::Begin("Watch", &cfg.watchOpen) || !g_symbolMap) {

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -159,7 +159,7 @@ private:
 
 class ImLogWindow {
 public:
-	ImLogWindow() {}
+	ImLogWindow() = default;
 	void Draw(ImConfig &cfg);
 
 private:

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -30,7 +30,7 @@ ImMemView::ImMemView() {
 	lastSelectReset_ = curAddress_;
 }
 
-ImMemView::~ImMemView() {}
+ImMemView::~ImMemView() = default;
 
 static uint32_t pickTagColor(std::string_view tag) {
 	uint32_t colors[6] = { 0xFF301010, 0xFF103030, 0xFF403010, 0xFF103000, 0xFF301030, 0xFF101030 };


### PR DESCRIPTION
Please read reference link with user benchmarks.
Reference:
- https://stackoverflow.com/questions/59261490/why-is-there-performance-variation-using-default-constructor-instead-of