### PR TITLE
Reimplement fast-culling code using CrossSIMD

### DIFF
--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -173,13 +173,20 @@ struct Vec4S32 {
 	// NOTE: This uses a CrossSIMD wrapper if we don't compile with SSE4 support, and is thus slow.
 	Vec4S32 operator *(Vec4S32 other) const { return Vec4S32{ _mm_mullo_epi32_SSE2(v, other.v) }; }  // (ab3,ab2,ab1,ab0)
 
-	Vec4S32 CompareEq(Vec4S32 other) const { return Vec4S32{ _mm_cmpeq_epi32(v, other.v) }; }
-	Vec4S32 CompareLt(Vec4S32 other) const { return Vec4S32{ _mm_cmplt_epi32(v, other.v) }; }
-	Vec4S32 CompareGt(Vec4S32 other) const { return Vec4S32{ _mm_cmpgt_epi32(v, other.v) }; }
+	Vec4S32 CompareEq(Vec4S32 other) const { return Vec4S32{ _mm_cmpeq_epi32(v, other.v)}; }
+	Vec4S32 CompareLt(Vec4S32 other) const { return Vec4S32{ _mm_cmplt_epi32(v, other.v)}; }
+	Vec4S32 CompareLe(Vec4S32 other) const { return Vec4S32{ _mm_cmpgt_epi32(other.v, v) }; }
+	Vec4S32 CompareGt(Vec4S32 other) const { return Vec4S32{ _mm_cmpgt_epi32(v, other.v)}; }
+	Vec4S32 CompareGe(Vec4S32 other) const { return Vec4S32{ _mm_cmplt_epi32(other.v, v) }; }
 };
 
 inline bool AnyZeroSignBit(Vec4S32 value) {
 	return _mm_movemask_ps(_mm_castsi128_ps(value.v)) != 0xF;
+}
+
+// These are for evaluating compare masks.
+inline bool AllCompareBitsSet(Vec4S32 value) {
+	return _mm_movemask_ps(_mm_castsi128_ps(value.v)) == 0xF;
 }
 
 struct Vec4F32 {
@@ -254,6 +261,9 @@ struct Vec4F32 {
 	Vec4F32 operator +(Vec4F32 other) const { return Vec4F32{ _mm_add_ps(v, other.v) }; }
 	Vec4F32 operator -(Vec4F32 other) const { return Vec4F32{ _mm_sub_ps(v, other.v) }; }
 	Vec4F32 operator *(Vec4F32 other) const { return Vec4F32{ _mm_mul_ps(v, other.v) }; }
+	Vec4F32 operator &(Vec4S32 other) const { return Vec4F32{ _mm_and_ps(v, _mm_castsi128_ps(other.v))}; }
+	Vec4F32 operator |(Vec4S32 other) const { return Vec4F32{ _mm_or_ps(v, _mm_castsi128_ps(other.v))}; }
+	Vec4F32 operator ^(Vec4S32 other) const { return Vec4F32{ _mm_xor_ps(v, _mm_castsi128_ps(other.v))}; }
 	Vec4F32 Min(Vec4F32 other) const { return Vec4F32{ _mm_min_ps(v, other.v) }; }
 	Vec4F32 Max(Vec4F32 other) const { return Vec4F32{ _mm_max_ps(v, other.v) }; }
 	void operator +=(Vec4F32 other) { v = _mm_add_ps(v, other.v); }
@@ -261,6 +271,8 @@ struct Vec4F32 {
 	void operator *=(Vec4F32 other) { v = _mm_mul_ps(v, other.v); }
 	void operator /=(Vec4F32 other) { v = _mm_div_ps(v, other.v); }
 	void operator &=(Vec4S32 other) { v = _mm_and_ps(v, _mm_castsi128_ps(other.v)); }
+	void operator |=(Vec4S32 other) { v = _mm_or_ps(v, _mm_castsi128_ps(other.v)); }
+	void operator ^=(Vec4S32 other) { v = _mm_xor_ps(v, _mm_castsi128_ps(other.v)); }
 	Vec4F32 operator *(float f) const { return Vec4F32{_mm_mul_ps(v, _mm_set1_ps(f))}; }
 	void operator *=(float f) { v = _mm_mul_ps(v, _mm_set1_ps(f)); }
 	// NOTE: May be slow.
@@ -300,6 +312,14 @@ struct Vec4F32 {
 		};
 	}
 
+	// Useful shuffles.
+	Vec4F32 ShuffleYYXX() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(1, 1, 0, 0))}; }
+	Vec4F32 ShuffleZZWW() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(3, 3, 2, 2))}; }
+	Vec4F32 ShuffleXXXX() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(0, 0, 0, 0))}; }
+	Vec4F32 ShuffleYYYY() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(1, 1, 1, 1))}; }
+	Vec4F32 ShuffleZZZZ() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(2, 2, 2, 2))}; }
+	Vec4F32 ShuffleWWWW() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(3, 3, 3, 3))}; }
+
 	static void Transpose(Vec4F32 &col0, Vec4F32 &col1, Vec4F32 &col2, Vec4F32 &col3) {
 		_MM_TRANSPOSE4_PS(col0.v, col1.v, col2.v, col3.v);
 	}
