### PR TITLE
Add sprite border compat flag to monster hunter portable 3rd

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2123,5 +2123,5 @@ ULUS11826 = 0.5
 ULJS00097 = -0.25
 # Monster Hunter Portable 3rd 
 # None HD version (ULJM05800) is not tested yet, should be similar like HD
-NPJB40001 = -0.3
-ULJM05800 = -0.3
+NPJB40001 = -0.4
+ULJM05800 = -0.4

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2121,3 +2121,7 @@ ULUS11826 = 0.5
 # Tales of Destiny 2
 # Unfortunately, this affects game backgrounds negatively, although fixes lines in the menus.
 ULJS00097 = -0.25
+# Monster Hunter Portable 3rd 
+# None HD version (ULJM05800) is not tested yet, should be similar like HD
+NPJB40001 = -0.3
+ULJM05800 = -0.3


### PR DESCRIPTION
In menu and victory ui, border gaps can be seen when linear filter or cubic/nnedi3/spline36 texture scaler is enable . 
Value -0.4 will "Hide" the AF bug on Qualcomm Adreno driver. 
And seens unharmed when ohter filtering mode is selected.