### PR TITLE
Implement (hopefully) accurate vdot instruction

### DIFF
--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -598,288 +598,98 @@ float Float16ToFloat32(unsigned short l)
 	return f;
 }
 
+// Implementation of vdot instruction. Assumed bitwise-exact
+// to PSP output on all inputs. For details see
+// https://github.com/hrydgard/ppsspp/issues/21070#issuecomment-4640382516
 // Reference C++ version.
 static float vfpu_dot_cpp(const float a[4], const float b[4]) {
-	static const int EXTRA_BITS = 2;
-	float2int result;
-	float2int src[2];
-
-	int32_t exps[4];
-	int32_t mants[4];
-	int32_t signs[4];
-	int32_t max_exp = 0;
-	int32_t last_inf = -1;
-
-	for (int i = 0; i < 4; i++) {
-		src[0].f = a[i];
-		src[1].f = b[i];
-
-		int32_t aexp = get_uexp(src[0].i);
-		int32_t bexp = get_uexp(src[1].i);
-		int32_t amant = get_mant(src[0].i) << EXTRA_BITS;
-		int32_t bmant = get_mant(src[1].i) << EXTRA_BITS;
-
-		exps[i] = aexp + bexp - 127;
-		if (aexp == 255) {
-			// INF * 0 = NAN
-			if ((src[0].i & 0x007FFFFF) != 0 || bexp == 0) {
-				result.i = 0x7F800001;
-				return result.f;
-			}
-			mants[i] = get_mant(0) << EXTRA_BITS;
-			exps[i] = 255;
-		} else if (bexp == 255) {
-			if ((src[1].i & 0x007FFFFF) != 0 || aexp == 0) {
-				result.i = 0x7F800001;
-				return result.f;
-			}
-			mants[i] = get_mant(0) << EXTRA_BITS;
-			exps[i] = 255;
-		} else {
-			// TODO: Adjust precision?
-			uint64_t adjust = (uint64_t)amant * (uint64_t)bmant;
-			mants[i] = (adjust >> (23 + EXTRA_BITS)) & 0x7FFFFFFF;
-		}
-		signs[i] = get_sign(src[0].i) ^ get_sign(src[1].i);
-
-		if (exps[i] > max_exp) {
-			max_exp = exps[i];
-		}
-		if (exps[i] >= 255) {
-			// Infinity minus infinity is not a real number.
-			if (last_inf != -1 && signs[i] != last_inf) {
-				result.i = 0x7F800001;
-				return result.f;
-			}
-			last_inf = signs[i];
-		}
-	}
-
-	int32_t mant_sum = 0;
-	for (int i = 0; i < 4; i++) {
-		int exp = max_exp - exps[i];
-		if (exp >= 32) {
-			mants[i] = 0;
-		} else {
-			mants[i] >>= exp;
-		}
-		if (signs[i]) {
-			mants[i] = -mants[i];
-		}
-		mant_sum += mants[i];
-	}
-
-	uint32_t sign_sum = 0;
-	if (mant_sum < 0) {
-		sign_sum = 0x80000000;
-		mant_sum = -mant_sum;
-	}
-
-	// Truncate off the extra bits now.  We want to zero them for rounding purposes.
-	mant_sum >>= EXTRA_BITS;
-
-	if (mant_sum == 0 || max_exp <= 0) {
-		return 0.0f;
-	}
-
-	int8_t shift = (int8_t)clz32_nonzero(mant_sum) - 8;
-	if (shift < 0) {
-		// Round to even if we'd shift away a 0.5.
-		const uint32_t round_bit = 1 << (-shift - 1);
-		if ((mant_sum & round_bit) && (mant_sum & (round_bit << 1))) {
-			mant_sum += round_bit;
-			shift = (int8_t)clz32_nonzero(mant_sum) - 8;
-		} else if ((mant_sum & round_bit) && (mant_sum & (round_bit - 1))) {
-			mant_sum += round_bit;
-			shift = (int8_t)clz32_nonzero(mant_sum) - 8;
-		}
-		mant_sum >>= -shift;
-		max_exp += -shift;
-	} else {
-		mant_sum <<= shift;
-		max_exp -= shift;
-	}
-	_dbg_assert_msg_((mant_sum & 0x00800000) != 0, "Mantissa wrong: %08x", mant_sum);
-
-	if (max_exp >= 255) {
-		max_exp = 255;
-		mant_sum = 0;
-	} else if (max_exp <= 0) {
-		return 0.0f;
-	}
-
-	result.i = sign_sum | (max_exp << 23) | (mant_sum & 0x007FFFFF);
-	return result.f;
+    int EXTRA_BITS = 2;
+    uint32_t I = uint32_t(1) << 23, J = uint32_t(1) << (23 - EXTRA_BITS);
+    int32_t s[4], e[4], ehi = -2*127;
+    uint32_t p[4];
+    int32_t val = 0;
+    int has_inf = 0;
+    for(int i=0; i < 4; ++i) {
+        uint32_t x, y;
+        memcpy(&x, a + i, sizeof(x));
+        memcpy(&y, b + i, sizeof(y));
+        int32_t ex = int32_t((x >> 23) & 255), ey = int32_t((y >> 23) & 255);
+        uint32_t mx = x & (I - 1), my = y & (I - 1);
+        if(ex == 255 || ey == 255) {
+            // Handle inf/nan.
+            float ret;
+            uint32_t bits = 0x7F800001;
+            memcpy(&ret, &bits, sizeof(ret));
+            int sgn=((x ^ y) >> 31 ? -1 : +1);
+            if(ex == 255 && mx != 0) return ret;      // x=nan
+            if(ey == 255 && my != 0) return ret;      // y=nan
+            if(ex == 255 && ey == 0) return ret;      // inf*0=nan
+            if(ey == 255 && ex == 0) return ret;      // 0*inf=nan
+            if(has_inf && has_inf != sgn) return ret; // inf-inf=nan
+            has_inf=sgn;
+        }
+        // Compute sign/exponent and intermediate product.
+        // Note that "exponent" here is basically ex+ey,
+        // even though IEEE-754 exponent of the product
+        // may be 1 higher (product of 2 numbers in [1;2)
+        // range is in [1;4) range).
+        // Note that product is computed in extra precision,
+        // and using round-to-odd mode (for details see
+        // https://github.com/hrydgard/ppsspp/issues/21070#issuecomment-4640372343).
+        s[i] = int32_t((x ^ y) >> 31);
+        e[i] = int32_t(ex + ey) - 2 * 127;
+        uint64_t v = uint64_t(I + mx) * uint64_t(I + my);
+        p[i] = uint32_t(v >> (23 - EXTRA_BITS));
+        if(v & (J - 1)) p[i] |= 1; // round-to-odd
+        if(!(ex && ey)) {e[i] = -2*127; p[i] = 0;} // subnormals -> zero
+        if(e[i] > ehi) ehi = e[i];
+    }
+    if(has_inf) {
+        uint32_t bits = (has_inf < 0 ? 0xFF800000 : 0x7F800000);
+        float ret;
+        memcpy(&ret, &bits, sizeof(bits));
+        return ret;
+    }
+    // Align the terms according to max. exponent and compute
+    // the intermediate sum.
+    // Uses round-to-zero (i.e. truncation) to align; the
+    // sum afterwards is integer (and therefore exact).
+    for(int i=0;i<4;++i) {
+        int32_t d = ehi - e[i];
+        if(d > 28) d = 28;
+        uint32_t v = (p[i] >> d);
+        val += (s[i] ? -1 : +1) * int32_t(v);
+    }
+    uint32_t m = uint32_t(val < 0 ? -val : +val);
+    // Remove the extra precision (using round-to-zero).
+    m >>= EXTRA_BITS;
+    // Adjust significand to 1.xxxxxxxxxxxxxxxxxxxxxxx
+    // (i.e. 2^23 <= m < 2^24), unless 0. Rounding, if any,
+    // is done via round-to-nearest-ties-to-even.
+    if(m) {
+        int b = int(8 - clz32_nonzero(m));
+        ehi += b;
+        if(b > 0) {
+            uint32_t r = uint32_t(1) << (b - 1); // next-after-lsb bit
+            m = (m >> b)+((m & (2 * r - 1)) + ((m >> b) & 1) > r);
+        }
+        if(b < 0) m = m << -b;
+        _dbg_assert_msg_(m >= I && m < 2 * I, "Significand wrong: %08X", m);
+    }
+    else ehi = -128;
+    if(ehi <= -127) {ehi = -127; m = 0;} // subnormals -> zero
+    if(ehi >= +128) {ehi = +128; m = 0;} // inf
+    uint32_t bits = (uint32_t(val < 0) << 31) |
+                    (uint32_t(ehi + 127) << 23) |
+                    uint32_t(m & 0x007FFFFF);
+    float ret;
+    memcpy(&ret, &bits, sizeof(ret));
+    return ret;
 }
