### PR TITLE
Remove unnecessary scaling and then un-scaling of through-mode Z coordinates

### DIFF
--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -125,6 +125,8 @@ class VertexReader {
 public:
 	VertexReader(const u8 *base, const DecVtxFormat &decFmt, int vtype) : base_(base), data_(base), decFmt_(decFmt), vtype_(vtype) {}
 
+	// TODO: Only reason we might want to still keep the separation of ReadPosThrough and ReadPosNonThrough is
+	// in case we need to do some rounding for through mode. I doubt it's needed though.
 	void ReadPosAuto(float pos[3]) const {
 		// Only DEC_FLOAT_3 is supported.
 		const float *f = (const float *)(data_ + decFmt_.posoff);
@@ -134,7 +136,7 @@ public:
 			pos[2] = f[2];
 		} else {
 			// Integer value passed in a float. Clamped to 0, 65535.
-			pos[2] = (int)f[2] * (1.0f / 65535.0f);
+			pos[2] = f[2];
 		}
 	}
 
@@ -143,17 +145,11 @@ public:
 		const float *f = (const float *)(data_ + decFmt_.posoff);
 		pos[0] = f[0];
 		pos[1] = f[1];
-		// Integer value passed in a float. Clamped to 0, 65535.
-		pos[2] = (int)f[2] * (1.0f / 65535.0f);
+		// Integer value passed in a float. Clamped to 0, 65535 (but where?)
+		pos[2] = f[2];
 	}
 
 	void ReadPosNonThrough(float pos[3]) const {
-		// Only DEC_FLOAT_3 is supported.
-		const float *f = (const float *)(data_ + decFmt_.posoff);
-		memcpy(pos, f, 12);
-	}
-
-	void ReadPosThroughZ16(float pos[3]) const {
 		// Only DEC_FLOAT_3 is supported.
 		const float *f = (const float *)(data_ + decFmt_.posoff);
 		memcpy(pos, f, 12);

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -760,13 +760,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			}
 		}
 		WRITE(p, "  %sv_fogdepth = fog;\n", compat.vsOutPrefix);
-		if (isModeThrough)	{
-			WRITE(p, "  vec4 outPos = position;\n");
-			WRITE(p, "  outPos.z *= 65536.0;\n");  // TODO: This multiplication should be moved to the vertex decoders for through mode.
-		} else {
-			// The viewport has already been applied here, along with the division.
-			WRITE(p, "  vec4 outPos = position;\n");
-		}
+
+		// If non-through, the viewport has already been applied here.
+		WRITE(p, "  vec4 outPos = position;\n");
 
 		if (fsMinmaxDiscard || fsDepthClamp) {
 			WRITE(p, "  %sv_zw = vec2(outPos.z * outPos.w, outPos.w);\n", compat.vsOutPrefix);

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -350,8 +350,7 @@ ClipVertexData TransformUnit::ReadVertex(const VertexReader &vreader, const Tran
 	ClipVertexData vertex;
 
 	ModelCoords pos;
-	// VertexDecoder normally scales z, but we want it unscaled.
-	vreader.ReadPosThroughZ16(pos.AsArray());
+	vreader.ReadPosThrough(pos.AsArray());
 
 	static Vec3Packedf lastTC;
 	if (state.readUV) {


### PR DESCRIPTION
Second attempt, first one I accidentally pushed to master and it failed tests.

This is just a minor cleanup of something that looked confusing in the code.