### PR TITLE
Avoid soft-transform-and-clip if the near plane matches the final clip plane, and a new compat flag isn't set

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -161,6 +161,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "PersistentFramebuffers", &flags_.PersistentFramebuffers);
 	CheckSetting(iniFile, gameID, "FileCreatedTimeHack", &flags_.FileCreatedTimeHack);
 	CheckSetting(iniFile, gameID, "FastEmulatedGPU", &flags_.FastEmulatedGPU);
+	CheckSetting(iniFile, gameID, "CorrectCullAfterClip", &flags_.CorrectCullAfterClip);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -120,6 +120,7 @@ struct CompatFlags {
 	bool PersistentFramebuffers;
 	bool FileCreatedTimeHack;
 	bool FastEmulatedGPU;
+	bool CorrectCullAfterClip;
 };
 
 struct VRCompat {

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -454,7 +454,7 @@ static bool TestBoundingBoxFast(const float *cullMatrix, const void *vdata, cons
 		}
 	}
 
-	if (AnyCompareBitsSet(anyOutsideMaskZ)) {
+	if (AnyCompareBitsSet(anyOutsideMaskZ) && (!gstate_c.viewportNearPlaneMatchesOutput || PSP_CoreParameter().compat.flags().CorrectCullAfterClip)) {
 		// Some vertices were outside the Z clipping planes. Clip againt Z=-W in software (and do culling, too).
 		// TODO: With a compat flag for Flatout/Sengoku, we'll be able to avoid this in many cases, unless
 		// GPU_USE_CULL_DISTANCE is missing, in which case we need it for culling.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2071,3 +2071,15 @@ NPJH50148 = true
 ULES00262 = true
 ULUS10064 = true
 ULKS46087 = true
+
+[CorrectCullAfterClip]
+# Only two known games need culling to happen accurately *after* clipping: Sengoku Cannon and Flatout.
+
+# Sengoku Cannon
+UCAS40019 = true
+ULJM05021 = true
+
+# Flatout
+ULUS10328 = true
+ULES00968 = true
+ULES00969 = true


### PR DESCRIPTION
Fixes #21776 , and probably some other games where draw calls must match up exactly to avoid z fighting.

Since only two games are known to need the cull-after-clip behavior (previously known as inversion), we flag those and avoid unnecessary soft clipping.

I had hoped to find a dynamic check that would work, but haven't managed to figure out a good one yet.

This will improve performance a little bit in some other games since we can avoid clipping in software at all in many cases.