### PR TITLE
Fix muti ringbuffer structures for mpeg By Gemini in Android Studio

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1375,6 +1375,7 @@ static int sceMpegRingbufferAvailableSize(u32 ringbufferAddr) {
 		return hleLogError(Log::Mpeg, SCE_MPEG_ERROR_NOT_YET_INIT, "bad mpeg handle");
 	}
 
+	ctx->mpegRingbufferAddr = ringbufferAddr;
 	if (ctx->mediaengine) {
 		ringbuffer->packetsAvail = ringbuffer->packets - ctx->mediaengine->getRemainSize() / 2048;
 	}

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -180,7 +180,7 @@ MpegContext::~MpegContext() {
 	delete mediaengine;
 }
 void MpegContext::DoState(PointerWrap &p) {
-	auto s = p.Section("MpegContext", 1, 3);
+	auto s = p.Section("MpegContext", 1, 4);
 	if (!s)
 		return;
 	if (s >= 3)
@@ -215,6 +215,21 @@ void MpegContext::DoState(PointerWrap &p) {
 	Do(p, ignoreAvc);
 	Do(p, isAnalyzed);
 	Do<u32, StreamInfo>(p, streamMap);
+	if (s >= 4) {
+		Do(p, streamIgnoreMap);
+	} else if (p.mode == PointerWrap::MODE_READ) {
+		streamIgnoreMap.clear();
+		for (auto const &it : streamMap) {
+			if (it.second.type == MPEG_AVC_STREAM)
+				streamIgnoreMap[it.first] = ignoreAvc;
+			else if (it.second.type == MPEG_ATRAC_STREAM || it.second.type == MPEG_AUDIO_STREAM)
+				streamIgnoreMap[it.first] = ignoreAtrac;
+			else if (it.second.type == MPEG_PCM_STREAM)
+				streamIgnoreMap[it.first] = ignorePcm;
+			else
+				streamIgnoreMap[it.first] = false;
+		}
+	}
 	DoClass(p, mediaengine);
 	ringbufferNeedsReverse = s < 2;
 }
@@ -660,6 +675,7 @@ static int sceMpegRegistStream(u32 mpeg, u32 streamType, u32 streamNum)
 	info.sid = sid;
 	info.needsReset = true;
 	ctx->streamMap[sid] = info;
+	ctx->streamIgnoreMap[sid] = false;
 	return hleLogInfo(Log::Mpeg, sid);
 }
 
@@ -1563,6 +1579,17 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		return hleLogWarning(Log::Mpeg, -1, "invalid video stream %08x", streamId);
 	}
 
+	if (ctx->streamIgnoreMap[streamId]) {
+		avcAu.pts = ctx->mediaengine->getVideoTimeStamp() + ctx->mpegFirstTimestamp;
+		avcAu.dts = avcAu.pts - videoTimestampStep;
+		avcAu.esBuffer = streamInfo->second.num;
+		avcAu.write(auAddr);
+		if (Memory::IsValidAddress(attrAddr)) {
+			Memory::Write_U32(1, attrAddr);
+		}
+		return hleDelayResult(hleLogDebug(Log::Mpeg, 0), "mpeg get avc ignore", 100);
+	}
+
 	if (streamInfo->second.needsReset) {
 		avcAu.pts = 0;
 		streamInfo->second.needsReset = false;
@@ -1651,6 +1678,17 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		// TODO: Why was this changed to not return an error?
 	}
 