@@ -315,7 +335,9 @@ struct Vec4F32 {
 
 	Vec4S32 CompareEq(Vec4F32 other) const { return Vec4S32{ _mm_castps_si128(_mm_cmpeq_ps(v, other.v)) }; }
 	Vec4S32 CompareLt(Vec4F32 other) const { return Vec4S32{ _mm_castps_si128(_mm_cmplt_ps(v, other.v)) }; }
-	Vec4S32 CompareGt(Vec4F32 other) const { return Vec4S32{ _mm_castps_si128(_mm_cmpgt_ps(v, other.v)) }; }
+	Vec4S32 CompareGt(Vec4F32 other) const { return Vec4S32{_mm_castps_si128(_mm_cmpgt_ps(v, other.v))}; }
+	Vec4S32 CompareGe(Vec4F32 other) const { return Vec4S32{_mm_castps_si128(_mm_cmpge_ps(v, other.v))}; }
+	Vec4S32 CompareLe(Vec4F32 other) const { return Vec4S32{ _mm_castps_si128(_mm_cmple_ps(v, other.v)) }; }
 
 	template<int i> float GetLane() const {
 		return _mm_cvtss_f32(_mm_shuffle_ps(v, v, _MM_SHUFFLE(i, i, i, i)));
@@ -327,6 +349,9 @@ inline Vec4F32 Vec4F32FromS32(Vec4S32 f) { return Vec4F32{ _mm_cvtepi32_ps(f.v) 
 
 inline bool AnyZeroSignBit(Vec4F32 value) {
 	return _mm_movemask_ps(value.v) != 0xF;
+}
+inline bool AllCompareBitsSet(Vec4F32 value) {
+	return _mm_movemask_ps(value.v) == 0xF;
 }
 
 // Make sure the W component of scale is 1.0f.
@@ -523,6 +548,8 @@ struct Vec4S32 {
 	Vec4S32 AndNot(Vec4S32 inverted) const { return Vec4S32{ vandq_s32(v, vmvnq_s32(inverted.v))}; }
 	Vec4S32 Mul(Vec4S32 other) const { return Vec4S32{ vmulq_s32(v, other.v) }; }
 	void operator &=(Vec4S32 other) { v = vandq_s32(v, other.v); }
+	void operator |=(Vec4S32 other) { v = vorrq_s32(v, other.v); }
+	void operator ^=(Vec4S32 other) { v = veorq_s32(v, other.v); }
 
 	template<int imm>
 	Vec4S32 Shl() const { return Vec4S32{ vshlq_n_s32(v, imm) }; }
@@ -603,7 +630,10 @@ struct Vec4F32 {
 
 	Vec4F32 operator +(Vec4F32 other) const { return Vec4F32{ vaddq_f32(v, other.v) }; }
 	Vec4F32 operator -(Vec4F32 other) const { return Vec4F32{ vsubq_f32(v, other.v) }; }
-	Vec4F32 operator *(Vec4F32 other) const { return Vec4F32{ vmulq_f32(v, other.v) }; }
+	Vec4F32 operator *(Vec4F32 other) const { return Vec4F32{ vmulq_f32(v, other.v)}; }
+	Vec4F32 operator &(Vec4S32 other) const { return Vec4F32{ vreinterpretq_f32_s32(vandq_s32(vreinterpretq_s32_f32(v), other.v))}; }
+	Vec4F32 operator |(Vec4S32 other) const { return Vec4F32{ vreinterpretq_f32_s32(vorrq_s32(vreinterpretq_s32_f32(v), other.v))}; }
+	Vec4F32 operator ^(Vec4S32 other) const { return Vec4F32{ vreinterpretq_f32_s32(veorq_s32(vreinterpretq_s32_f32(v), other.v))}; }
 	Vec4F32 Min(Vec4F32 other) const { return Vec4F32{ vminq_f32(v, other.v) }; }
 	Vec4F32 Max(Vec4F32 other) const { return Vec4F32{ vmaxq_f32(v, other.v) }; }
 	void operator +=(Vec4F32 other) { v = vaddq_f32(v, other.v); }
@@ -616,6 +646,8 @@ struct Vec4F32 {
 	void operator /=(Vec4F32 other) { v = vmulq_f32(v, other.Recip().v); }
 #endif
 	void operator &=(Vec4S32 other) { v = vreinterpretq_f32_s32(vandq_s32(vreinterpretq_s32_f32(v), other.v)); }
+	void operator |=(Vec4S32 other) { v = vreinterpretq_f32_s32(vorrq_s32(vreinterpretq_s32_f32(v), other.v)); }
+	void operator ^=(Vec4S32 other) { v = vreinterpretq_f32_s32(veorq_s32(vreinterpretq_s32_f32(v), other.v)); }
 	Vec4F32 operator *(float f) const { return Vec4F32{ vmulq_f32(v, vdupq_n_f32(f)) }; }
 	void operator *=(float f) { v = vmulq_f32(v, vdupq_n_f32(f)); }
 
@@ -650,6 +682,22 @@ struct Vec4F32 {
 	Vec4F32 WithLane3One() const {
 		return Vec4F32{ vsetq_lane_f32(1.0f, v, 3) };
 	}
+
+	Vec4F32 ShuffleXXYY() const {
+		float32x2_t low = vget_low_f32(v);  // {X, Y} pair
+		// Combine them into {X, X, Y, Y}
+		return Vec4F32{vcombine_f32(vdup_lane_f32(low, 0), vdup_lane_f32(low, 1))};
+	}
+	Vec4F32 ShuffleZZWW() const {
+		float32x2_t high = vget_high_f32(v);  // {Z, W} pair
+		// Combine them into {Z, Z, W, W}
+		return Vec4F32{vcombine_f32(vdup_lane_f32(high, 0), vdup_lane_f32(high, 1))};
+	}
+
+	Vec4F32 ShuffleXXXX() const { return Vec4F32{vdupq_lane_f32(vget_low_f32(v), 0)}; }
+	Vec4F32 ShuffleYYYY() const { return Vec4F32{vdupq_lane_f32(vget_low_f32(v), 1)}; }
+	Vec4F32 ShuffleZZZZ() const { return Vec4F32{vdupq_lane_f32(vget_high_f32(v), 0)}; }
+	Vec4F32 ShuffleWWWW() const { return Vec4F32{vdupq_lane_f32(vget_high_f32(v), 1)}; }
 
 	Vec4S32 CompareEq(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vceqq_f32(v, other.v)) }; }
 	Vec4S32 CompareLt(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vcltq_f32(v, other.v)) }; }
@@ -734,6 +782,17 @@ inline bool AnyZeroSignBit(Vec4S32 value) {
 	int32x2_t prod = vand_s32(vget_low_s32(value.v), vget_high_s32(value.v));
 	int mask = vget_lane_s32(prod, 0) & vget_lane_s32(prod, 1);
 	return (mask & 0x80000000) == 0;
+#endif
+}
+
+inline bool AllCompareBitsSet(Vec4S32 value) {
+#if PPSSPP_ARCH(ARM64_NEON)
+	return vminvq_u32(vreinterpretq_u32_s32(value.v)) == 0xFFFFFFFF;
+#else
+	// Very suboptimal, let's optimize later.
+	int32x2_t prod = vand_s32(vget_low_s32(value.v), vget_high_s32(value.v));
+	int mask = vget_lane_s32(prod, 0) & vget_lane_s32(prod, 1);
+	return mask == 0xFFFFFFFF;
 #endif
 }
 
@@ -929,6 +988,8 @@ struct Vec4S32 {
 	Vec4S32 AndNot(Vec4S32 inverted) const { return Vec4S32{ __lsx_vandn_v(inverted.v, v) }; }
 	Vec4S32 Mul(Vec4S32 other) const { return Vec4S32{ __lsx_vmul_w(v, other.v) }; }
 	void operator &=(Vec4S32 other) { v = __lsx_vand_v(v, other.v); }
+	void operator |=(Vec4S32 other) { v = __lsx_vor_v(v, other.v); }
+	void operator ^=(Vec4S32 other) { v = __lsx_vxor_v(v, other.v); }
 
 	template<int imm>
 	Vec4S32 Shl() const { return Vec4S32{ __lsx_vslli_w(v, imm) }; }
@@ -1009,7 +1070,10 @@ struct Vec4F32 {
 
 	Vec4F32 operator +(Vec4F32 other) const { return Vec4F32{ (__m128)__lsx_vfadd_s(v, other.v) }; }
 	Vec4F32 operator -(Vec4F32 other) const { return Vec4F32{ (__m128)__lsx_vfsub_s(v, other.v) }; }
-	Vec4F32 operator *(Vec4F32 other) const { return Vec4F32{ (__m128)__lsx_vfmul_s(v, other.v) }; }
+	Vec4F32 operator *(Vec4F32 other) const { return Vec4F32{ (__m128)__lsx_vfmul_s(v, other.v)}; }
+	Vec4F32 operator &(Vec4S32 other) const { return Vec4F32{ (__m128)__lsx_vand_v((__m128i)v, other.v)}; }
+	Vec4F32 operator |(Vec4S32 other) const { return Vec4F32{(__m128)__lsx_vor_v((__m128i)v, other.v)}; }
+	Vec4F32 operator ^(Vec4S32 other) const { return Vec4F32{ (__m128)__lsx_vxor_v((__m128i)v, other.v) }; }
 	Vec4F32 Min(Vec4F32 other) const { return Vec4F32{ (__m128)__lsx_vfmin_s(v, other.v) }; }
 	Vec4F32 Max(Vec4F32 other) const { return Vec4F32{ (__m128)__lsx_vfmax_s(v, other.v) }; }
 	void operator +=(Vec4F32 other) { v = (__m128)__lsx_vfadd_s(v, other.v); }
@@ -1017,6 +1081,7 @@ struct Vec4F32 {
 	void operator *=(Vec4F32 other) { v = (__m128)__lsx_vfmul_s(v, other.v); }
 	void operator /=(Vec4F32 other) { v = (__m128)__lsx_vfdiv_s(v, other.v); }
 	void operator &=(Vec4S32 other) { v = (__m128)__lsx_vand_v((__m128i)v, other.v); }
+
 	Vec4F32 operator *(float f) const { return Vec4F32{ (__m128)__lsx_vfmul_s(v, __lsx_vreplfr2vr_s(f)) }; }
 	void operator *=(float f) { v = (__m128)__lsx_vfmul_s(v, __lsx_vreplfr2vr_s(f)); }
 
@@ -1055,6 +1120,38 @@ struct Vec4F32 {
 	Vec4S32 CompareGt(Vec4F32 other) const { return Vec4S32{ (__m128i)__lsx_vfcmp_clt_s(other.v, v) }; }
 	Vec4S32 CompareLe(Vec4F32 other) const { return Vec4S32{ (__m128i)__lsx_vfcmp_cle_s(v, other.v) }; }
 	Vec4S32 CompareGe(Vec4F32 other) const { return Vec4S32{ (__m128i)__lsx_vfcmp_cle_s(other.v, v) }; }
+
+	Vec4F32 ShuffleXXYY() const {
+		// __builtin_lsx_vilvl_w interleaves the lower 32-bit elements of two vectors.
+		// Interleaving 'v' with itself pairs X with X and Y with Y -> {X, X, Y, Y}
+		return Vec4F32{(__m128)__lsx_vilvl_w((__m128i)v, (__m128i)v)};
+	}
+
+	Vec4F32 ShuffleZZWW() const {
+		// __builtin_lsx_vilvh_w interleaves the higher 32-bit elements of two vectors.
+		// Interleaving 'v' with itself pairs Z with Z and W with W -> {Z, Z, W, W}
+		return Vec4F32{(__m128)__lsx_vilvh_w((__m128i)v, (__m128i)v)};
+	}
+
+	Vec4F32 ShuffleXXXX() const {
+		// Replicate/splat lane 0 (X) across all 4 elements
+		return Vec4F32{(__m128)__lsx_vreplvei_w((__m128i)v, 0)};
+	}
+
+	Vec4F32 ShuffleYYYY() const {
+		// Replicate/splat lane 1 (Y) across all 4 elements
+		return Vec4F32{(__m128)__lsx_vreplvei_w((__m128i)v, 1)};
+	}
+
+	Vec4F32 ShuffleZZZZ() const {
+		// Replicate/splat lane 2 (Z) across all 4 elements
+		return Vec4F32{(__m128)__lsx_vreplvei_w((__m128i)v, 2)};
+	}
+
+	Vec4F32 ShuffleWWWW() const {
+		// Replicate/splat lane 3 (W) across all 4 elements
+		return Vec4F32{(__m128)__lsx_vreplvei_w((__m128i)v, 3)};
+	}
 
 	static void Transpose(Vec4F32 &col0, Vec4F32 &col1, Vec4F32 &col2, Vec4F32 &col3) {
 		// Transpose 4x4 matrix using interleave operations
@@ -1119,6 +1216,11 @@ inline bool AnyZeroSignBit(Vec4S32 value) {
 inline bool AnyZeroSignBit(Vec4F32 value) {
 	int mask = __lsx_vpickve2gr_w(__lsx_vmskltz_w((__m128i)value.v), 0);
 	return mask != 0xF;
+}
+
+inline bool AllCompareBitsSet(Vec4S32 value) {
+	int mask = __lsx_vpickve2gr_w(__lsx_vmskltz_w((__m128i)value.v), 0);
+	return mask == 0xF;
 }
 
 struct Vec4U16 {
@@ -1286,6 +1388,8 @@ struct Vec4S32 {
 	Vec4S32 Mul(Vec4S32 other) const { return *this * other; }
 
 	void operator &=(Vec4S32 other) { for (int i = 0; i < 4; i++) v[i] &= other.v[i]; }
+	void operator |=(Vec4S32 other) { for (int i = 0; i < 4; i++) v[i] |= other.v[i]; }
+	void operator ^=(Vec4S32 other) { for (int i = 0; i < 4; i++) v[i] ^= other.v[i]; }
 	void operator +=(Vec4S32 other) { for (int i = 0; i < 4; i++) v[i] += other.v[i]; }
 	void operator -=(Vec4S32 other) { for (int i = 0; i < 4; i++) v[i] -= other.v[i]; }
 
@@ -1509,6 +1613,29 @@ struct Vec4F32 {
 		}
 		return temp;
 	}
+	Vec4F32 ShuffleXXYY() const {
+		return Vec4F32{{ v[0], v[0], v[1], v[1] }};
+	}
+
+	Vec4F32 ShuffleZZWW() const {
+		return Vec4F32{{ v[2], v[2], v[3], v[3] }};
+	}
+
+	Vec4F32 ShuffleXXXX() const {
+		return Vec4F32{{ v[0], v[0], v[0], v[0] }};
+	}
+
+	Vec4F32 ShuffleYYYY() const {
+		return Vec4F32{{ v[1], v[1], v[1], v[1] }};
+	}
+
+	Vec4F32 ShuffleZZZZ() const {
+		return Vec4F32{{ v[2], v[2], v[2], v[2] }};
+	}
+
+	Vec4F32 ShuffleWWWW() const {
+		return Vec4F32{{ v[3], v[3], v[3], v[3] }};
+	}
 
 	// In-place transpose.
 	static void Transpose(Vec4F32 &col0, Vec4F32 &col1, Vec4F32 &col2, Vec4F32 &col3) {
@@ -1556,6 +1683,11 @@ inline bool AnyZeroSignBit(Vec4F32 value) {
 		}
 	}
 	return false;
+}
+
+inline bool AllCompareBitsSet(Vec4S32 value) {
+	if (value.v[0] != 0xFFFFFFFF || value.v[1] != 0xFFFFFFFF || value.v[2] != 0xFFFFFFFF || value.v[3] != 0xFFFFFFFF) return false;
+	return true;
 }
 
 struct Vec4U16 {

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -313,7 +313,7 @@ struct Vec4F32 {
 	}
 
 	// Useful shuffles.
-	Vec4F32 ShuffleYYXX() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(1, 1, 0, 0))}; }
+	Vec4F32 ShuffleXXYY() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(1, 1, 0, 0))}; }
 	Vec4F32 ShuffleZZWW() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(3, 3, 2, 2))}; }
 	Vec4F32 ShuffleXXXX() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(0, 0, 0, 0))}; }
 	Vec4F32 ShuffleYYYY() const { return Vec4F32{_mm_shuffle_ps(v, v, _MM_SHUFFLE(1, 1, 1, 1))}; }

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -438,127 +438,21 @@ static bool TestBoundingBoxFast(const float *worldViewProj, const void *vdata, i
 	// y > -w -> y + w > 0
 	// y < w -> -y + w > 0
 
-#if PPSSPP_ARCH(SSE2)
-
-	alignas(16) static const float sse_planes[8] = { 1, -1, 1, -1 };
-
-	const __m128 worldX = _mm_loadu_ps(worldViewProj);
-	const __m128 worldY = _mm_loadu_ps(worldViewProj + 4);
-	const __m128 worldZ = _mm_loadu_ps(worldViewProj + 8);
-	const __m128 worldW = _mm_loadu_ps(worldViewProj + 12);
-	const __m128 planesXY = _mm_load_ps(sse_planes);
-	__m128 inside = _mm_set1_ps(0.0f);
+	Mat4F32 worldViewProjMat(worldViewProj);
+	alignas(16) static const float planesXYData[4] = { 1, -1, 1, -1 };
+	Vec4F32 planesXY = Vec4F32::LoadAligned(planesXYData);
+	Vec4S32 insideMask = Vec4S32::Zero();
 	for (int i = 0; i < vertexCount; i++) {
 		const float *pos = verts + i * vertStride;
-		__m128 clippos = _mm_add_ps(
-			_mm_add_ps(
-				_mm_mul_ps(worldX, _mm_set1_ps(pos[0])),
-				_mm_mul_ps(worldY, _mm_set1_ps(pos[1]))
-			),
-			_mm_add_ps(
-				_mm_mul_ps(worldZ, _mm_set1_ps(pos[2])),
-				worldW
-			)
-		);
-		// OK, we got the clip space homogenous coordinate.
-		// Check it against the four planes in parallel.
-		// We also later want to extract the Z component and take min/max.
-		__m128 posXY = _mm_shuffle_ps(clippos, clippos, _MM_SHUFFLE(1, 1, 0, 0));
-		__m128 posW = _mm_shuffle_ps(clippos, clippos, _MM_SHUFFLE(3, 3, 3, 3));
-		__m128 planeDist = _mm_add_ps(_mm_mul_ps(posXY, planesXY), posW);
-		inside = _mm_or_ps(inside, _mm_cmpge_ps(planeDist, _mm_setzero_ps()));
+		Vec4F32 objPos = Vec4F32::Load(pos);
+		Vec4F32 clippos = objPos.AsVec3ByMatrix44(worldViewProjMat);
+		Vec4F32 posXY = clippos.ShuffleXXYY();
+		Vec4F32 posW = clippos.ShuffleWWWW();
+		Vec4F32 planeDist = posXY * planesXY + posW;
+		insideMask |= planeDist.CompareGe(Vec4F32::Zero());
 	}
-	// 0xF means that we found at least one vertex inside every one of the planes.
-	// We don't bother with counts, though it wouldn't be hard if we had a use for them.
-	return _mm_movemask_ps(inside) == 0xF;
-#elif PPSSPP_ARCH(ARM_NEON)
-	alignas(16) static const float planesXY[4] = { 1, -1, 1, -1 };
-	const float32x4_t worldX = vld1q_f32(worldViewProj);
-	const float32x4_t worldY = vld1q_f32(worldViewProj + 4);
-	const float32x4_t worldZ = vld1q_f32(worldViewProj + 8);
-	const float32x4_t worldW = vld1q_f32(worldViewProj + 12);
-	const float32x4_t planesMul = vld1q_f32(planesXY);
-	uint32x4_t inside = vdupq_n_u32(0);
-	for (int i = 0; i < vertexCount; i++) {
-		const float *pos = verts + i * vertStride;
-		float32x4_t clippos = vmlaq_n_f32(
-			vmlaq_n_f32(
-				vmlaq_n_f32(worldW, worldX, pos[0]),
-				worldY, pos[1]
-			),
-			worldZ, pos[2]
-		);
-		// OK, we got the clip space homogenous coordinate.
-		// Check it against the four planes in parallel.
-		// Build [x, x, y, y] using vdup_lane
-		float32x2_t xy = vget_low_f32(clippos);
-		float32x4_t posXY = vcombine_f32(vdup_lane_f32(xy, 0), vdup_lane_f32(xy, 1));  // [x, x, y, y]
-		float32x4_t posW = vdupq_laneq_f32(clippos, 3);  // [w, w, w, w]
-		float32x4_t planeDist = vmlaq_f32(posW, posXY, planesMul);
-		inside = vorrq_u32(inside, vcgeq_f32(planeDist, vdupq_n_f32(0.0f)));
-	}
-	uint64_t insideBits = vget_lane_u64(vreinterpret_u64_u16(vmovn_u32(inside)), 0);
-	return ~insideBits == 0;
-#elif PPSSPP_ARCH(LOONGARCH64_LSX)
-	// NOTE: Untested
-	alignas(16) static const float planesXY[4] = { 1, -1, 1, -1 };
-	const __m128 worldX = (__m128)__lsx_vld(worldViewProj, 0);
-	const __m128 worldY = (__m128)__lsx_vld(worldViewProj + 4, 0);
-	const __m128 worldZ = (__m128)__lsx_vld(worldViewProj + 8, 0);
-	const __m128 worldW = (__m128)__lsx_vld(worldViewProj + 12, 0);
-	const __m128 planesMul = (__m128)__lsx_vld(planesXY, 0);
-	__m128 inside = (__m128)__lsx_vreplfr2vr_s(0.0f);
-	for (int i = 0; i < vertexCount; i++) {
-		const float *pos = verts + i * vertStride;
-		// clippos = worldX * pos[0] + worldY * pos[1] + worldZ * pos[2] + worldW
-		__m128 clippos = (__m128)__lsx_vfadd_s(
-			(__m128)__lsx_vfadd_s(
-				(__m128)__lsx_vfmul_s(worldX, (__m128)__lsx_vreplfr2vr_s(pos[0])),
-				(__m128)__lsx_vfmul_s(worldY, (__m128)__lsx_vreplfr2vr_s(pos[1]))
-			),
-			(__m128)__lsx_vfadd_s(
-				(__m128)__lsx_vfmul_s(worldZ, (__m128)__lsx_vreplfr2vr_s(pos[2])),
-				worldW
-			)
-		);
-		// OK, we got the clip space homogenous coordinate.
-		// Check it against the four planes in parallel.
-		// Build [x, x, y, y] using __lsx_vshuf4i_w
-		__m128 posXY = (__m128)__lsx_vshuf4i_w(clippos, 0b01010000);  // [x, x, y, y]
-		__m128 posW = (__m128)__lsx_vshuf4i_w(clippos, 0b11111111);   // [w, w, w, w]
-		__m128 planeDist = (__m128)__lsx_vfmadd_s(planesMul, posXY, posW);
-		inside = (__m128)__lsx_vor_v((__m128i)inside, (__m128i)__lsx_vfcmp_cle_s((__m128)__lsx_vreplfr2vr_s(0.0f), planeDist));
-	}
-	// Check if all 4 lanes are set
-	__m128i mask = (__m128i)__lsx_vseqi_w((__m128i)inside, 0);
-	return __lsx_bz_v(mask);
-#else
-	int inside[4]{};
-	for (int i = 0; i < vertexCount; i++) {
-		const float *pos = verts + i * vertStride;
-		float clippos[4];
-		Vec3ByMatrix44(clippos, pos, gstate_c.worldviewproj);
-		if (clippos[0] > -clippos[3]) { //  x > -w
-			inside[0]++;
-		}
-		if (clippos[0] < clippos[3]) {  //  x < w
-			inside[1]++;
-		}
-		if (clippos[1] > -clippos[3]) { //  y > -w
-			inside[2]++;
-		}
-		if (clippos[1] < clippos[3]) {  //  y < w
-			inside[3]++;
-		}
-	}
-
-	for (int plane = 0; plane < 4; plane++) {
-		if (inside[plane] == 0) {
-			return false;
-		}
-	}
-#endif
-	return true;
+	// At least one vertex is inside one of the planes.
+	return AllCompareBitsSet(insideMask);
 }
 
 bool DrawEngineCommon::TestBoundingBoxFast(const float *worldViewProj, const void *vdata, int vertexCount, const VertexDecoder *dec, u32 vertType) {

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -329,100 +329,10 @@ bool DrawEngineCommon::TestBoundingBox(const void *vdata, const void *inds, int 
 // We could take the min/max during the regular vertex decode, and just skip the draw call if it's trivially culled.
 // This would help games like Midnight Club (that one does a lot of out-of-bounds drawing) immensely.
 template<u32 posFmt>
-static bool TestBoundingBoxFast(const float *worldViewProj, const void *vdata, int vertexCount, const VertexDecoder *dec, u32 vertType, u8 *decoded) {
-	SimpleVertex *corners = (SimpleVertex *)(decoded + 65536 * 12);
-	float *verts = (float *)(decoded + 65536 * 18);
-
-	// Although this may lead to drawing that shouldn't happen, the viewport is more complex on VR.
-	// Let's always say objects are within bounds.
-	if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
-		return true;
-	}
-
+static bool TestBoundingBoxFast(const float *worldViewProj, const void *vdata, int vertexCount, const VertexDecoder *dec, u8 *decoded) {
 	// Simple, most common case.
 	const int stride = dec->VertexSize();
 	const int offset = dec->posoff;
-	int vertStride = 3;
-
-	// TODO: Possibly do the plane tests directly against the source formats instead of converting.
-	switch (vertType & GE_VTYPE_POS_MASK) {
-	case GE_VTYPE_POS_8BIT:
-	{
-#if PPSSPP_ARCH(SSE2)
-		__m128 scaleFactor = _mm_set1_ps(1.0f / 128.0f);
-		for (int i = 0; i < vertexCount; i++) {
-			const s8 *data = (const s8 *)vdata + i * stride + offset;
-			// Load 4 bytes (only first 3 will be used, 4th doesn't matter)
-			int32_t temp;
-			memcpy(&temp, data, sizeof(temp));
-			__m128i bits8 = _mm_cvtsi32_si128(temp);
-			// Unpack 8->16 and 16->32, placing the original bytes in the high byte of each 32-bit lane
-			bits8 = _mm_unpacklo_epi8(bits8, bits8);
-			__m128i bits32 = _mm_unpacklo_epi16(bits8, bits8);
-			// Sign extend with a single shift right by 24
-			bits32 = _mm_srai_epi32(bits32, 24);
-			__m128 pos = _mm_mul_ps(_mm_cvtepi32_ps(bits32), scaleFactor);
-			_mm_storeu_ps(verts + i * 3, pos);
-		}
-#elif PPSSPP_ARCH(ARM_NEON)
-		for (int i = 0; i < vertexCount; i++) {
-			const s8 *data = (const s8 *)vdata + i * stride + offset;
-			// Load 4 bytes (only first 3 will be used, 4th doesn't matter)
-			int32_t temp;
-			memcpy(&temp, data, sizeof(temp));
-			int32x2_t data32x2 = vdup_n_s32(temp);
-			int8x8_t data8 = vreinterpret_s8_s32(data32x2);
-			// Sign extend 8-bit to 16-bit, then to 32-bit
-			int16x8_t data16 = vmovl_s8(data8);
-			int32x4_t data32 = vmovl_s16(vget_low_s16(data16));
-			float32x4_t pos = vcvtq_n_f32_s32(data32, 7);  // >> 7 = division by 128.0f
-			vst1q_f32(verts + i * 3, pos);
-		}
-#else
-		for (int i = 0; i < vertexCount; i++) {
-			const s8 *data = (const s8 *)vdata + i * stride + offset;
-			for (int j = 0; j < 3; j++) {
-				verts[i * 3 + j] = data[j] * (1.0f / 128.0f);
-			}
-		}
-#endif
-		break;
-	}
-	case GE_VTYPE_POS_16BIT:
-	{
-#if PPSSPP_ARCH(SSE2)
-		__m128 scaleFactor = _mm_set1_ps(1.0f / 32768.0f);
-		for (int i = 0; i < vertexCount; i++) {
-			const s16 *data = ((const s16 *)((const s8 *)vdata + i * stride + offset));
-			__m128i bits = _mm_loadl_epi64((const __m128i*)data);
-			// Sign extension. Hacky without SSE4.
-			bits = _mm_srai_epi32(_mm_unpacklo_epi16(bits, bits), 16);
-			__m128 pos = _mm_mul_ps(_mm_cvtepi32_ps(bits), scaleFactor);
-			_mm_storeu_ps(verts + i * 3, pos);  // TODO: use stride 4 to avoid clashing writes?
-		}
-#elif PPSSPP_ARCH(ARM_NEON)
-		for (int i = 0; i < vertexCount; i++) {
-			const s16 *dataPtr = ((const s16 *)((const s8 *)vdata + i * stride + offset));
-			int32x4_t data = vmovl_s16(vld1_s16(dataPtr));
-			float32x4_t pos = vcvtq_n_f32_s32(data, 15);  // >> 15 = division by 32768.0f
-			vst1q_f32(verts + i * 3, pos);
-		}
-#else
-		for (int i = 0; i < vertexCount; i++) {
-			const s16 *data = ((const s16 *)((const s8 *)vdata + i * stride + offset));
-			for (int j = 0; j < 3; j++) {
-				verts[i * 3 + j] = data[j] * (1.0f / 32768.0f);
-			}
-		}
-#endif
-		break;
-	}
-	case GE_VTYPE_POS_FLOAT:
-		// No need to copy in this case, we can just read directly from the source format with a stride.
-		verts = (float *)((uint8_t *)vdata + offset);
-		vertStride = stride / 4;
-		break;
-	}
 
 	// We only check the 4 sides. Near/far won't likely make a huge difference.
 	// We test one vertex against 4 planes to get some SIMD. Vertices need to be transformed to world space
@@ -442,9 +352,20 @@ static bool TestBoundingBoxFast(const float *worldViewProj, const void *vdata, i
 	alignas(16) static const float planesXYData[4] = { 1, -1, 1, -1 };
 	Vec4F32 planesXY = Vec4F32::LoadAligned(planesXYData);
 	Vec4S32 insideMask = Vec4S32::Zero();
-	for (int i = 0; i < vertexCount; i++) {
-		const float *pos = verts + i * vertStride;
-		Vec4F32 objPos = Vec4F32::Load(pos);
+	const s8 *data = (const s8 *)vdata + offset;
+	for (int i = 0; i < vertexCount; i++, data += stride) {
+		Vec4F32 objPos;
+		switch (posFmt) {
+		case GE_VTYPE_POS_8BIT:
+			objPos = Vec4F32::LoadS8Norm(data);
+			break;
+		case GE_VTYPE_POS_16BIT:
+			objPos = Vec4F32::LoadS16Norm((const s16 *)data);
+			break;
+		default:
+			objPos = Vec4F32::Load((const float *)data);
+			break;
+		}
 		Vec4F32 clippos = objPos.AsVec3ByMatrix44(worldViewProjMat);
 		Vec4F32 posXY = clippos.ShuffleXXYY();
 		Vec4F32 posW = clippos.ShuffleWWWW();
@@ -456,6 +377,12 @@ static bool TestBoundingBoxFast(const float *worldViewProj, const void *vdata, i
 }
 
 bool DrawEngineCommon::TestBoundingBoxFast(const float *worldViewProj, const void *vdata, int vertexCount, const VertexDecoder *dec, u32 vertType) {
+	// Although this may lead to drawing that shouldn't happen, the viewport is more complex on VR.
+	// Let's always say objects are within bounds.
+	if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
+		return true;
+	}
+
 	// Modify the transform matrix to take the viewport into account before culling. This is not necessary
 	// for most games, but there are games that rely on outside-viewport draws (such as Dante's Inferno)'s post
 	// processing effects, and we don't want to cull those.
@@ -503,11 +430,11 @@ bool DrawEngineCommon::TestBoundingBoxFast(const float *worldViewProj, const voi
 
 	switch (vertType & GE_VTYPE_POS_MASK) {
 	case GE_VTYPE_POS_8BIT:
-		return ::TestBoundingBoxFast<GE_VTYPE_POS_8BIT>(worldViewProj, vdata, vertexCount, dec, vertType, decoded_);
+		return ::TestBoundingBoxFast<GE_VTYPE_POS_8BIT>(worldViewProj, vdata, vertexCount, dec, decoded_);
 	case GE_VTYPE_POS_16BIT:
-		return ::TestBoundingBoxFast<GE_VTYPE_POS_16BIT>(worldViewProj, vdata, vertexCount, dec, vertType, decoded_);
+		return ::TestBoundingBoxFast<GE_VTYPE_POS_16BIT>(worldViewProj, vdata, vertexCount, dec, decoded_);
 	case GE_VTYPE_POS_FLOAT:
-		return ::TestBoundingBoxFast<GE_VTYPE_POS_FLOAT>(worldViewProj, vdata, vertexCount, dec, vertType, decoded_);
+		return ::TestBoundingBoxFast<GE_VTYPE_POS_FLOAT>(worldViewProj, vdata, vertexCount, dec, decoded_);
 	default:
 		// Shouldn't end up here with the checks outside this function.
 		_dbg_assert_(false);


### PR DESCRIPTION
Adds a bunch new required operations to CrossSIMD, and uses them.

Additionally, merges the two loops allowing simplification and removing temp storage.

Code generation, at least on x86, is excellent, looks pretty much hand written.

This culling code will play a new role in #21715 .