### PR TITLE
libretro: call SetGLCoreContext(true) in LibretroGLCoreContext

### DIFF
--- a/libretro/LibretroGLCoreContext.cpp
+++ b/libretro/LibretroGLCoreContext.cpp
@@ -24,6 +24,13 @@ void LibretroGLCoreContext::CreateDrawContext() {
 		}
 #endif
 		glewInitDone = true;
+		// We requested RETRO_HW_CONTEXT_OPENGL_CORE; tell GLFeatures so the
+		// Core-profile workaround in CheckGLExtensions (which force-enables
+		// ARB_framebuffer_object / ARB_vertex_array_object) fires. Apple's
+		// Core driver doesn't list these as extensions, so without this both
+		// stay false and glBindFramebuffer(default) silently no-ops in
+		// GLQueueRunner::fbo_unbind on macOS → black screen.
+		SetGLCoreContext(true);
 		CheckGLExtensions();
 	}
 	draw_ = Draw::T3DCreateGLContext(false);


### PR DESCRIPTION
LibretroGLCoreContext is the backend for `RETRO_HW_CONTEXT_OPENGL_CORE`, so the frontend hands us a desktop GL Core profile context — but `CreateDrawContext()` never told GLFeatures, so `useCoreContext` stayed at its default `false` and `gl_extensions.IsCoreContext` stayed `false`.

The consequence is at `Common/GPU/OpenGL/GLFeatures.cpp:532`, where the Core-profile workaround that force-enables `ARB_framebuffer_object` (because Apple's Core driver doesn't list it in the extension string) is gated on `IsCoreContext`. With that gate off, `gl_extensions.ARB_framebuffer_object` stays `false`. Every `glBindFramebuffer(GL_FRAMEBUFFER, g_defaultFBO)` in `GLQueueRunner::fbo_unbind` then falls through both branches and never actually binds — so the `BackBuffer` present pass renders into nothing and the screen stays black on macOS, with `GL_INVALID_OPERATION` accumulating each frame. Audio and game logic still run.

I hit this while integrating PPSSPP libretro into a custom Qt/Metal frontend on macOS. I haven't verified RetroArch's behavior — possibly its env-callback path happens to dodge this, or it's silently broken too. Either way the call seems clearly missing, since this backend exists specifically to wrap the Core profile context.

One-line fix: call `SetGLCoreContext(true)` before `CheckGLExtensions()` in `LibretroGLCoreContext::CreateDrawContext()`. Confirmed locally on macOS 15 / Apple Silicon (x86_64 under Rosetta) that PSP rendering now lands in the frontend's framebuffer end-to-end.

Thanks for the review.