+	if (streamInfo != ctx->streamMap.end() && ctx->streamIgnoreMap[streamId]) {
+		atracAu.pts = ctx->mediaengine->getAudioTimeStamp() + ctx->mpegFirstTimestamp;
+		atracAu.dts = atracAu.pts;
+		atracAu.esBuffer = streamInfo->second.num;
+		atracAu.write(auAddr);
+		if (Memory::IsValidAddress(attrAddr)) {
+			Memory::Write_U32(0, attrAddr);
+		}
+		return hleDelayResult(hleLogDebug(Log::Mpeg, 0), "mpeg get atrac ignore", 100);
+	}
+
 	// The audio can end earlier than the video does.
 	if (ringbuffer->packetsAvail == 0) {
 		atracAu.pts = 0;
@@ -1726,34 +1764,8 @@ static u32 sceMpegChangeGetAuMode(u32 mpeg, int streamUid, int mode)
 		return hleLogError(Log::Mpeg, SCE_MPEG_ERROR_INVALID_VALUE, "UNIMPL / unknown streamID");
 	} else {
 		StreamInfo &info = stream->second;
-		DEBUG_LOG(Log::Mpeg, "UNIMPL sceMpegChangeGetAuMode(%08x, %i, %i): changing type=%d", mpeg, streamUid, mode, info.type);
-		switch (info.type) {
-		case MPEG_AVC_STREAM:
-			if (mode == MPEG_AU_MODE_DECODE) {
-				ctx->ignoreAvc = false;
-			} else if (mode == MPEG_AU_MODE_SKIP) {
-				ctx->ignoreAvc = true;
-			}
-			break;
-		case MPEG_AUDIO_STREAM:
-		case MPEG_ATRAC_STREAM:
-			if (mode == MPEG_AU_MODE_DECODE) {
-				ctx->ignoreAtrac = false;
-			} else if (mode == MPEG_AU_MODE_SKIP) {
-				ctx->ignoreAtrac = true;
-			}
-			break;
-		case MPEG_PCM_STREAM:
-			if (mode == MPEG_AU_MODE_DECODE) {
-				ctx->ignorePcm = false;
-			} else if (mode == MPEG_AU_MODE_SKIP) {
-				ctx->ignorePcm = true;
-			}
-			break;
-		default:
-			ERROR_LOG(Log::Mpeg, "UNIMPL sceMpegChangeGetAuMode(%08x, %i, %i): unknown streamID", mpeg, streamUid, mode);
-			break;
-		}
+		DEBUG_LOG(Log::Mpeg, "sceMpegChangeGetAuMode(%08x, %i, %i): changing type=%d", mpeg, streamUid, mode, info.type);
+		ctx->streamIgnoreMap[streamUid] = (mode == MPEG_AU_MODE_SKIP);
 	}
 	return hleNoLog(0);
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1376,7 +1376,12 @@ static int sceMpegRingbufferAvailableSize(u32 ringbufferAddr) {
 	}
 
 	ctx->mpegRingbufferAddr = ringbufferAddr;
