### PR TITLE
Fix some y-flip issues in D3D11. It got broken by recent refactorings.

### DIFF
--- a/Common/GPU/ShaderTranslation.cpp
+++ b/Common/GPU/ShaderTranslation.cpp
@@ -275,6 +275,7 @@ bool TranslateShader(std::string *dest, ShaderLanguage destLang, const ShaderLan
 		spirv_cross::CompilerHLSL::Options options{};
 		options.shader_model = 50;
 		spirv_cross::CompilerGLSL::Options options_common{};
+		options_common.vertex.flip_vert_y = true;
 		options_common.vertex.fixup_clipspace = true;
 		hlsl.set_hlsl_options(options);
 		hlsl.set_common_options(options_common);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1551,10 +1551,6 @@ bool FramebufferManagerCommon::DrawFramebufferToOutput(const DisplayLayoutConfig
 	if (needBackBufferYSwap_) {
 		flags |= OutputFlags::BACKBUFFER_FLIPPED;
 	}
-	// CopyToOutput reverses these, probably to match "up".
-	if (GetGPUBackend() == GPUBackend::DIRECT3D11) {
-		flags |= OutputFlags::POSITION_FLIPPED;
-	}
 
 	constexpr float u0 = 0.0f, u1 = 480.0f / 512.0f;
 	constexpr float v0 = 0.0f, v1 = 1.0f;
@@ -1724,10 +1720,6 @@ void FramebufferManagerCommon::PrepareCopyDisplayToOutput(const DisplayLayoutCon
 		OutputFlags flags = config.iDisplayFilter == SCALE_LINEAR ? OutputFlags::LINEAR : OutputFlags::NEAREST;
 		if (needBackBufferYSwap_) {
 			flags |= OutputFlags::BACKBUFFER_FLIPPED;
-		}
-		// DrawActiveTexture reverses these, probably to match "up".
-		if (GetGPUBackend() == GPUBackend::DIRECT3D11) {
-			flags |= OutputFlags::POSITION_FLIPPED;
 		}
 
 		int actualWidth = (vfb->bufferWidth * vfb->renderWidth) / vfb->width;

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -745,7 +745,7 @@ void PresentationCommon::RunPostshaderPasses(const DisplayLayoutConfig &config, 
 		}
 
 		// If we flipped, we rotate the other way.
-		if ((flags & OutputFlags::BACKBUFFER_FLIPPED) || (flags & OutputFlags::POSITION_FLIPPED)) {
+		if ((flags & OutputFlags::BACKBUFFER_FLIPPED)) {
 			if ((rotation & 1) != 0)
 				rotation ^= 2;
 		}
@@ -784,7 +784,7 @@ void PresentationCommon::RunPostshaderPasses(const DisplayLayoutConfig &config, 
 	}
 
 	// Finally, we compensate the y vertex positions for the backbuffer for any flipping.
-	if ((flags & OutputFlags::POSITION_FLIPPED) || (flags & OutputFlags::BACKBUFFER_FLIPPED)) {
+	if (flags & OutputFlags::BACKBUFFER_FLIPPED) {
 		for (int i = 0; i < 4; i++) {
 			verts[i].y = -verts[i].y;
 		}
@@ -831,11 +831,8 @@ void PresentationCommon::RunPostshaderPasses(const DisplayLayoutConfig &config, 
 
 	if (usePostShader) {
 		// When we render to temp framebuffers during post, we switch position, not UV.
-		// The flipping here is only because D3D has a clip coordinate system that doesn't match their screen coordinate system.
-		// The flipping here is only because D3D has a clip coordinate system that doesn't match their screen coordinate system.
-		bool flipped = flags & OutputFlags::POSITION_FLIPPED;
-		float y0 = flipped ? 1.0f : -1.0f;
-		float y1 = flipped ? -1.0f : 1.0f;
+		float y0 = -1.0f;
+		float y1 = 1.0f;
 		verts[4] = {-1.0f, y0, 0.0f, 0.0f, 0.0f, 0xFFFFFFFF}; // TL
 		verts[5] = {1.0f, y0, 0.0f, 1.0f, 0.0f, 0xFFFFFFFF}; // TR
 		verts[6] = {-1.0f, y1, 0.0f, 0.0f, 1.0f, 0xFFFFFFFF}; // BL

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -74,7 +74,6 @@ enum class OutputFlags {
 	NEAREST = 0x0001,
 	RB_SWIZZLE = 0x0002,
 	BACKBUFFER_FLIPPED = 0x0004,  // Viewport/scissor coordinates are y-flipped.
-	POSITION_FLIPPED = 0x0008,    // Vertex position in the shader is y-flipped relative to the screen.
 	PILLARBOX = 0x0010,           // Squeeze the image horizontally. Used for the DarkStalkers hack.
 };
 ENUM_CLASS_BITOPS(OutputFlags);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -630,15 +630,8 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(const DisplayLayoutConfig &config, 
 
 	fbTex = draw_->CreateTexture(desc);
 
-	switch (GetGPUBackend()) {
-	case GPUBackend::OPENGL:
+	if (GetGPUBackend() == GPUBackend::OPENGL) {
 		outputFlags |= OutputFlags::BACKBUFFER_FLIPPED;
-		break;
-	case GPUBackend::DIRECT3D11:
-		outputFlags |= OutputFlags::POSITION_FLIPPED;
-		break;
-	case GPUBackend::VULKAN:
-		break;
 	}
 
 	presentation_->SourceTexture(fbTex, desc.width, desc.height);


### PR DESCRIPTION
Likely fixes #21726

It didn't just affect libretro.