### PR TITLE
Add a debug window to check active compat flags

### DIFF
--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -130,7 +130,7 @@ private:
 
 class MessagePopupScreen : public PopupScreen {
 public:
-	MessagePopupScreen(std::string_view title, std::string_view message, std::string_view button1, std::string_view button2, std::function<void(bool)> callback)
+	MessagePopupScreen(std::string_view title, std::string_view message, std::string_view button1, std::string_view button2, std::function<void(bool)> callback = nullptr)
 		: PopupScreen(title, button1, button2), message_(message), callback_(callback) {}
 
 	const char *tag() const override { return "MessagePopupScreen"; }

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -44,6 +44,7 @@ void Compatibility::Load(const std::string &gameID) {
 		// This loads from assets.
 		if (compat.LoadFromVFS(g_VFS, "compat.ini")) {
 			CheckSettings(compat, gameID);
+			filesLoaded_.push_back("assets/compat.ini");
 		} else {
 			auto e = GetI18NCategory(I18NCat::ERRORS);
 			std::string msg = ApplySafeSubstitutions(e->T("File not found: %1"), "compat.ini");
@@ -57,6 +58,7 @@ void Compatibility::Load(const std::string &gameID) {
 		Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compat.ini";
 		if (compat2.Load(path)) {
 			CheckSettings(compat2, gameID);
+			filesLoaded_.push_back(path.ToString());
 		}
 	}
 
@@ -67,6 +69,7 @@ void Compatibility::Load(const std::string &gameID) {
 			// This loads from assets.
 			if (compat.LoadFromVFS(g_VFS, "compatvr.ini")) {
 				CheckVRSettings(compat, gameID);
+				filesLoaded_.push_back("assets/compatvr.ini");
 			}
 		}
 
@@ -76,6 +79,7 @@ void Compatibility::Load(const std::string &gameID) {
 			Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compatvr.ini";
 			if (compat2.Load(path)) {
 				CheckVRSettings(compat2, gameID);
+				filesLoaded_.push_back(path.ToString());
 			}
 		}
 	}
@@ -85,6 +89,7 @@ void Compatibility::Clear() {
 	memset(&flags_, 0, sizeof(flags_));
 	memset(&vrCompat_, 0, sizeof(vrCompat_));
 	activeList_.clear();
+	filesLoaded_.clear();
 }
 
 void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
@@ -191,10 +196,14 @@ void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, co
 		section->Get("ALL", &all);
 		if (all) {
 			*flag = true;
+		}
+
+		if (*flag) {
 			if (!activeList_.empty()) {
 				activeList_ += "\n";
 			}
 			activeList_ += option;
+			activeList_ += ": True";
 		}
 	}
 }
@@ -204,6 +213,11 @@ void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, co
 	Section *section = iniFile.GetSection(option);
 	if (section && section->Get(gameID.c_str(), &value)) {
 		*flag = stof(value);
+
+		if (!activeList_.empty()) {
+			activeList_ += "\n";
+		}
+		activeList_ += std::string(option) + ": " + std::to_string(*flag);
 	}
 }
 
@@ -211,6 +225,11 @@ void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, co
 	std::string value;
 	Section *section = iniFile.GetSection(option);
 	if (section && section->Get(gameID.c_str(), &value)) {
-		*flag = stof(value);
+		*flag = stoi(value);
+
+		if (!activeList_.empty()) {
+			activeList_ += ":" + std::to_string(*flag) + "\n";
+		}
+		activeList_ += std::string(option) + ": " + std::to_string(*flag);
 	}
 }

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include <cstdint>
 #include <set>
 
@@ -152,6 +153,8 @@ public:
 	const std::string &GetActiveFlagsString() const {
 		return activeList_;
 	}
+	const std::vector<std::string> &filesLoaded() const { return filesLoaded_; }
+
 
 private:
 	void Clear();
@@ -165,4 +168,5 @@ private:
 	VRCompat vrCompat_{};
 	std::set<std::string> ignored_;
 	std::string activeList_;
+	std::vector<std::string> filesLoaded_;
 };

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -198,6 +198,28 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 		});
 	}
 
+	items->Add(new Choice(dev->T("Compatibility flags")))->OnClick.Add([this](UI::EventParams &e) {
+		auto dev = GetI18NCategory(I18NCat::DEVELOPER);
+		auto di = GetI18NCategory(I18NCat::DIALOG);
+		std::string activeFlags = PSP_CoreParameter().compat.GetActiveFlagsString();
+		std::string compatText = join(di->T("Enabled"), "\n");
+		compatText += activeFlags.empty() ? "None" : activeFlags;
+		compatText += "\n\n";
+		std::string ignored = g_Config.sIgnoreCompatSettings;
+		compatText += join(di->T("Ignored"), ":");
+		if (ignored.empty()) {
+			compatText += " None";
+		} else {
+			compatText += "\n" + ignored;
+		}
+		compatText += "\n\n";
+		compatText += "Loaded files: ";
+		for (const auto &file : PSP_CoreParameter().compat.filesLoaded()) {
+			compatText += "\n" + file;
+		}
+		screenManager()->push(new MessagePopupScreen(dev->T("Compatibility flags"), compatText, di->T("OK"), ""));
+	});
+
 	scroll->Add(items);
 	parent->Add(scroll);
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -55,6 +55,7 @@
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
 
+#include "UI/DevScreens.h"
 #include "UI/EmuScreen.h"
 #include "UI/PauseScreen.h"
 #include "UI/LoadStateConfirmScreen.h"
@@ -795,7 +796,10 @@ void GamePauseScreen::ShowContextMenu(UI::View *menuButton, bool portrait) {
 				finishNextFrame_ = true;
 			}
 		});
-
+		auto dev = GetI18NCategory(I18NCat::DEVELOPER);
+		parent->Add(new Choice(dev->T("DevMenu"), ImageID("I_DEBUGGER")))->OnClick.Add([this](UI::EventParams &e) {
+			screenManager()->push(new DevMenuScreen(gamePath_, I18NCat::DEVELOPER));
+		});
 		if (portrait) {
 			AddExtraOptions(parent);
 		}


### PR DESCRIPTION
It's in the bottom of the DevMenu popup, which you can now access from the three dots on the pause screen (or enable an on-screen button in Tools/Developer Tools).

Hopefully we can get some clarity in why it seems that compat flags are not correctly loaded for some people.