-	if (ctx->mediaengine) {
+
+	// PPSSPP doesn't have a fully asynchronous Media Engine thread to constantly drain the buffer.
+	// Games like Ridge Racer 2 rely on this function to implicitly update the available size.
+	// However, we must NOT overwrite packetsAvail if the stream hasn't been initialized/analyzed yet.
+	// This protects manual struct modifications (like in the 'avail' test) prior to stream playback.
+	if (ctx->mediaengine && ctx->isAnalyzed) {
 		ringbuffer->packetsAvail = ringbuffer->packets - ctx->mediaengine->getRemainSize() / 2048;
 	}
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1375,7 +1375,10 @@ static int sceMpegRingbufferAvailableSize(u32 ringbufferAddr) {
 		return hleLogError(Log::Mpeg, SCE_MPEG_ERROR_NOT_YET_INIT, "bad mpeg handle");
 	}
 
-	ctx->mpegRingbufferAddr = ringbufferAddr;
+	if (ctx->mediaengine) {
+		ringbuffer->packetsAvail = ringbuffer->packets - ctx->mediaengine->getRemainSize() / 2048;
+	}
+
 	hleEatCycles(2020);
 	hleReSchedule("mpeg ringbuffer avail");
 
@@ -1542,11 +1545,11 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	avcAu.read(auAddr);
 
 	if (ringbuffer->packetsRead == 0 || ringbuffer->packetsAvail == 0) {
-		avcAu.pts = -1;
-		avcAu.dts = -1;
+		avcAu.pts = 0;
+		avcAu.dts = 0;
 		avcAu.write(auAddr);
 		// TODO: Does this really reschedule?
-		return hleDelayResult(hleLogDebug(Log::Mpeg, SCE_MPEG_ERROR_NO_DATA), "mpeg get avc", mpegDecodeErrorDelayMs);
+		return hleDelayResult(hleLogDebug(Log::Mpeg, SCE_MPEG_ERROR_NO_DATA), "mpeg get avc", 2000);
 	}
 
 	auto streamInfo = ctx->streamMap.find(streamId);
@@ -1578,17 +1581,18 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 
 	if (ctx->mediaengine->IsVideoEnd()) {
 		INFO_LOG(Log::Mpeg, "video end reach. pts: %i dts: %i", (int)avcAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
-		ringbuffer->packetsAvail = 0;
-
+		avcAu.dts = -1;
 		result = SCE_MPEG_ERROR_NO_DATA;
 	}
 
 	// The avcau struct may have been modified by mediaengine, write it back.
 	avcAu.write(auAddr);
 
-	// Jeanne d'Arc return 00000000 as attrAddr here and cause WriteToHardware error
-	if (Memory::IsValidAddress(attrAddr)) {
-		Memory::Write_U32(1, attrAddr);
+	if (result == 0) {
+		// Jeanne d'Arc return 00000000 as attrAddr here and cause WriteToHardware error
+		if (Memory::IsValidAddress(attrAddr)) {
+			Memory::Write_U32(1, attrAddr);
+		}
 	}
 
 	// TODO: sceMpegGetAvcAu seems to modify esSize, and delay when it's > 1000 or something.
@@ -1643,6 +1647,9 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 
 	// The audio can end earlier than the video does.
 	if (ringbuffer->packetsAvail == 0) {
+		atracAu.pts = 0;
+		atracAu.dts = 0;
+		atracAu.write(auAddr);
 		// TODO: Does this really delay?
 		return hleDelayResult(hleLogDebug(Log::Mpeg, SCE_MPEG_ERROR_NO_DATA), "mpeg get atrac", mpegDecodeErrorDelayMs);
 	}
@@ -1656,14 +1663,10 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 
 	int result = 0;
 	atracAu.pts = ctx->mediaengine->getAudioTimeStamp() + ctx->mpegFirstTimestamp;
+	atracAu.dts = atracAu.pts;
 
-	if (ctx->mediaengine->IsVideoEnd()) {
-		INFO_LOG(Log::Mpeg, "video end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
-		ringbuffer->packetsAvail = 0;
-		// TODO: Is this correct?
-		if (!ctx->mediaengine->IsNoAudioData()) {
-			WARN_LOG_REPORT(Log::Mpeg, "Video end without audio end, potentially skipping some audio?");
-		}
+	if (ctx->mediaengine->IsNoAudioData()) {
+		atracAu.dts = -1;
 		result = SCE_MPEG_ERROR_NO_DATA;
 	}
 
@@ -1671,15 +1674,14 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		WARN_LOG(Log::Mpeg, "Audio end reach. pts: %i dts: %i", (int)atracAu.pts, (int)ctx->mediaengine->getLastTimeStamp());
 		ctx->endOfAudioReached = true;
 	}
-	if (ctx->mediaengine->IsNoAudioData()) {
-		result = SCE_MPEG_ERROR_NO_DATA;
-	}
 
 	atracAu.write(auAddr);
 
-	// 3rd birthday return 00000000 as attrAddr here and cause WriteToHardware error
-	if (Memory::IsValidAddress(attrAddr)) {
-		Memory::Write_U32(0, attrAddr);
+	if (result == 0) {
+		// 3rd birthday return 00000000 as attrAddr here and cause WriteToHardware error
+		if (Memory::IsValidAddress(attrAddr)) {
+			Memory::Write_U32(0, attrAddr);
+		}
 	}
 
 	// TODO: Not clear on exactly when this delays.
@@ -1874,6 +1876,11 @@ static u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 	atracAu.pts = ctx->mediaengine->getAudioTimeStamp() + ctx->mpegFirstTimestamp;
 
 	atracAu.write(auAddr);
+
+	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ctx->mpegRingbufferAddr);
+	if (ringbuffer.IsValid()) {
+		ringbuffer->packetsAvail = ringbuffer->packets - ctx->mediaengine->getRemainSize() / 2048;
+	}
 
 	return hleDelayResult(hleLogDebug(Log::Mpeg, 0), "mpeg atrac decode", atracDecodeDelayMs);
 	//hleEatMicro(4000);

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -127,6 +127,7 @@ struct MpegContext {
 	bool ringbufferNeedsReverse = false;
 
 	StreamInfoMap streamMap;
+	std::map<u32, bool> streamIgnoreMap;
 	MediaEngine *mediaengine = nullptr;
 };
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -569,6 +569,17 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 	return true;
 }
 
+bool MediaEngine::setAudioStream(int streamNum) {
+	if (m_audioStream == streamNum)
+		return true;
+
+	m_audioStream = streamNum;
+	if (m_demux) {
+		m_demux->setAudioChannel(streamNum);
+	}
+	return true;
+}
+
 bool MediaEngine::setVideoDim(int width, int height)
 {
 #ifdef USE_FFMPEG

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -69,7 +69,7 @@ public:
 
 	bool setVideoStream(int streamNum, bool force = false);
 	// TODO: Return false if the stream doesn't exist.
-	bool setAudioStream(int streamNum) { m_audioStream = streamNum; return true; }
+	bool setAudioStream(int streamNum);
 
 	u8 *getFrameImage();
 	int getRemainSize();

--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -187,10 +187,16 @@ bool MpegDemux::skipPackHeader() {
 	return true;
 }
 
+void MpegDemux::setAudioChannel(int audioChannel) {
+	if (m_audioChannel != audioChannel) {
+		m_audioChannel = audioChannel;
+		m_audioStream.clear();
+	}
+}
+
 bool MpegDemux::demux(int audioChannel)
 {
-	if (audioChannel >= 0)
-		m_audioChannel = audioChannel;
+	setAudioChannel(audioChannel);
 
 	bool looksValid = false;
 	bool needMore = false;

--- a/Core/HW/MpegDemux.h
+++ b/Core/HW/MpegDemux.h
@@ -16,6 +16,7 @@ public:
 
 	bool addStreamData(const u8 *buf, int addSize);
 	bool demux(int audioChannel);
+	void setAudioChannel(int audioChannel);
 
 	// return its framesize
 	int getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2, s64 *pts = NULL);


### PR DESCRIPTION
And Fix muti ringbuffer structures for mpeg.
Fix #11934 Fix https://github.com/hrydgard/ppsspp/issues/15606

v1.20.4-251-g392a862be2 Ridge Racer 2 log (bad)
https://gist.github.com/sum2012/08042e16c27b9f99d7bd2916344e3be7

Patched log
https://gist.githubusercontent.com/sum2012/b28fc64d6a719c616336a44f3a9603ef/raw/575b479d1b0432b5fb21e6f644ed57b050b150f6/gistfile1.txt

pspautotest for muti ringbuffer structures also by Gemini update 1

[multi2.zip](https://github.com/user-attachments/files/28654732/multi2.zip)


1. Fix for FMV Audio Cut-off
•
Prevented Premature Termination: Removed logic in sceMpegGetAtracAu and sceMpegGetAvcAu that forcibly cleared the ringbuffer's available packets when the video stream ended. This allows audio to continue playing until its own data stream is exhausted.
•
Synchronized Decoder State: Added code to sceMpegAtracDecode to update the ringbuffer's packetsAvail count after audio frames are processed, keeping the HLE state in sync with the internal Media Engine.
2. Fix for "Hang at End" and Infinite Loop
•
Improved Rescheduling: Increased the delay returned on SCE_MPEG_ERROR_NO_DATA from 100μs to 2ms. This significantly reduces CPU overhead and log flooding when the game is waiting for more data or handling the end of a movie.
3. Timestamp and Attribute Signaling (JPCSP Parity)
•
DTS Signaling: Updated sceMpegGetAtracAu and sceMpegGetAvcAu to set the Decode Time Stamp (dts) to -1 when reaching the end of the stream, matching JPCSP's behavior.
•
Error Case Handling: Modified both functions to set pts and dts to 0 and write them back to memory when returning SCE_MPEG_ERROR_NO_DATA due to an empty buffer.
•
Attribute Protection: Wrapped the writes to attrAddr in success checks (if (result == 0)). This prevents the emulator from overwriting valid game data with "success" flags when the function actually failed

The issue where FMV playback was cut short in Ridge Racer 2 was caused by the packetsAvail field of the MPEG ringbuffer becoming out of sync when audio was decoded. PPSSPP's sceMpegAtracDecode was failing to decrement the count of occupied packets in the ringbuffer struct, causing sceMpegRingbufferAvailableSize to eventually report that the buffer was full even when it was actually empty. This led to the game's data-feeding thread (readThread) starving the decoder.

