### PR TITLE
Keep updated products of view*proj and world*view*proj matrices.

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -164,12 +164,7 @@ void DrawEngineCommon::DispatchSubmitImm(GEPrimitiveType prim, TransformedVertex
 }
 
 // Gated by DIRTY_CULL_PLANES
-void DrawEngineCommon::UpdatePlanes() {
-	float view[16];
-	float viewproj[16];
-	ConvertMatrix4x3To4x4(view, gstate.viewMatrix);
-	Matrix4ByMatrix4(viewproj, view, gstate.projMatrix);
-
+void DrawEngineCommon::UpdatePlanes(const float viewproj[16]) {
 	// Next, we need to apply viewport, scissor, region, and even offset - but only for X/Y.
 	// Note that the PSP does not clip against the viewport.
 	const Vec2f baseOffset = Vec2f(gstate.getOffsetX(), gstate.getOffsetY());
@@ -237,7 +232,7 @@ bool DrawEngineCommon::TestBoundingBox(const void *vdata, const void *inds, int 
 	// Due to world matrix updates per "thing", this isn't quite as effective as it could be if we did world transform
 	// in here as well. Though, it still does cut down on a lot of updates in Tekken 6.
 	if (gstate_c.IsDirty(DIRTY_CULL_PLANES)) {
-		UpdatePlanes();
+		UpdatePlanes(gstate_c.viewproj);
 		gpuStats.numPlaneUpdates++;
 		gstate_c.Clean(DIRTY_CULL_PLANES);
 	}
@@ -371,7 +366,7 @@ bool DrawEngineCommon::TestBoundingBoxFast(const void *vdata, int vertexCount, c
 	// Due to world matrix updates per "thing", this isn't quite as effective as it could be if we did world transform
 	// in here as well. Though, it still does cut down on a lot of updates in Tekken 6.
 	if (gstate_c.IsDirty(DIRTY_CULL_PLANES)) {
-		UpdatePlanes();
+		UpdatePlanes(gstate_c.viewproj);
 		gpuStats.numPlaneUpdates++;
 		gstate_c.Clean(DIRTY_CULL_PLANES);
 	}

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -169,7 +169,7 @@ public:
 
 protected:
 	virtual bool UpdateUseHWTessellation(bool enabled) const { return enabled; }
-	void UpdatePlanes();
+	void UpdatePlanes(const float viewproj[16]);
 
 	void DecodeVerts(const VertexDecoder *dec, u8 *dest);
 	int DecodeInds();

--- a/GPU/Common/ShaderCommon.h
+++ b/GPU/Common/ShaderCommon.h
@@ -93,14 +93,15 @@ enum : uint64_t {
 	DIRTY_LIGHT_CONTROL = 1ULL << 38,
 	DIRTY_TEX_ALPHA_MUL = 1ULL << 39,
 
-	// Bits 40-42 are free for new uniforms. Then we're really out and need to start merging.
-	// Don't forget to update DIRTY_ALL_UNIFORMS when you start using them.
-
 	DIRTY_BONE_UNIFORMS = 0xFF000000ULL,
 
 	DIRTY_ALL_UNIFORMS = 0x0FFFFFFFFFFULL,
 
 	// Other dirty elements that aren't uniforms
+
+	DIRTY_VIEW_PROJ_MATRIX = 1ULL << 40,
+	DIRTY_WORLD_VIEW_PROJ_MATRIX = 1ULL << 41,
+	// Free non-uniform bit 42.
 	DIRTY_CULL_PLANES = 1ULL << 43,
 	DIRTY_FRAMEBUF = 1ULL << 44,
 	DIRTY_TEXTURE_IMAGE = 1ULL << 45,  // Means that the definition of the texture image has changed (address, stride etc), and we need to look up again.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1220,6 +1220,8 @@ void GPUCommon::Execute_BoundingBox(u32 op, u32 diff) {
 		inds = Memory::GetPointerUnchecked(gstate_c.indexAddr);
 	}
 
+	UpdateMatrixProducts();
+
 	// Test if the bounding box is within the drawing region.
 	// The PSP only seems to vary the result based on a single range of 0x100.
 	if (count > 0x200) {
@@ -2186,5 +2188,21 @@ bool GPUCommon::SetRestrictPrims(std::string_view rule) {
 		return true;
 	} else {
 		return false;
+	}
+}
+
+void GPUCommon::UpdateMatrixProducts() {
+	// Compute any dirty product matrices.
+	if (gstate_c.IsDirty(DIRTY_VIEW_PROJ_MATRIX)) {
+		float view[4 * 4];
+		ConvertMatrix4x3To4x4(view, gstate.viewMatrix);
+		Matrix4ByMatrix4(gstate_c.viewproj, view, gstate.projMatrix);
+		gstate_c.Clean(DIRTY_VIEW_PROJ_MATRIX);
+	}
+	if (gstate_c.IsDirty(DIRTY_WORLD_VIEW_PROJ_MATRIX)) {
+		float world[4 * 4];
+		ConvertMatrix4x3To4x4(world, gstate.worldMatrix);
+		Matrix4ByMatrix4(gstate_c.worldviewproj, world, gstate_c.viewproj);
+		gstate_c.Clean(DIRTY_WORLD_VIEW_PROJ_MATRIX);
 	}
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -268,6 +268,8 @@ protected:
 	// While debugging is active, these may block.
 	void NotifyDisplay(u32 framebuf, u32 stride, int format);
 
+	void UpdateMatrixProducts();
+
 	bool NeedsSlowInterpreter() const;
 	GPUDebug::NotifyResult NotifyCommand(u32 pc, GPUBreakpoints *breakpoints);
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -916,6 +916,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 	PROFILE_THIS_SCOPE("execprim");
 
 	FlushImm();
+	UpdateMatrixProducts();
 
 	// Upper bits are ignored.
 	const GEPrimitiveType prim = static_cast<GEPrimitiveType>((op >> 16) & 7);
@@ -1301,6 +1302,8 @@ bail:
 }
 
 void GPUCommonHW::Execute_Bezier(u32 op, u32 diff) {
+	UpdateMatrixProducts();
+
 	// We don't dirty on normal changes anymore as we prescale, but it's needed for splines/bezier.
 	gstate_c.framebufFormat = gstate.FrameBufFormat();
 
@@ -1377,6 +1380,8 @@ void GPUCommonHW::Execute_Bezier(u32 op, u32 diff) {
 }
 
 void GPUCommonHW::Execute_Spline(u32 op, u32 diff) {
+	UpdateMatrixProducts();
+
 	// We don't dirty on normal changes anymore as we prescale, but it's needed for splines/bezier.
 	gstate_c.framebufFormat = gstate.FrameBufFormat();
 
@@ -1528,7 +1533,7 @@ void GPUCommonHW::Execute_WorldMtxNum(u32 op, u32 diff) {
 			if (dst[i] != newVal) {
 				Flush();
 				dst[i] = newVal;
-				gstate_c.Dirty(DIRTY_WORLDMATRIX);
+				gstate_c.Dirty(DIRTY_WORLDMATRIX | DIRTY_WORLD_VIEW_PROJ_MATRIX);
 			}
 			if (++i >= end) {
 				break;
@@ -1551,7 +1556,7 @@ void GPUCommonHW::Execute_WorldMtxData(u32 op, u32 diff) {
 	if (num < 12 && newVal != ((const u32 *)gstate.worldMatrix)[num]) {
 		Flush();
 		((u32 *)gstate.worldMatrix)[num] = newVal;
-		gstate_c.Dirty(DIRTY_WORLDMATRIX);
+		gstate_c.Dirty(DIRTY_WORLDMATRIX | DIRTY_WORLD_VIEW_PROJ_MATRIX);
 	}
 	num++;
 	gstate.worldmtxnum = (GE_CMD_WORLDMATRIXNUMBER << 24) | (num & 0x00FFFFFF);
@@ -1581,7 +1586,7 @@ void GPUCommonHW::Execute_ViewMtxNum(u32 op, u32 diff) {
 			if (dst[i] != newVal) {
 				Flush();
 				dst[i] = newVal;
-				gstate_c.Dirty(DIRTY_VIEWMATRIX | DIRTY_CULL_PLANES);
+				gstate_c.Dirty(DIRTY_VIEWMATRIX | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX | DIRTY_CULL_PLANES);
 			}
 			if (++i >= end) {
 				break;
@@ -1604,7 +1609,7 @@ void GPUCommonHW::Execute_ViewMtxData(u32 op, u32 diff) {
 	if (num < 12 && newVal != ((const u32 *)gstate.viewMatrix)[num]) {
 		Flush();
 		((u32 *)gstate.viewMatrix)[num] = newVal;
-		gstate_c.Dirty(DIRTY_VIEWMATRIX | DIRTY_CULL_PLANES);
+		gstate_c.Dirty(DIRTY_VIEWMATRIX | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX | DIRTY_CULL_PLANES);
 	}
 	num++;
 	gstate.viewmtxnum = (GE_CMD_VIEWMATRIXNUMBER << 24) | (num & 0x00FFFFFF);
@@ -1634,7 +1639,7 @@ void GPUCommonHW::Execute_ProjMtxNum(u32 op, u32 diff) {
 			if (dst[i] != newVal) {
 				Flush();
 				dst[i] = newVal;
-				gstate_c.Dirty(DIRTY_PROJMATRIX | DIRTY_CULL_PLANES);
+				gstate_c.Dirty(DIRTY_PROJMATRIX | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX | DIRTY_CULL_PLANES);
 			}
 			if (++i >= end) {
 				break;
@@ -1657,7 +1662,7 @@ void GPUCommonHW::Execute_ProjMtxData(u32 op, u32 diff) {
 	if (num < 16 && newVal != ((const u32 *)gstate.projMatrix)[num]) {
 		Flush();
 		((u32 *)gstate.projMatrix)[num] = newVal;
-		gstate_c.Dirty(DIRTY_PROJMATRIX | DIRTY_CULL_PLANES);
+		gstate_c.Dirty(DIRTY_PROJMATRIX | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX | DIRTY_CULL_PLANES);
 	}
 	num++;
 	if (num <= 16)

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -116,7 +116,7 @@ void GPUgstate::Reset() {
 
 	savedContextVersion = 1;
 
-	gstate_c.Dirty(DIRTY_CULL_PLANES);
+	gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 }
 
 void GPUgstate::Save(u32_le *ptr) {
@@ -248,7 +248,7 @@ void GPUgstate::Restore(const u32_le *ptr) {
 	if (gpu)
 		gpu->ResetMatrices();
 
-	gstate_c.Dirty(DIRTY_CULL_PLANES);
+	gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 }
 
 bool vertTypeIsSkinningEnabled(u32 vertType) {
@@ -359,7 +359,7 @@ void GPUStateCache::DoState(PointerWrap &p) {
 	}
 
 	if (p.GetMode() == PointerWrap::MODE_READ)
-		gstate_c.Dirty(DIRTY_CULL_PLANES);
+		gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 }
 
 static const char *const g_gpuUseFlagNames[32] = {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -648,6 +648,13 @@ public:
 	float vpHeightScale;
 	float vpDepthScale;
 
+	// Cached 4x4 products of the matrices.
+	// Useful for culling and extracing the final Z from vertices (so we can check if clipping is needed).
+	// Most often, world changes the most.
+	// We recompute viewproj when view or proj changes, and worldviewproj when world, view, or proj changes.
+	float viewproj[16];
+	float worldviewproj[16];
+
 	KnownVertexBounds vertBounds;
 
 	GEBufferFormat framebufFormat;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1038,7 +1038,7 @@ void SoftGPU::Execute_FramebufFormat(u32 op, u32 diff) {
 }
 
 void SoftGPU::Execute_BoundingBox(u32 op, u32 diff) {
-	gstate_c.Dirty(DIRTY_CULL_PLANES);
+	gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 	GPUCommon::Execute_BoundingBox(op, diff);
 }
 
@@ -1094,7 +1094,7 @@ void SoftGPU::Execute_WorldMtxData(u32 op, u32 diff) {
 		if (newVal != *target) {
 			*target = newVal;
 			dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
-			gstate_c.Dirty(DIRTY_CULL_PLANES);
+			gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 		}
 	}
 
@@ -1115,7 +1115,7 @@ void SoftGPU::Execute_ViewMtxData(u32 op, u32 diff) {
 		if (newVal != *target) {
 			*target = newVal;
 			dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
-			gstate_c.Dirty(DIRTY_CULL_PLANES);
+			gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 		}
 	}
 
@@ -1136,7 +1136,7 @@ void SoftGPU::Execute_ProjMtxData(u32 op, u32 diff) {
 		if (newVal != *target) {
 			*target = newVal;
 			dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
-			gstate_c.Dirty(DIRTY_CULL_PLANES);
+			gstate_c.Dirty(DIRTY_CULL_PLANES | DIRTY_WORLD_VIEW_PROJ_MATRIX | DIRTY_VIEW_PROJ_MATRIX);
 		}
 	}
 


### PR DESCRIPTION
Uses them to simplify bbox culling plane setup.

- Later, this will be used in #21715 to detect when we need to apply clipping, which will be valuable for the expensive fallbacks when some GPU functionality is missing.