### PR TITLE
Add new GTA romhack to compat.ini

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -363,8 +363,10 @@ ULJM05885 = true
 NPJH50825 = true
 # Grand Theft Auto: Liberty City Stories (prototypes)
 ULUX80146 = true
-# Grand Theft Auto: Sindacco Chronicles (romhack)
+# Grand Theft Auto: Sindacco Chronicles (GTA LCS romhack)
 ULUS01826 = true
+# Seen in Liberty City (GTA LCS romhack)
+ULUS11826 = true
 
 # GOW : Ghost of Sparta
 UCUS98737 = true

--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -133,8 +133,11 @@ ULJM05359 = true
 ULJM05885 = true
 ULUS10041 = true
 
-# Grand Theft Auto: Sindacco Chronicles (romhack)
+# Grand Theft Auto: Sindacco Chronicles (GTA LCS romhack)
 ULUS01826 = true
+
+# Seen in Liberty City (GTA LCS romhack)
+ULUS11826 = true
 
 # Grand Theft Auto: Vice City Stories
 NPJH50827 = true
@@ -151,7 +154,7 @@ ULUS10160 = true
 # + 3D stereoscopy  (that can work only with accurate values)
 # * 6DoF motion tracking (that can work with inaccurate values)
 
-# cube.elf (homebrew)
+# cube.elf (homebrew, from https://www.ppsspp.org/legacybuilds/)
 CUBE00772 = 10.0
 
 # 300: March to Glory
@@ -855,8 +858,11 @@ ULJM05359 = 0.5
 ULJM05885 = 0.5
 ULUS10041 = 0.5
 
-# Grand Theft Auto: Sindacco Chronicles (romhack)
+# Grand Theft Auto: Sindacco Chronicles (GTA LCS romhack)
 ULUS01826 = 0.5
+
+# Seen in Liberty City (GTA LCS romhack)
+ULUS11826 = 0.5
 
 # Grand Theft Auto: Vice City Stories
 NPJH50827 = 1.0


### PR DESCRIPTION
Adds the recently released popular GTA LCS romhack, Seen in Liberty City to `compat.ini` and `compatvr.ini`.