### PR TITLE
Windows: Cache unsupported HID device paths during HID controller polling

### DIFF
--- a/Windows/Hid/HidInputDevice.cpp
+++ b/Windows/Hid/HidInputDevice.cpp
@@ -81,7 +81,7 @@ static const HIDControllerInfo *GetGamepadInfo(const HIDD_ATTRIBUTES &attr) {
 	return nullptr;
 }
 
-static HANDLE OpenFirstHIDController(HIDControllerType *subType, int *reportSize, int *outReportSize, const HIDControllerInfo **outInfo) {
+static HANDLE OpenFirstHIDController(std::unordered_set<std::wstring> &ignoreHidDevicePaths, HIDControllerType *subType, int *reportSize, int *outReportSize, const HIDControllerInfo **outInfo) {
 	GUID hidGuid;
 	HidD_GetHidGuid(&hidGuid);
 
@@ -104,6 +104,11 @@ static HANDLE OpenFirstHIDController(HIDControllerType *subType, int *reportSize
 			continue;
 		}
 
+		std::wstring hidDevicePath = detailData->DevicePath;
+		if (ignoreHidDevicePaths.find(hidDevicePath) != ignoreHidDevicePaths.end()) {
+			continue;
+		}
+
 		HANDLE handle = CreateFile(detailData->DevicePath, GENERIC_READ | GENERIC_WRITE,
 			FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
 		if (handle == INVALID_HANDLE_VALUE) {
@@ -120,6 +125,7 @@ static HANDLE OpenFirstHIDController(HIDControllerType *subType, int *reportSize
 		*outInfo = info;
 		if (!info) {
 			CloseHandle(handle);
+			ignoreHidDevicePaths.insert(hidDevicePath);
 			continue;
 		}
 
@@ -223,7 +229,7 @@ int HidInputDevice::UpdateState() {
 		if (pollCount_ == 0) {
 			pollCount_ = POLL_FREQ;
 			const HIDControllerInfo *info{};
-			HANDLE newController = OpenFirstHIDController(&subType_, &inReportSize_, &outReportSize_, &info);
+			HANDLE newController = OpenFirstHIDController(ignoreHidDevicePaths_, &subType_, &inReportSize_, &outReportSize_, &info);
 			if (newController) {
 				controller_ = newController;
 				if (info) {

--- a/Windows/Hid/HidInputDevice.h
+++ b/Windows/Hid/HidInputDevice.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <set>
+#include <unordered_set>
 
 #include "Common/CommonTypes.h"
 #include "Common/Input/InputState.h"
@@ -63,6 +64,7 @@ private:
 	HIDControllerType subType_{};
 	HANDLE controller_;
 	std::string name_;
+	std::unordered_set<std::wstring> ignoreHidDevicePaths_;
 	int pad_ = 0;
 	int pollCount_ = 0;
 	int inReportSize_ = 0;


### PR DESCRIPTION
Cache non-gamepad/unsupported HID device paths to avoid checking devices that have previously been identified as unsupported during periodic controller polling.
Unsupported HID device paths are cached for the lifetime of the process.

After investigating an issue where inputs would occasionally be missed, I found once every ~4 seconds, an iteration in the input thread would take ~120ms to complete, preventing `XinputDevice` from polling for inputs.

I traced this to `HidInputDevice`'s controller polling, specifically calls to `HidD_GetAttributes`.

On my pc, `HidD_GetAttributes` is called for two non-gamepad HID devices (an Apple watch charger and my motherboard's LED controller), each taking ~60ms to return.

Since the number of connected HID devices vary between systems, the severity and reproducibilty likely varies between users. This may be related to #21676

I was able to reproduce the issue using a python script with vgamepad to repeatedly send button presses from a virtual xbox 360 controller, experiencing missed inputs whenever a button press was made during a HID scan.

This change caches unsupported HID device paths when `GetGamepadInfo` returns a null pointer, preventing repeated calls to `HidD_GetAttribute` for the same unsupported HID devices.

Following the change I can no longer reproduce the issue.

AI assistance disclosure: I used ChatGPT as a debugging aid, to break down/explain code I find difficult to understand, and discussing possible solutions and tradeoffs. All code changes were implemented and tested by me.
