### PR TITLE
Fix build on aarch64/arm64 FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1277,6 +1277,7 @@ add_library(7zip STATIC
 	ext/lzma-sdk/Bcj2.c
 	ext/lzma-sdk/Bra.c
 	ext/lzma-sdk/Bra86.c
+	ext/lzma-sdk/CpuArch.c
 	ext/lzma-sdk/Delta.c
 	ext/lzma-sdk/Lzma2Dec.c
 	ext/lzma-sdk/LzmaDec.c


### PR DESCRIPTION
Fix build on aarch64/arm64 FreeBSD. Build otherwise fails due to a missing symbol linker error:

ld: error: undefined symbol: CPU_IsSupported_CRC32
>>> referenced by 7zCrc.c
>>>               7zCrc.c.o:(CrcGenerateTable) in archive lib/lib7zip.a
c++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.