-
-#if PPSSPP_ARCH(SSE2)
-
-static inline __m128i mulhi32x4(__m128i a, __m128i b) {
-	__m128i m02 = _mm_mul_epu32(a, b);
-	__m128i m13 = _mm_mul_epu32(
-		_mm_shuffle_epi32(a, _MM_SHUFFLE(3, 3, 1, 1)),
-		_mm_shuffle_epi32(b, _MM_SHUFFLE(3, 3, 1, 1)));
-	__m128i m=_mm_unpacklo_epi32(
-		_mm_shuffle_epi32(m02, _MM_SHUFFLE(3, 2, 3, 1)),
-		_mm_shuffle_epi32(m13, _MM_SHUFFLE(3, 2, 3, 1)));
-	return m;
-}
-
-// Values of rounding_mode:
-//   -1 - detect at runtime
-//    0 - assume round-to-nearest-ties-to-even
-//    1 - round yourself in integer math
-template<int rounding_mode=-1>
-static float vfpu_dot_sse2(const float a[4], const float b[4])
-{
-	static const int EXTRA_BITS = 2;
-
-	bool is_default_rounding_mode = (rounding_mode == 0);
-	if(rounding_mode == -1)
-	{
-		volatile float test05 = 5.9604644775390625e-08f;  // 0.5*2^-23
-		volatile float test15 = 1.78813934326171875e-07f; // 1.5*2^-23
-		const float res15 = 1.0000002384185791015625f;    // 1+2^-22
-		test05 += 1.0f;
-		test15 += 1.0f;
-		is_default_rounding_mode = (test05 == 1.0f && test15 == res15);
-	}
-	__m128 A = _mm_loadu_ps(a);
-	__m128 B = _mm_loadu_ps(b);
-	// Extract exponents.
-	__m128 exp_mask = _mm_castsi128_ps(_mm_set1_epi32(0x7F800000));
-	__m128 eA = _mm_and_ps(A, exp_mask);
-	__m128 eB = _mm_and_ps(B, exp_mask);
-	__m128i exps = _mm_srli_epi32(_mm_add_epi32(
-		_mm_castps_si128(eA),
-		_mm_castps_si128(eB)),23);
-	// Find maximum exponent, stored as float32 in [1;2),
-	// so we can use _mm_max_ps() with normal arguments.
-	__m128 t = _mm_or_ps(_mm_castsi128_ps(exps), _mm_set1_ps(1.0f));
-	t = _mm_max_ps(t, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(t), _MM_SHUFFLE(2, 3, 0, 1))));
-	t = _mm_max_ps(t, _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(t), _MM_SHUFFLE(1, 0, 3, 2))));
-	t = _mm_max_ps(t, _mm_castsi128_ps(_mm_set1_epi32(0x3F80007F)));
-	int32_t mexp = _mm_cvtsi128_si32(_mm_castps_si128(t)) & 511;
-	// NOTE: mexp is doubly-biased, same for exps.
-	int32_t max_exp = mexp - 127;
-	// Fall back on anything weird.
-	__m128 finiteA = _mm_sub_ps(A, A);
-	__m128 finiteB = _mm_sub_ps(B, B);
-	finiteA = _mm_cmpeq_ps(finiteA, finiteA);
-	finiteB = _mm_cmpeq_ps(finiteB, finiteB);
-	if(max_exp >= 255 || _mm_movemask_ps(_mm_and_ps(finiteA, finiteB)) != 15) return vfpu_dot_cpp(a, b);
-	// Extract significands.
-	__m128i mA = _mm_or_si128(_mm_and_si128(_mm_castps_si128(A),_mm_set1_epi32(0x007FFFFF)),_mm_set1_epi32(0x00800000));
-	__m128i mB = _mm_or_si128(_mm_and_si128(_mm_castps_si128(B),_mm_set1_epi32(0x007FFFFF)),_mm_set1_epi32(0x00800000));
-	// Multiply.
-	// NOTE: vfpu_dot does multiplication as
-	// ((x<<EXTRA_BITS)*(y<<EXTRA_BITS))>>(23+EXTRA_BITS),
-	// here we do (x*y)>>(23-EXTRA_BITS-1),
-	// which produces twice the result (neither expression
-	// overflows in our case). We need that because our
-	// variable-shift scheme (below) must shift by at least 1 bit.
-	static const int s = 32-(23 - EXTRA_BITS - 1), s0 = s / 2,s1 = s - s0;
-	// We compute ((x*y)>>shift) as
-	// (((x*y)<<(32-shift))>>32), which we express as
-	// (((x<<s0)*(y<<s1))>>32) (neither shift overflows).
-	__m128i m = mulhi32x4(_mm_slli_epi32(mA, s0), _mm_slli_epi32(mB, s1));
-	// Shift according to max_exp. Since SSE2 doesn't have
-	// variable per-lane shifts, we multiply *again*,
-	// specifically, x>>y turns into (x<<(1<<(32-y)))>>32.
-	// We compute 1<<(32-y) using floating-point casts.
-	// NOTE: the cast for 1<<31 produces the correct value,
-	// since the _mm_cvttps_epi32 error code just happens
-	// to be 0x80000000.
-	// So (since we pre-multiplied m by 2), we need
-	// (m>>1)>>(mexp-exps),
-	// i.e. m>>(mexp+1-exps),
-	// i.e. (m<<(32-(mexp+1-exps)))>>32,
-	// i.e. (m<<(exps-(mexp-31)))>>32.
-	__m128i amounts = _mm_sub_epi32(exps, _mm_set1_epi32(mexp - 31));
-	// Clamp by 0. Both zero and negative amounts produce zero,
-	// since they correspond to right-shifting by 32 or more bits.
-	amounts = _mm_and_si128(amounts, _mm_cmpgt_epi32(amounts, _mm_set1_epi32(0)));
-	// Set up multipliers.
-	__m128i bits = _mm_add_epi32(_mm_set1_epi32(0x3F800000), _mm_slli_epi32(amounts, 23));
-	__m128i muls = _mm_cvttps_epi32(_mm_castsi128_ps(bits));
-	m = mulhi32x4(m, muls);
-	// Extract signs.
-	__m128i signs = _mm_cmpgt_epi32(
-			_mm_set1_epi32(0),
-			_mm_xor_si128(_mm_castps_si128(A), _mm_castps_si128(B)));
-	// Apply signs to m.
-	m = _mm_sub_epi32(_mm_xor_si128(m, signs), signs);
-	// Horizontal sum.
-	// See https://stackoverflow.com/questions/6996764/fastest-way-to-do-horizontal-sse-vector-sum-or-other-reduction
-	__m128i h64 = _mm_shuffle_epi32(m, _MM_SHUFFLE(1, 0, 3, 2));
-	__m128i s64 = _mm_add_epi32(h64, m);
-	__m128i h32 = _mm_shufflelo_epi16(s64, _MM_SHUFFLE(1, 0, 3, 2));
-	__m128i s32 = _mm_add_epi32(s64, h32);
-	int32_t mant_sum = _mm_cvtsi128_si32(s32);
-
-	// The rest is scalar.
-	uint32_t sign_sum = 0;
-	if (mant_sum < 0) {
-		sign_sum = 0x80000000;
-		mant_sum = -mant_sum;
-	}
-
-	// Truncate off the extra bits now.  We want to zero them for rounding purposes.
-	mant_sum >>= EXTRA_BITS;
-
-	if (mant_sum == 0 || max_exp <= 0) {
-		return 0.0f;
-	}
-
-	if(is_default_rounding_mode)
-	{
-		float2int r;
-		r.f = (float)mant_sum;
-		mant_sum = (r.i & 0x007FFFFF) | 0x00800000;
-		max_exp += (r.i >> 23) - 0x96;
-	}
-	else
-	{
-		int8_t shift = (int8_t)clz32_nonzero(mant_sum) - 8;
-		if (shift < 0) {
-			// Round to even if we'd shift away a 0.5.
-			const uint32_t round_bit = 1 << (-shift - 1);
-			if ((mant_sum & round_bit) && (mant_sum & (round_bit << 1))) {
-				mant_sum += round_bit;
-				shift = (int8_t)clz32_nonzero(mant_sum) - 8;
-			} else if ((mant_sum & round_bit) && (mant_sum & (round_bit - 1))) {
-				mant_sum += round_bit;
-				shift = (int8_t)clz32_nonzero(mant_sum) - 8;
-			}
-			mant_sum >>= -shift;
-			max_exp += -shift;
-		} else {
-			mant_sum <<= shift;
-			max_exp -= shift;
-		}
-		_dbg_assert_msg_((mant_sum & 0x00800000) != 0, "Mantissa wrong: %08x", mant_sum);
-	}
-
-	if (max_exp >= 255) {
-		max_exp = 255;
-		mant_sum = 0;
-	} else if (max_exp <= 0) {
-		return 0.0f;
-	}
-
-	float2int result;
-	result.i = sign_sum | (max_exp << 23) | (mant_sum & 0x007FFFFF);
-	return result.f;
-}
-
-#endif // PPSSPP_ARCH(SSE2)
 
 float vfpu_dot(const float a[4], const float b[4]) {
-#if PPSSPP_ARCH(SSE2)
-	return vfpu_dot_sse2(a, b);
-#else
+	// SIMD version(s) not implemented.
 	return vfpu_dot_cpp(a, b);
-#endif
 }
 
 //==============================================================================

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -609,7 +609,7 @@ static float vfpu_dot_cpp(const float a[4], const float b[4]) {
     uint32_t p[4];
     int32_t val = 0;
     int has_inf = 0;
-    for(int i=0; i < 4; ++i) {
+    for (int i = 0; i < 4; i++) {
         uint32_t x, y;
         memcpy(&x, a + i, sizeof(x));
         memcpy(&y, b + i, sizeof(y));
@@ -644,7 +644,7 @@ static float vfpu_dot_cpp(const float a[4], const float b[4]) {
         if(!(ex && ey)) {e[i] = -2*127; p[i] = 0;} // subnormals -> zero
         if(e[i] > ehi) ehi = e[i];
     }
-    if(has_inf) {
+    if (has_inf) {
         uint32_t bits = (has_inf < 0 ? 0xFF800000 : 0x7F800000);
         float ret;
         memcpy(&ret, &bits, sizeof(bits));
@@ -654,7 +654,7 @@ static float vfpu_dot_cpp(const float a[4], const float b[4]) {
     // the intermediate sum.
     // Uses round-to-zero (i.e. truncation) to align; the
     // sum afterwards is integer (and therefore exact).
-    for(int i=0;i<4;++i) {
+    for (int i = 0; i < 4; i++) {
         int32_t d = ehi - e[i];
         if(d > 28) d = 28;
         uint32_t v = (p[i] >> d);
@@ -666,7 +666,7 @@ static float vfpu_dot_cpp(const float a[4], const float b[4]) {
     // Adjust significand to 1.xxxxxxxxxxxxxxxxxxxxxxx
     // (i.e. 2^23 <= m < 2^24), unless 0. Rounding, if any,
     // is done via round-to-nearest-ties-to-even.
-    if(m) {
+    if (m != 0) {
         int b = int(8 - clz32_nonzero(m));
         ehi += b;
         if(b > 0) {
@@ -677,8 +677,8 @@ static float vfpu_dot_cpp(const float a[4], const float b[4]) {
         _dbg_assert_msg_(m >= I && m < 2 * I, "Significand wrong: %08X", m);
     }
     else ehi = -128;
-    if(ehi <= -127) {ehi = -127; m = 0;} // subnormals -> zero
-    if(ehi >= +128) {ehi = +128; m = 0;} // inf
+    if (ehi <= -127) {ehi = -127; m = 0;} // subnormals -> zero
+    if (ehi >= +128) {ehi = +128; m = 0;} // inf
     uint32_t bits = (uint32_t(val < 0) << 31) |
                     (uint32_t(ehi + 127) << 23) |
                     uint32_t(m & 0x007FFFFF);


### PR DESCRIPTION
Hopefully bitwise-exact to PSP.
See https://github.com/hrydgard/ppsspp/issues/21070#issuecomment-4640382516 for details.

Again, massive thanks to danzel for the data.

SIMD version not implemented.

Didn't touch USE_VFPU_DOT, etc., so needs to be enabled if you want to test it.