### PR TITLE
Add support for using in-shader CLUT (palette) lookups for regular textures

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -685,7 +685,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				}
 				WRITE(p, "  vec2 tsize = vec2(textureSize(tex, 0).xy);\n");
 				WRITE(p, "  vec2 fraction;\n");
-				WRITE(p, "  bool bilinear = (u_depal_mask_shift_off_fmt >> 0x2Fu) != 0x0u;\n");
+				WRITE(p, "  bool bilinear = (u_depal_mask_shift_off_fmt >> 0x1Fu) != 0x0u;\n");
 				WRITE(p, "  if (bilinear) {\n");
 				WRITE(p, "    uv_round = uv * tsize - vec2(0.5, 0.5);\n");
 				WRITE(p, "    fraction = fract(uv_round);\n");
@@ -694,6 +694,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				WRITE(p, "    uv_round = uv;\n");
 				WRITE(p, "  }\n");
 
+				// TODO: Use fetch here when possible.
 				p.C("  highp vec4 t = ").SampleTexture2D("tex", "uv_round").C(";\n");
 				p.C("  highp vec4 t1 = ").SampleTexture2DOffset("tex", "uv_round", 1, 0).C(";\n");
 				p.C("  highp vec4 t2 = ").SampleTexture2DOffset("tex", "uv_round", 0, 1).C(";\n");

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -944,7 +944,7 @@ Draw2DPipeline *FramebufferManagerCommon::GetReinterpretPipeline(GEBufferFormat 
 
 	Draw2DPipeline *pipeline = reinterpretFromTo_[(int)from][(int)to];
 	if (!pipeline) {
-		pipeline = draw2D_.Create2DPipeline([=](ShaderWriter &shaderWriter) -> Draw2DPipelineInfo {
+		pipeline = draw2D_.Create2DPipeline([from, to](ShaderWriter &shaderWriter) -> Draw2DPipelineInfo {
 			return GenerateReinterpretFragmentShader(shaderWriter, from, to);
 		});
 		reinterpretFromTo_[(int)from][(int)to] = pipeline;

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -193,9 +193,24 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool useBuffe
 		int indexOffset = gstate.getClutIndexStartPos() >> 4;
 		int format = gstate_c.depalTextureFormat;
 		uint32_t val = BytesToUint32(indexMask, indexShift, indexOffset, format);
-		// Poke in a bilinear filter flag in the top bit.
-		if (gstate.isMagnifyFilteringEnabled())
+		// NOTE: This must follow similar logic to TextureCacheCommon::GetSamplingParams -
+		// maybe we can share it somehow.
+		// TOOD: Handle replaced textures.
+		bool bilinear = gstate.isMagnifyFilteringEnabled() && !gstate_c.pixelMapped;
+		switch (g_Config.iTexFiltering) {
+		case TEX_FILTER_FORCE_NEAREST:
+			bilinear = false;
+			break;
+		case TEX_FILTER_FORCE_LINEAR:
+			bilinear = true;
+			break;
+		default:
+			break;
+		}
+		if (bilinear) {
+			// Poke in a bilinear filter flag in the top bit.
 			val |= 0x80000000;
+		}
 		ub->depal_mask_shift_off_fmt = val;
 	}
 }

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -669,7 +669,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 
 		if (hasClutGPU) {
 			WARN_LOG_N_TIMES(clutUseRender, 5, Log::G3D, "Using texture with dynamic CLUT: texfmt=%d, clutfmt=%d", gstate.getTextureFormat(), gstate.getClutPaletteFormat());
-			entry->status |= TexStatus::CLUT_GPU;
+			entry->status |= TexStatus::CLUT_GPU | TexStatus::CLUT8_INDEXED;
 		}
 
 		if (hasClut && clutRenderAddress_ == 0xFFFFFFFF) {
@@ -691,6 +691,8 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 		}
 
 		nextNeedsChange_ = false;
+	} else {
+		// We had an entry already, modify it.
 	}
 
 	// We have to decode it, let's setup the cache entry first.
@@ -703,6 +705,14 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	entry->bufw = bufw;
 
 	entry->cluthash = cluthash;
+
+	/*
+	if (entry->maxLevel == 0 && (entry->format == GE_TFMT_CLUT8 || entry->format == GE_TFMT_CLUT4) &&
+		!(entry->status & TexStatus::TO_REPLACE) && !(entry->status & TexStatus::TO_SCALE) && !(entry->status & TexStatus::RELIABLE)) {
+		// Experiment with CLUT8 decoding for regular textures.
+		entry->status |= TexStatus::CLUT8_INDEXED;
+	}
+	*/
 
 	gstate_c.curTextureWidth = w;
 	gstate_c.curTextureHeight = h;
@@ -720,7 +730,6 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	nextTexture_ = entry;
 	nextFramebufferTexture_ = nullptr;
 	nextNeedsRehash_ = true;
-	// We still need to rebuild, to allocate a texture.  But we'll bail early.
 	nextNeedsRebuild_ = true;
 	return entry;
 }
@@ -2216,16 +2225,16 @@ void TextureCacheCommon::ApplyTexture(bool doBind, bool flatZ) {
 	}
 
 	gstate_c.SetTextureIsVideo((entry->status & TexStatus::VIDEO) != 0);
+	entry->lastFrame = gpuStats.totals.numFlips;
 	if (entry->status & TexStatus::CLUT_GPU) {
+		_dbg_assert_(entry->status & TexStatus::CLUT8_INDEXED);
 		// Special process.
-		ApplyTextureDepal(entry);
-		entry->lastFrame = gpuStats.totals.numFlips;
+		ApplyTextureDepalFramebufferCLUT(entry);
 		gstate_c.SetTextureSolidAlpha(false);
 		gstate_c.SetTextureIs3D(false);
 		gstate_c.SetTextureIsArray(false);
 		gstate_c.SetTextureIsBGRA(false);
 	} else {
-		entry->lastFrame = gpuStats.totals.numFlips;
 		if (doBind) {
 			BindTexture(entry, flatZ);
 		}
@@ -2233,7 +2242,15 @@ void TextureCacheCommon::ApplyTexture(bool doBind, bool flatZ) {
 		gstate_c.SetTextureIs3D((entry->status & TexStatus::IS_3D) != 0);
 		gstate_c.SetTextureIsArray(false);
 		gstate_c.SetTextureIsBGRA((entry->status & TexStatus::BGRA) != 0);
-		gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
+		if (entry->status & TexStatus::CLUT8_INDEXED) {
+			bool smoothedDepal = false;
+			u32 depthUpperBits = 0;
+			ClutTexture clutTexture = clutTextureCache_.GetClutTexture(gstate.getClutPaletteFormat(), clutHash_, clutBuf_);
+			BindAsClutTexture(clutTexture.texture, false);
+			gstate_c.SetShaderDepal(ShaderDepalMode::NORMAL, GE_FORMAT_CLUT8);
+		} else {
+			gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
+		}
 	}
 }
 
@@ -2474,7 +2491,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 }
 
 // Applies depal to a normal (non-framebuffer) texture, pre-decoded to CLUT8 format.
-void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
+void TextureCacheCommon::ApplyTextureDepalFramebufferCLUT(TexCacheEntry *entry) {
 	uint32_t clutMode = gstate.clutformat & 0xFFFFFF;
 
 	switch (entry->format) {
@@ -2881,7 +2898,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	}
 
 	bool canReplace = !isPPGETexture;
-	if (entry->status & TexStatus::CLUT_GPU) {
+	if (entry->status & TexStatus::CLUT8_INDEXED) {
 		_dbg_assert_(entry->format == GE_TFMT_CLUT4 || entry->format == GE_TFMT_CLUT8);
 		plan.decodeToClut8 = true;
 		// We only support 1 mip level when doing CLUT on GPU for now.
@@ -3001,7 +3018,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, s
 		if (!gstate_c.Use(GPU_USE_16BIT_FORMATS) || dstFmt == Draw::DataFormat::R8G8B8A8_UNORM) {
 			texDecFlags |= TexDecodeFlags::EXPAND32;
 		}
-		if (entry.status & (TexStatus::CLUT_GPU | TexStatus::CLUT8_INDEXED)) {
+		if (entry.status & TexStatus::CLUT8_INDEXED) {
 			_dbg_assert_(entry.format == GE_TFMT_CLUT4 || entry.format == GE_TFMT_CLUT8);
 			texDecFlags |= TexDecodeFlags::TO_CLUT8;
 		}
@@ -3079,6 +3096,9 @@ std::string TexStatusToString(TexStatus status) {
 	}
 	if (status & TexStatus::CLUT_GPU) {
 		result += "CLUT_GPU ";
+	}
+	if (status & TexStatus::CLUT8_INDEXED) {
+		result += "CLUT8_INDEXED ";
 	}
 	if (status & TexStatus::FORCE_REBUILD) {
 		result += "FORCE_REBUILD ";

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -462,6 +462,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 		gstate_c.SetTextureIs3D(false);
 		gstate_c.SetTextureIsArray(false);
 		gstate_c.SetTextureIsFramebuffer(false);
+		gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
 		return nullptr;
 	}
 
@@ -600,6 +601,11 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 			gstate_c.SetTextureIsArray(false);
 			gstate_c.SetTextureIsBGRA(entry->status & TexStatus::BGRA);
 			gstate_c.SetTextureIsFramebuffer(false);
+			if (entry->status & TexStatus::CLUT8_INDEXED) {
+				gstate_c.SetShaderDepal(ShaderDepalMode::NORMAL, GE_FORMAT_CLUT8);
+			} else {
+				gstate_c.SetShaderDepal(ShaderDepalMode::OFF, GE_FORMAT_INVALID);
+			}
 
 			if (rehash) {
 				// Update in case any of these changed.
@@ -701,6 +707,11 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	gstate_c.SetTextureIs3D((entry->status & TexStatus::IS_3D) != 0);
 	gstate_c.SetTextureIsArray(false);  // Ordinary 2D textures still aren't used by array view in VK. We probably might as well, though, at this point..
 	gstate_c.SetTextureIsFramebuffer(false);
+	if (entry->status & TexStatus::CLUT8_INDEXED) {
+		gstate_c.SetShaderDepal(ShaderDepalMode::NORMAL, GE_FORMAT_CLUT8);
+	} else {
+		gstate_c.SetShaderDepal(ShaderDepalMode::OFF, GE_FORMAT_INVALID);
+	}
 
 	failedTexture_ = false;
 	nextTexture_ = entry;
@@ -1233,6 +1244,7 @@ void TextureCacheCommon::SetTextureFramebuffer(const AttachCandidate &candidate)
 	gstate_c.SetTextureIsVideo(false);
 	gstate_c.SetTextureIs3D(false);
 	gstate_c.SetTextureIsArray(true);
+	gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
 
 	nextNeedsRehash_ = false;
 	nextNeedsChange_ = false;
@@ -2218,7 +2230,7 @@ void TextureCacheCommon::ApplyTexture(bool doBind, bool flatZ) {
 		gstate_c.SetTextureIs3D((entry->status & TexStatus::IS_3D) != 0);
 		gstate_c.SetTextureIsArray(false);
 		gstate_c.SetTextureIsBGRA((entry->status & TexStatus::BGRA) != 0);
-		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
+		gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
 	}
 }
 
@@ -2358,8 +2370,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 			}
 
 			gstate_c.Dirty(DIRTY_DEPAL | DIRTY_FRAGMENTSHADER_STATE);
-			gstate_c.SetUseShaderDepal(mode);
-			gstate_c.depalTextureFormat = fbFormat;
+			gstate_c.SetShaderDepal(mode, fbFormat);
 
 			const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
 			const u32 clutTotalColors = clutMaxBytes_ / bytesPerColor;
@@ -2373,7 +2384,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		depthUpperBits = (depth && framebuffer->fb_format == GE_FORMAT_8888) ? ((gstate.getTextureAddress(0) & 0x600000) >> 20) : 0;
 
 		textureShader = textureShaderCache_.GetDepalettizeShader(clutMode, texFormat, fbFormat, smoothedDepal, depthUpperBits);
-		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
+		gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
 	}
 
 	if (textureShader) {
@@ -2448,7 +2459,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET, Draw::ALL_LAYERS);
 		BoundFramebufferTexture();
 
-		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
+		gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
 		gstate_c.SetTextureSolidAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 	}
 
@@ -2487,7 +2498,7 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 		dynamicClutTemp_, 0.0f, 0.0f, 512.0f, 1.0f, dynamicClutFbo_, 0.0f, 0.0f, scaleFactorX * 512.0f, 1.0f, false, 1.0f, reinterpret, "reinterpret_clut");
 
 	Draw2DPipeline *textureShader = textureShaderCache_.GetDepalettizeShader(clutMode, GE_TFMT_CLUT8, GE_FORMAT_CLUT8, false, 0);
-	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
+	gstate_c.SetShaderDepal(ShaderDepalMode::OFF);
 
 	int texWidth = gstate.getTextureWidth(0);
 	int texHeight = gstate.getTextureHeight(0);
@@ -2987,7 +2998,8 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, s
 		if (!gstate_c.Use(GPU_USE_16BIT_FORMATS) || dstFmt == Draw::DataFormat::R8G8B8A8_UNORM) {
 			texDecFlags |= TexDecodeFlags::EXPAND32;
 		}
-		if (entry.status & TexStatus::CLUT_GPU) {
+		if (entry.status & (TexStatus::CLUT_GPU | TexStatus::CLUT8_INDEXED)) {
+			_dbg_assert_(entry.format == GE_TFMT_CLUT4 || entry.format == GE_TFMT_CLUT8);
 			texDecFlags |= TexDecodeFlags::TO_CLUT8;
 		}
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -385,20 +385,23 @@ void TextureCacheCommon::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutB
 	clutBuf_ = clutBufRaw_;
 
 	// Special optimization: fonts typically draw clut4 with just alpha values in a single color.
-	clutAlphaLinear_ = false;
-	clutAlphaLinearColor_ = 0;
+	bool alphaLinear = false;
+	u16 alphaLinearColor = 0;
 	if (clutFormat == GE_CMODE_16BIT_ABGR4444 && clutIndexIsSimple) {
-		const u16_le *clut = GetCurrentClut<u16_le>();
-		clutAlphaLinear_ = true;
-		clutAlphaLinearColor_ = clut[15] & 0x0FFF;
+		const u16 *clut = (const u16 *)(clutBuf_);
+		alphaLinear = true;
+		alphaLinearColor = clut[15] & 0x0FFF;
 		for (int i = 0; i < 16; ++i) {
-			u16 step = clutAlphaLinearColor_ | (i << 12);
+			u16 step = alphaLinearColor | (i << 12);
 			if (clut[i] != step) {
-				clutAlphaLinear_ = false;
+				alphaLinear = false;
 				break;
 			}
 		}
 	}
+
+	clutProperties_.clutAlphaLinear = alphaLinear;
+	clutProperties_.clutAlphaLinearColor = alphaLinearColor;
 
 	clutLastFormat_ = gstate.clutformat;
 }
@@ -1841,23 +1844,23 @@ TextureAlpha TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETex
 		{
 			// The w > 1 check is to not need a case that handles a single pixel
 			// in DeIndexTexture4Optimal<u16>.
-			if (clutAlphaLinear_ && mipmapShareClut && !expandTo32bit && w >= 4) {
-				// We don't bother with fullalpha here (clutAlphaLinear_)
+			if (clutProperties_.clutAlphaLinear && mipmapShareClut && !expandTo32bit && w >= 4) {
+				// We don't bother with fullalpha here (clutAlphaLinear)
 				// Here, reverseColors means the CLUT is already reversed.
 				if (reverseColors) {
 					for (int y = 0; y < h; ++y) {
-						DeIndexTexture4Optimal((u16 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, clutAlphaLinearColor_);
+						DeIndexTexture4Optimal((u16 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, clutProperties_.clutAlphaLinearColor);
 					}
 				} else {
 					for (int y = 0; y < h; ++y) {
-						DeIndexTexture4OptimalRev((u16 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, clutAlphaLinearColor_);
+						DeIndexTexture4OptimalRev((u16 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, clutProperties_.clutAlphaLinearColor);
 					}
 				}
 			} else {
 				// Need to have the "un-reversed" (raw) CLUT here since we are using a generic conversion function.
 				if (expandTo32bit) {
 					// We simply expand the CLUT to 32-bit, then we deindex as usual. Probably the fastest way.
-					const u16 *clut = GetCurrentRawClut<u16>() + clutSharingOffset;
+					const u16 *clut = (const u16 *)(clutBufRaw_) + clutSharingOffset;
 					const int clutStart = gstate.getClutIndexStartPos();
 					if (gstate.getClutIndexShift() == 0 || gstate.getClutIndexMask() <= 16) {
 						ConvertFormatToRGBA8888(clutformat, expandClut_ + clutStart, clut + clutStart, 16);
@@ -1871,7 +1874,7 @@ TextureAlpha TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETex
 					}
 				} else {
 					// If we're reversing colors, the CLUT was already reversed, no special handling needed.
-					const u16 *clut = GetCurrentClut<u16>() + clutSharingOffset;
+					const u16 *clut = (const u16 *)(clutBuf_) + clutSharingOffset;
 					fullAlphaMask = ClutFormatToFullAlpha(clutformat, reverseColors);
 					for (int y = 0; y < h; ++y) {
 						DeIndexTexture4<u16>((u16 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, clut, &alphaSum);
@@ -1888,7 +1891,7 @@ TextureAlpha TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETex
 
 		case GE_CMODE_32BIT_ABGR8888:
 		{
-			const u32 *clut = GetCurrentClut<u32>() + clutSharingOffset;
+			const u32 *clut = (const u32 *)(clutBuf_) + clutSharingOffset;
 			fullAlphaMask = 0xFF000000;
 			for (int y = 0; y < h; ++y) {
 				DeIndexTexture4<u32>((u32 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, clut, &alphaSum);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -92,7 +92,7 @@ static bool GetBestFramebufferCandidate(FramebufferManagerCommon *fbManager, con
 // These are Data::Format:: B4G4R4A4_PACK16, B5G6R6_PACK16, B5G5R5A1_PACK16, R8G8B8A8
 
 TextureCacheCommon::TextureCacheCommon(Draw::DrawContext *draw, Draw2D *draw2D)
-	: draw_(draw), draw2D_(draw2D), replacer_(draw) {
+	: draw_(draw), draw2D_(draw2D), replacer_(draw), textureShaderCache_(draw, draw2D_) {
 	decimationCounter_ = TEXCACHE_DECIMATION_INTERVAL;
 
 	// It's only possible to have 1KB of palette entries, although we allow 2KB in a hack.
@@ -111,13 +111,9 @@ TextureCacheCommon::TextureCacheCommon(Draw::DrawContext *draw, Draw2D *draw2D)
 	// These buffers will grow if necessary, but most won't need more than this.
 	tmpTexBuf32_.resize(512 * 512);  // 1MB
 	tmpTexBufRearrange_.resize(512 * 512);   // 1MB
-
-	textureShaderCache_ = new TextureShaderCache(draw, draw2D_);
 }
 
 TextureCacheCommon::~TextureCacheCommon() {
-	delete textureShaderCache_;
-
 	FreeAlignedMemory(clutBufConverted_);
 	FreeAlignedMemory(clutBufRaw_);
 	FreeAlignedMemory(expandClut_);
@@ -125,7 +121,7 @@ TextureCacheCommon::~TextureCacheCommon() {
 
 void TextureCacheCommon::StartFrame() {
 	ForgetLastTexture();
-	textureShaderCache_->Decimate();
+	clutTextureCache_.Decimate();
 	replacementTimeThisFrame_ = 0.0;
 
 	float fps;
@@ -2323,7 +2319,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 
 	if (need_depalettize) {
 		if (clutRenderAddress_ == 0xFFFFFFFF) {
-			clutTexture = textureShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBufRaw_);
+			clutTexture = clutTextureCache_.GetClutTexture(clutFormat, clutHash_, clutBufRaw_);
 			smoothedDepal = CanUseSmoothDepal(gstate, fbFormat, clutTexture);
 		} else {
 			// The CLUT texture is dynamic, it's the framebuffer pointed to by clutRenderAddress.
@@ -2376,7 +2372,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 
 		depthUpperBits = (depth && framebuffer->fb_format == GE_FORMAT_8888) ? ((gstate.getTextureAddress(0) & 0x600000) >> 20) : 0;
 
-		textureShader = textureShaderCache_->GetDepalettizeShader(clutMode, texFormat, fbFormat, smoothedDepal, depthUpperBits);
+		textureShader = textureShaderCache_.GetDepalettizeShader(clutMode, texFormat, fbFormat, smoothedDepal, depthUpperBits);
 		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 	}
 
@@ -2421,8 +2417,8 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		} else {
 			draw_->BindFramebufferAsTexture(dynamicClutFbo_, 1, Draw::Aspect::COLOR_BIT, 0);
 		}
-		Draw::SamplerState *nearest = textureShaderCache_->GetSampler(false);
-		Draw::SamplerState *clutSampler = textureShaderCache_->GetSampler(smoothedDepal);
+		Draw::SamplerState *nearest = textureShaderCache_.GetSampler(false);
+		Draw::SamplerState *clutSampler = textureShaderCache_.GetSampler(smoothedDepal);
 		draw_->BindSamplerStates(0, 1, &nearest);
 		draw_->BindSamplerStates(1, 1, &clutSampler);
 
@@ -2490,7 +2486,7 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	framebufferManager_->BlitUsingRaster(
 		dynamicClutTemp_, 0.0f, 0.0f, 512.0f, 1.0f, dynamicClutFbo_, 0.0f, 0.0f, scaleFactorX * 512.0f, 1.0f, false, 1.0f, reinterpret, "reinterpret_clut");
 
-	Draw2DPipeline *textureShader = textureShaderCache_->GetDepalettizeShader(clutMode, GE_TFMT_CLUT8, GE_FORMAT_CLUT8, false, 0);
+	Draw2DPipeline *textureShader = textureShaderCache_.GetDepalettizeShader(clutMode, GE_TFMT_CLUT8, GE_FORMAT_CLUT8, false, 0);
 	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 
 	int texWidth = gstate.getTextureWidth(0);
@@ -2523,8 +2519,8 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 
 	draw_->BindNativeTexture(0, GetNativeTextureView(entry, false));
 	draw_->BindFramebufferAsTexture(dynamicClutFbo_, 1, Draw::Aspect::COLOR_BIT, 0);
-	Draw::SamplerState *nearest = textureShaderCache_->GetSampler(false);
-	Draw::SamplerState *clutSampler = textureShaderCache_->GetSampler(false);
+	Draw::SamplerState *nearest = textureShaderCache_.GetSampler(false);
+	Draw::SamplerState *clutSampler = textureShaderCache_.GetSampler(false);
 	draw_->BindSamplerStates(0, 1, &nearest);
 	draw_->BindSamplerStates(1, 1, &clutSampler);
 
@@ -2557,8 +2553,20 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	gstate_c.Dirty(DIRTY_ALL_RENDER_STATE);
 }
 
+void TextureCacheCommon::DeviceLost() {
+	textureShaderCache_.DeviceLost();
+	clutTextureCache_.DeviceLost();
+	Clear(false);
+}
+
+void TextureCacheCommon::DeviceRestore(Draw::DrawContext *draw) {
+	draw_ = draw;
+	textureShaderCache_.DeviceRestore(draw);
+	clutTextureCache_.DeviceRestore(draw);
+}
+
 void TextureCacheCommon::Clear(bool delete_them) {
-	textureShaderCache_->Clear();
+	textureShaderCache_.Clear();
 
 	for (TexCache::iterator iter = cache_.begin(); iter != cache_.end(); ++iter) {
 		ReleaseTexture(iter->second.get(), delete_them);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 
+#include "ext/xxhash.h"
 #include "Common/Common.h"
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Collections/TinySet.h"
@@ -367,6 +368,43 @@ SamplerCacheKey TextureCacheCommon::GetFramebufferSamplingParams(u16 bufferWidth
 		key.tClamp = true;
 	}
 	return key;
+}
+
+// NOTE: this is overridden in TextureCacheGLES, with some extra color conversion.
+void TextureCacheCommon::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) {
+	const u32 clutBaseBytes = clutFormat == GE_CMODE_32BIT_ABGR8888 ? (clutBase * sizeof(u32)) : (clutBase * sizeof(u16));
+	// Technically, these extra bytes weren't loaded, but hopefully it was loaded earlier.
+	// If not, we're going to hash random data, which hopefully doesn't cause a performance issue.
+	//
+	// TODO: Actually, this seems like a hack.  The game can upload part of a CLUT and reference other data.
+	// clutTotalBytes_ is the last amount uploaded.  We should hash clutMaxBytes_, but this will often hash
+	// unrelated old entries for small palettes.
+	// Adding clutBaseBytes may just be mitigating this for some usage patterns.
+	const u32 clutExtendedBytes = std::min(clutTotalBytes_ + clutBaseBytes, clutMaxBytes_);
+
+	if (replacer_.Enabled())
+		clutHash_ = XXH32((const char *)clutBufRaw_, clutExtendedBytes, 0xC0108888);
+	else
+		clutHash_ = XXH3_64bits((const char *)clutBufRaw_, clutExtendedBytes) & 0xFFFFFFFF;
+	clutBuf_ = clutBufRaw_;
+
+	// Special optimization: fonts typically draw clut4 with just alpha values in a single color.
+	clutAlphaLinear_ = false;
+	clutAlphaLinearColor_ = 0;
+	if (clutFormat == GE_CMODE_16BIT_ABGR4444 && clutIndexIsSimple) {
+		const u16_le *clut = GetCurrentClut<u16_le>();
+		clutAlphaLinear_ = true;
+		clutAlphaLinearColor_ = clut[15] & 0x0FFF;
+		for (int i = 0; i < 16; ++i) {
+			u16 step = clutAlphaLinearColor_ | (i << 12);
+			if (clut[i] != step) {
+				clutAlphaLinear_ = false;
+				break;
+			}
+		}
+	}
+
+	clutLastFormat_ = gstate.clutformat;
 }
 
 // TODO: This should be called from the through mode bbox check.

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -338,7 +338,7 @@ public:
 	void InvalidateAll(GPUInvalidationType type);
 	void ClearNextFrame();
 
-	TextureShaderCache *GetTextureShaderCache() { return textureShaderCache_; }
+	TextureShaderCache &GetTextureShaderCache() { return textureShaderCache_; }
 
 	virtual void ForgetLastTexture() = 0;
 	virtual void Clear(bool delete_them);
@@ -364,8 +364,8 @@ public:
 
 	virtual void StartFrame();
 
-	virtual void DeviceLost() = 0;
-	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
+	virtual void DeviceLost();
+	virtual void DeviceRestore(Draw::DrawContext *draw);
 
 	// Accessors for the debugger.
 	virtual void *GetNativeTextureView(const TexCacheEntry *entry, bool flat) const = 0;
@@ -480,7 +480,8 @@ protected:
 	TextureReplacer replacer_;
 	TextureScalerCommon scaler_;
 	FramebufferManagerCommon *framebufferManager_;
-	TextureShaderCache *textureShaderCache_;
+	TextureShaderCache textureShaderCache_;
+	ClutTextureCache clutTextureCache_;
 	ShaderManagerCommon *shaderManager_;
 
 	bool clearCacheNextFrame_ = false;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -404,7 +404,7 @@ protected:
 	void Decimate(TexCacheEntry *exceptThisOne, bool forcePressure);  // forcePressure defaults to false.
 
 	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, RasterChannel channel);
-	void ApplyTextureDepal(TexCacheEntry *entry);
+	void ApplyTextureDepalFramebufferCLUT(TexCacheEntry *entry);
 
 	void HandleTextureChange(TexCacheEntry *const entry, const char *reason, bool initialMatch, bool doDelete);
 	virtual void BuildTexture(TexCacheEntry *const entry) = 0;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -247,6 +247,12 @@ struct AttachCandidate {
 	std::string ToString() const;
 };
 
+struct CLUTProperties {
+	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
+	bool clutAlphaLinear = false;
+	u16 clutAlphaLinearColor;
+};
+
 class FramebufferManagerCommon;
 
 struct BuildTexturePlan {
@@ -416,16 +422,6 @@ protected:
 	// Return value is mapData normally, but could be another buffer allocated with AllocateAlignedMemory.
 	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, size_t dataSize, int mapRowPitch, BuildTexturePlan &plan, int srcLevel, Draw::DataFormat dstFmt, TexDecodeFlags texDecFlags);
 
-	template <typename T>
-	inline const T *GetCurrentClut() {
-		return (const T *)clutBuf_;
-	}
-
-	template <typename T>
-	inline const T *GetCurrentRawClut() {
-		return (const T *)clutBufRaw_;
-	}
-
 	// These need to be member functions just for IsVideo and Replacer.
 	SamplerCacheKey GetSamplingParams(int maxLevel, const TexCacheEntry *entry, bool flatZ);
 	SamplerCacheKey GetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
@@ -517,16 +513,14 @@ protected:
 	u32 *clutBufConverted_;
 	// This is the active one.
 	u32 *clutBuf_;
+
 	u32 clutLastFormat_ = 0xFFFFFFFF;
 	u32 clutTotalBytes_ = 0;
 	u32 clutMaxBytes_ = 0;
 	u32 clutRenderAddress_ = 0xFFFFFFFF;
 	u32 clutRenderOffset_;
 	GEBufferFormat clutRenderFormat_;
-
-	// True if the clut is just alpha values in the same order (RGBA4444-bit only.)
-	bool clutAlphaLinear_ = false;
-	u16 clutAlphaLinearColor_;
+	CLUTProperties clutProperties_;
 
 	// Facilities for GPU depal of static textures.
 	Draw::Framebuffer *dynamicClutTemp_ = nullptr;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -400,7 +400,7 @@ protected:
 
 	void HandleTextureChange(TexCacheEntry *const entry, const char *reason, bool initialMatch, bool doDelete);
 	virtual void BuildTexture(TexCacheEntry *const entry) = 0;
-	virtual void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) = 0;
+	virtual void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple);  // only overridden in GLES
 	bool CheckFullHash(TexCacheEntry *entry, bool &doDelete);
 
 	virtual void BindAsClutTexture(Draw::Texture *tex, bool smooth) {}

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -131,6 +131,10 @@ struct TextureDefinition {
 // At one point we might merge the concepts of framebuffers and textures, but that
 // moment is far away.
 
+// When hashing large textures, we optimize 512x512 down to 512x272 by default, since this
+// is commonly the only part accessed.  If access is made above 272, we hash the entire
+// texture, and set this flag to allow scaling the texture just once for the new hash.
+
 enum class TexStatus : u16 {
 	VIDEO = (1 << 0),
 	BGRA = (1 << 1),
@@ -143,13 +147,11 @@ enum class TexStatus : u16 {
 	TO_SCALE = (1 << 7),        // Pending texture scaling in a later frame.
 	IS_SCALED_OR_REPLACED = (1 << 8),  // Has been scaled already (ignored for replacement checks).
 	TO_REPLACE = (1 << 9),    // Pending texture replacement.
-	// When hashing large textures, we optimize 512x512 down to 512x272 by default, since this
-	// is commonly the only part accessed.  If access is made above 272, we hash the entire
-	// texture, and set this flag to allow scaling the texture just once for the new hash.
+	IS_3D = (1 << 10),
 	NO_MIPS = (1 << 11),      // Has bad or unusable mipmap levels.
 	FRAMEBUFFER_OVERLAP = (1 << 12),
 	FORCE_REBUILD = (1 << 13),
-	IS_3D = (1 << 14),
+	CLUT8_INDEXED = (1 << 14),  // Decoded as plain CLUT8 indices instead of all the way to colors.
 	CLUT_GPU = (1 << 15),
 };
 ENUM_CLASS_BITOPS(TexStatus);
@@ -338,7 +340,7 @@ public:
 	void InvalidateAll(GPUInvalidationType type);
 	void ClearNextFrame();
 
-	TextureShaderCache &GetTextureShaderCache() { return textureShaderCache_; }
+	const TextureShaderCache &GetTextureShaderCache() const { return textureShaderCache_; }
 
 	virtual void ForgetLastTexture() = 0;
 	virtual void Clear(bool delete_them);

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -53,7 +53,120 @@ void TextureShaderCache::DeviceLost() {
 	draw_ = nullptr;
 }
 
-ClutTexture TextureShaderCache::GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, const u32 *rawClut) {
+Draw::SamplerState *TextureShaderCache::GetSampler(bool linearFilter) {
+	if (linearFilter) {
+		if (!linearSampler_) {
+			Draw::SamplerStateDesc desc{};
+			desc.magFilter = Draw::TextureFilter::LINEAR;
+			desc.minFilter = Draw::TextureFilter::LINEAR;
+			desc.wrapU = Draw::TextureAddressMode::CLAMP_TO_EDGE;
+			desc.wrapV = Draw::TextureAddressMode::CLAMP_TO_EDGE;
+			desc.wrapW = Draw::TextureAddressMode::CLAMP_TO_EDGE;
+			linearSampler_ = draw_->CreateSamplerState(desc);
+		}
+		return linearSampler_;
+	} else {
+		if (!nearestSampler_) {
+			Draw::SamplerStateDesc desc{};
+			desc.wrapU = Draw::TextureAddressMode::CLAMP_TO_EDGE;
+			desc.wrapV = Draw::TextureAddressMode::CLAMP_TO_EDGE;
+			desc.wrapW = Draw::TextureAddressMode::CLAMP_TO_EDGE;
+			nearestSampler_ = draw_->CreateSamplerState(desc);
+		}
+		return nearestSampler_;
+	}
+}
+
+void TextureShaderCache::Clear() {
+	for (auto shader = pipelineCache_.begin(); shader != pipelineCache_.end(); ++shader) {
+		if (shader->second->pipeline) {
+			shader->second->pipeline->Release();
+		}
+		delete shader->second;
+	}
+	pipelineCache_.clear();
+	if (nearestSampler_) {
+		nearestSampler_->Release();
+		nearestSampler_ = nullptr;
+	}
+	if (linearSampler_) {
+		linearSampler_->Release();
+		linearSampler_ = nullptr;
+	}
+}
+
+Draw2DPipeline *TextureShaderCache::GetDepalettizeShader(uint32_t clutMode, GETextureFormat textureFormat, GEBufferFormat bufferFormat, bool smoothedDepal, u32 depthUpperBits) {
+	using namespace Draw;
+
+	// Generate an ID for depal shaders.
+	u64 id = ((u64)depthUpperBits << 32) | (clutMode & 0xFFFFFF) | (textureFormat << 24) | (bufferFormat << 28);
+
+	auto shader = pipelineCache_.find(id);
+	if (shader != pipelineCache_.end()) {
+		return shader->second;
+	}
+
+	// TODO: Parse these out of clutMode some nice way, to become a bit more stateless.
+	DepalConfig config;
+	config.clutFormat = gstate.getClutPaletteFormat();
+	config.startPos = gstate.getClutIndexStartPos();
+	config.shift = gstate.getClutIndexShift();
+	config.mask = gstate.getClutIndexMask();
+	config.bufferFormat = bufferFormat;
+	config.textureFormat = textureFormat;
+	config.smoothedDepal = smoothedDepal;
+	config.depthUpperBits = depthUpperBits;
+
+	Draw2DPipeline *ts = draw2D_->Create2DPipeline([config](ShaderWriter &writer) -> Draw2DPipelineInfo {
+		GenerateDepalFs(writer, config);
+		return Draw2DPipelineInfo{
+			"depal",
+			config.bufferFormat == GE_FORMAT_DEPTH16 ? RASTER_DEPTH : RASTER_COLOR,
+			RASTER_COLOR,
+			samplers
+		};
+	});
+
+	pipelineCache_[id] = ts;
+
+	return ts->pipeline ? ts : nullptr;
+}
+
+std::vector<std::string> TextureShaderCache::DebugGetShaderIDs(DebugShaderType type) {
+	std::vector<std::string> ids;
+	for (auto &entry : pipelineCache_) {
+		ids.push_back(StringFromFormat("%08x", entry.first));
+	}
+	return ids;
+}
+
+std::string TextureShaderCache::DebugGetShaderString(const std::string &idstr, DebugShaderType type, DebugShaderStringType stringType) {
+	uint32_t id = 0;
+	sscanf(idstr.c_str(), "%08x", &id);
+	auto iter = pipelineCache_.find(id);
+	if (iter == pipelineCache_.end())
+		return "";
+	switch (stringType) {
+	case SHADER_STRING_SHORT_DESC:
+		return idstr;
+	case SHADER_STRING_SOURCE_CODE:
+		return iter->second->code;
+	default:
+		return "";
+	}
+}
+
+void ClutTextureCache::DeviceRestore(Draw::DrawContext *draw) {
+	draw_ = draw;
+}
+
+void ClutTextureCache::DeviceLost() {
+	Clear();
+	draw_ = nullptr;
+}
+
+// TODO: We could cache many CLUTs in one big texture, might be more efficient.
+ClutTexture ClutTextureCache::GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, const u32 *rawClut) {
 	// Simplistic, but works well enough.
 	u32 clutId = clutHash ^ (uint32_t)clutFormat;
 
@@ -138,54 +251,15 @@ ClutTexture TextureShaderCache::GetClutTexture(GEPaletteFormat clutFormat, const
 	return *tex;
 }
 
-void TextureShaderCache::Clear() {
-	for (auto shader = depalCache_.begin(); shader != depalCache_.end(); ++shader) {
-		if (shader->second->pipeline) {
-			shader->second->pipeline->Release();
-		}
-		delete shader->second;
-	}
-	depalCache_.clear();
+void ClutTextureCache::Clear() {
 	for (auto tex = texCache_.begin(); tex != texCache_.end(); ++tex) {
 		tex->second->texture->Release();
 		delete tex->second;
 	}
 	texCache_.clear();
-	if (nearestSampler_) {
-		nearestSampler_->Release();
-		nearestSampler_ = nullptr;
-	}
-	if (linearSampler_) {
-		linearSampler_->Release();
-		linearSampler_ = nullptr;
-	}
 }
 
-Draw::SamplerState *TextureShaderCache::GetSampler(bool linearFilter) {
-	if (linearFilter) {
-		if (!linearSampler_) {
-			Draw::SamplerStateDesc desc{};
-			desc.magFilter = Draw::TextureFilter::LINEAR;
-			desc.minFilter = Draw::TextureFilter::LINEAR;
-			desc.wrapU = Draw::TextureAddressMode::CLAMP_TO_EDGE;
-			desc.wrapV = Draw::TextureAddressMode::CLAMP_TO_EDGE;
-			desc.wrapW = Draw::TextureAddressMode::CLAMP_TO_EDGE;
-			linearSampler_ = draw_->CreateSamplerState(desc);
-		}
-		return linearSampler_;
-	} else {
-		if (!nearestSampler_) {
-			Draw::SamplerStateDesc desc{};
-			desc.wrapU = Draw::TextureAddressMode::CLAMP_TO_EDGE;
-			desc.wrapV = Draw::TextureAddressMode::CLAMP_TO_EDGE;
-			desc.wrapW = Draw::TextureAddressMode::CLAMP_TO_EDGE;
-			nearestSampler_ = draw_->CreateSamplerState(desc);
-		}
-		return nearestSampler_;
-	}
-}
-
-void TextureShaderCache::Decimate() {
+void ClutTextureCache::Decimate() {
 	for (auto tex = texCache_.begin(); tex != texCache_.end(); ) {
 		if (tex->second->lastFrame + DEPAL_TEXTURE_OLD_AGE < gpuStats.totals.numFlips) {
 			tex->second->texture->Release();
@@ -196,65 +270,4 @@ void TextureShaderCache::Decimate() {
 		}
 	}
 	gpuStats.perFrame.numClutTextures = (int)texCache_.size();
-}
-
-Draw2DPipeline *TextureShaderCache::GetDepalettizeShader(uint32_t clutMode, GETextureFormat textureFormat, GEBufferFormat bufferFormat, bool smoothedDepal, u32 depthUpperBits) {
-	using namespace Draw;
-
-	// Generate an ID for depal shaders.
-	u64 id = ((u64)depthUpperBits << 32) | (clutMode & 0xFFFFFF) | (textureFormat << 24) | (bufferFormat << 28);
-
-	auto shader = depalCache_.find(id);
-	if (shader != depalCache_.end()) {
-		return shader->second;
-	}
-
-	// TODO: Parse these out of clutMode some nice way, to become a bit more stateless.
-	DepalConfig config;
-	config.clutFormat = gstate.getClutPaletteFormat();
-	config.startPos = gstate.getClutIndexStartPos();
-	config.shift = gstate.getClutIndexShift();
-	config.mask = gstate.getClutIndexMask();
-	config.bufferFormat = bufferFormat;
-	config.textureFormat = textureFormat;
-	config.smoothedDepal = smoothedDepal;
-	config.depthUpperBits = depthUpperBits;
-
-	Draw2DPipeline *ts = draw2D_->Create2DPipeline([config](ShaderWriter &writer) -> Draw2DPipelineInfo {
-		GenerateDepalFs(writer, config);
-		return Draw2DPipelineInfo{
-			"depal",
-			config.bufferFormat == GE_FORMAT_DEPTH16 ? RASTER_DEPTH : RASTER_COLOR,
-			RASTER_COLOR,
-			samplers
-		};
-	});
-
-	depalCache_[id] = ts;
-
-	return ts->pipeline ? ts : nullptr;
-}
-
-std::vector<std::string> TextureShaderCache::DebugGetShaderIDs(DebugShaderType type) {
-	std::vector<std::string> ids;
-	for (auto &entry : depalCache_) {
-		ids.push_back(StringFromFormat("%08x", entry.first));
-	}
-	return ids;
-}
-
-std::string TextureShaderCache::DebugGetShaderString(const std::string &idstr, DebugShaderType type, DebugShaderStringType stringType) {
-	uint32_t id = 0;
-	sscanf(idstr.c_str(), "%08x", &id);
-	auto iter = depalCache_.find(id);
-	if (iter == depalCache_.end())
-		return "";
-	switch (stringType) {
-	case SHADER_STRING_SHORT_DESC:
-		return idstr;
-	case SHADER_STRING_SOURCE_CODE:
-		return iter->second->code;
-	default:
-		return "";
-	}
 }

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -132,7 +132,7 @@ Draw2DPipeline *TextureShaderCache::GetDepalettizeShader(uint32_t clutMode, GETe
 	return ts->pipeline ? ts : nullptr;
 }
 
-std::vector<std::string> TextureShaderCache::DebugGetShaderIDs(DebugShaderType type) {
+std::vector<std::string> TextureShaderCache::DebugGetShaderIDs(DebugShaderType type) const {
 	std::vector<std::string> ids;
 	for (auto &entry : pipelineCache_) {
 		ids.push_back(StringFromFormat("%08x", entry.first));
@@ -140,9 +140,11 @@ std::vector<std::string> TextureShaderCache::DebugGetShaderIDs(DebugShaderType t
 	return ids;
 }
 
-std::string TextureShaderCache::DebugGetShaderString(const std::string &idstr, DebugShaderType type, DebugShaderStringType stringType) {
+std::string TextureShaderCache::DebugGetShaderString(const std::string &idstr, DebugShaderType type, DebugShaderStringType stringType) const {
 	uint32_t id = 0;
-	sscanf(idstr.c_str(), "%08x", &id);
+	if (sscanf(idstr.c_str(), "%08x", &id) == 0) {
+		return "";
+	}
 	auto iter = pipelineCache_.find(id);
 	if (iter == pipelineCache_.end())
 		return "";

--- a/GPU/Common/TextureShaderCommon.h
+++ b/GPU/Common/TextureShaderCommon.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <string>
 
@@ -36,6 +36,21 @@ public:
 	int rampStarts[MAX_RAMPS];
 };
 
+class ClutTextureCache {
+public:
+	ClutTexture GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, const u32 *rawClut);
+
+	void Clear();
+	void Decimate();
+
+	void DeviceLost();
+	void DeviceRestore(Draw::DrawContext *draw);
+
+private:
+	Draw::DrawContext *draw_;
+	std::unordered_map<u32, ClutTexture *> texCache_;
+};
+
 // For CLUT depal shaders, and other pre-bind texture shaders.
 // Caches both shaders and palette textures.
 class TextureShaderCache {
@@ -44,12 +59,10 @@ public:
 	~TextureShaderCache();
 
 	Draw2DPipeline *GetDepalettizeShader(uint32_t clutMode, GETextureFormat texFormat, GEBufferFormat pixelFormat, bool smoothedDepal, u32 depthUpperBits);
-	ClutTexture GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, const u32 *rawClut);
 
 	Draw::SamplerState *GetSampler(bool linearFilter);
 
 	void Clear();
-	void Decimate();
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType);
 
@@ -61,7 +74,5 @@ private:
 	Draw::SamplerState *nearestSampler_ = nullptr;
 	Draw::SamplerState *linearSampler_ = nullptr;
 	Draw2D *draw2D_;
-
-	std::map<u64, Draw2DPipeline *> depalCache_;
-	std::map<u32, ClutTexture *> texCache_;
+	std::unordered_map<u64, Draw2DPipeline *> pipelineCache_;
 };

--- a/GPU/Common/TextureShaderCommon.h
+++ b/GPU/Common/TextureShaderCommon.h
@@ -63,8 +63,8 @@ public:
 	Draw::SamplerState *GetSampler(bool linearFilter);
 
 	void Clear();
-	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
-	std::string DebugGetShaderString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType);
+	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type) const;
+	std::string DebugGetShaderString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType) const;
 
 	void DeviceLost();
 	void DeviceRestore(Draw::DrawContext *draw);

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -175,13 +175,13 @@ void TextureCacheD3D11::DestroyDeviceObjects() {
 }
 
 void TextureCacheD3D11::DeviceLost() {
-	Clear(false);
+	TextureCacheCommon::DeviceLost();
 	DestroyDeviceObjects();
 	draw_ = nullptr;
 }
 
 void TextureCacheD3D11::DeviceRestore(Draw::DrawContext *draw) { 
-	draw_ = draw;
+	TextureCacheCommon::DeviceRestore(draw);
 	InitDeviceObjects();
 }
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -225,7 +225,6 @@ void TextureCacheD3D11::BindTexture(TexCacheEntry *entry, bool flatZ) {
 	ComPtr<ID3D11SamplerState> state;
 	samplerCache_.GetOrCreateSampler(device_, samplerKey, &state);
 	context_->PSSetSamplers(0, 1, state.GetAddressOf());
-	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 }
 
 void TextureCacheD3D11::ApplySamplingParams(const SamplerCacheKey &key) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -209,42 +209,6 @@ void TextureCacheD3D11::ForgetLastTexture() {
 	context_->PSSetShaderResources(0, 4, nullTex);
 }
 
-void TextureCacheD3D11::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) {
-	const u32 clutBaseBytes = clutBase * (clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16));
-	// Technically, these extra bytes weren't loaded, but hopefully it was loaded earlier.
-	// If not, we're going to hash random data, which hopefully doesn't cause a performance issue.
-	//
-	// TODO: Actually, this seems like a hack.  The game can upload part of a CLUT and reference other data.
-	// clutTotalBytes_ is the last amount uploaded.  We should hash clutMaxBytes_, but this will often hash
-	// unrelated old entries for small palettes.
-	// Adding clutBaseBytes may just be mitigating this for some usage patterns.
-	const u32 clutExtendedBytes = std::min(clutTotalBytes_ + clutBaseBytes, clutMaxBytes_);
-
-	if (replacer_.Enabled())
-		clutHash_ = XXH32((const char *)clutBufRaw_, clutExtendedBytes, 0xC0108888);
-	else
-		clutHash_ = XXH3_64bits((const char *)clutBufRaw_, clutExtendedBytes) & 0xFFFFFFFF;
-	clutBuf_ = clutBufRaw_;
-
-	// Special optimization: fonts typically draw clut4 with just alpha values in a single color.
-	clutAlphaLinear_ = false;
-	clutAlphaLinearColor_ = 0;
-	if (clutFormat == GE_CMODE_16BIT_ABGR4444 && clutIndexIsSimple) {
-		const u16_le *clut = GetCurrentClut<u16_le>();
-		clutAlphaLinear_ = true;
-		clutAlphaLinearColor_ = clut[15] & 0x0FFF;
-		for (int i = 0; i < 16; ++i) {
-			u16 step = clutAlphaLinearColor_ | (i << 12);
-			if (clut[i] != step) {
-				clutAlphaLinear_ = false;
-				break;
-			}
-		}
-	}
-
-	clutLastFormat_ = gstate.clutformat;
-}
-
 void TextureCacheD3D11::BindTexture(TexCacheEntry *entry, bool flatZ) {
 	if (!entry) {
 		ID3D11ShaderResourceView *textureView = nullptr;

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -73,7 +73,6 @@ protected:
 
 private:
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
-	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
 	void BuildTexture(TexCacheEntry *const entry) override;
 

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -413,16 +413,14 @@ bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level,
 }
 
 void TextureCacheGLES::DeviceLost() {
-	textureShaderCache_->DeviceLost();
-	Clear(false);
+	TextureCacheCommon::DeviceLost();
 	draw_ = nullptr;
 	render_ = nullptr;
 }
 
 void TextureCacheGLES::DeviceRestore(Draw::DrawContext *draw) {
-	draw_ = draw;
+	TextureCacheCommon::DeviceRestore(draw);
 	render_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-	textureShaderCache_->DeviceRestore(draw);
 }
 
 void *TextureCacheGLES::GetNativeTextureView(const TexCacheEntry *entry, bool flat) const {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -174,20 +174,22 @@ void TextureCacheGLES::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBas
 	}
 
 	// Special optimization: fonts typically draw clut4 with just alpha values in a single color.
-	clutAlphaLinear_ = false;
-	clutAlphaLinearColor_ = 0;
+	bool alphaLinear = false;
+	u16 alphaLinearColor = 0;
 	if (clutFormat == GE_CMODE_16BIT_ABGR4444 && clutIndexIsSimple) {
-		const u16_le *clut = GetCurrentClut<u16_le>();
-		clutAlphaLinear_ = true;
-		clutAlphaLinearColor_ = clut[15] & 0xFFF0;
+		const u16 *clut = (const u16 *)(clutBuf_);
+		alphaLinear = true;
+		alphaLinearColor = clut[15] & 0xFFF0;
 		for (int i = 0; i < 16; ++i) {
-			u16 step = clutAlphaLinearColor_ | i;
+			u16 step = alphaLinearColor | i;
 			if (clut[i] != step) {
-				clutAlphaLinear_ = false;
+				alphaLinear = false;
 				break;
 			}
 		}
 	}
+	clutProperties_.clutAlphaLinear = alphaLinear;
+	clutProperties_.clutAlphaLinearColor = alphaLinearColor;
 
 	clutLastFormat_ = gstate.clutformat;
 }

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -205,7 +205,6 @@ void TextureCacheGLES::BindTexture(TexCacheEntry *entry, bool flatZ) {
 	int maxLevel = (entry->status & TexStatus::NO_MIPS) ? 0 : entry->maxLevel;
 	SamplerCacheKey samplerKey = GetSamplingParams(maxLevel, entry, flatZ);
 	ApplySamplingParams(samplerKey);
-	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 }
 
 void TextureCacheGLES::Unbind() {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -147,6 +147,7 @@ void TextureCacheGLES::StartFrame() {
 	}
 }
 
+// TODO: This is almost the same as the Common one, just with some extra color conversion. Should merge.
 void TextureCacheGLES::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) {
 	const u32 clutBaseBytes = clutFormat == GE_CMODE_32BIT_ABGR8888 ? (clutBase * sizeof(u32)) : (clutBase * sizeof(u16));
 	// Technically, these extra bytes weren't loaded, but hopefully it was loaded earlier.

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -40,9 +40,6 @@ public:
 	void StartFrame() override;
 
 	void SetFramebufferManager(FramebufferManagerGLES *fbManager);
-	void SetDepalShaderCache(TextureShaderCache *dpCache) {
-		textureShaderCache_ = dpCache;
-	}
 	void SetDrawEngine(DrawEngineGLES *td) {
 		drawEngine_ = td;
 	}

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -651,7 +651,7 @@ std::vector<std::string> GPUCommonHW::DebugGetShaderIDs(DebugShaderType type) {
 	case SHADER_TYPE_VERTEXLOADER:
 		return drawEngineCommon_->DebugGetVertexLoaderIDs();
 	case SHADER_TYPE_TEXTURE:
-		return textureCache_->GetTextureShaderCache()->DebugGetShaderIDs(type);
+		return textureCache_->GetTextureShaderCache().DebugGetShaderIDs(type);
 	default:
 		return shaderManager_->DebugGetShaderIDs(type);
 	}
@@ -662,7 +662,7 @@ std::string GPUCommonHW::DebugGetShaderString(std::string id, DebugShaderType ty
 	case SHADER_TYPE_VERTEXLOADER:
 		return drawEngineCommon_->DebugGetVertexLoaderString(id, stringType);
 	case SHADER_TYPE_TEXTURE:
-		return textureCache_->GetTextureShaderCache()->DebugGetShaderString(id, type, stringType);
+		return textureCache_->GetTextureShaderCache().DebugGetShaderString(id, type, stringType);
 	default:
 		return shaderManager_->DebugGetShaderString(id, type, stringType);
 	}

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -539,12 +539,6 @@ struct GPUStateCache {
 	bool IsDirty(u64 what) const {
 		return (dirty & what) != 0ULL;
 	}
-	void SetUseShaderDepal(ShaderDepalMode mode) {
-		if (mode != shaderDepalMode) {
-			shaderDepalMode = mode;
-			Dirty(DIRTY_FRAGMENTSHADER_STATE);
-		}
-	}
 	void SetTextureSolidAlpha(bool solidAlpha) {
 		if (solidAlpha != textureSolidAlpha) {
 			textureSolidAlpha = solidAlpha;
@@ -701,6 +695,14 @@ public:
 
 	ShaderDepalMode shaderDepalMode;
 	GEBufferFormat depalTextureFormat;
+
+	void SetShaderDepal(ShaderDepalMode mode, GEBufferFormat texFormat = {}) {
+		if (mode != shaderDepalMode || (mode != ShaderDepalMode::OFF && texFormat != depalTextureFormat)) {
+			shaderDepalMode = mode;
+			depalTextureFormat = texFormat;
+			Dirty(DIRTY_FRAGMENTSHADER_STATE);
+		}
+	}
 
 	u32 getRelativeAddress(u32 data) const {
 		u32 baseExtended = ((gstate.base & 0x000F0000) << 8) | data;

--- a/GPU/GeConstants.cpp
+++ b/GPU/GeConstants.cpp
@@ -287,6 +287,7 @@ const char *GeBufferFormatToString(GEBufferFormat fmt) {
 	case GE_FORMAT_565: return "565";
 	case GE_FORMAT_8888: return "8888";
 	case GE_FORMAT_DEPTH16: return "DEPTH16";
+	case GE_FORMAT_CLUT8: return "CLUT8";
 	default: return "N/A";
 	}
 }

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -958,7 +958,7 @@ void TextureCacheVulkan::LoadVulkanTextureLevel(TexCacheEntry &entry, uint8_t *w
 	if (!gstate_c.Use(GPU_USE_16BIT_FORMATS) || scaleFactor > 1 || dstFmt == VULKAN_8888_FORMAT) {
 		texDecFlags |= TexDecodeFlags::EXPAND32;
 	}
-	if (entry.status & TexStatus::CLUT_GPU) {
+	if (entry.status & TexStatus::CLUT8_INDEXED) {
 		texDecFlags |= TexDecodeFlags::TO_CLUT8;
 	}
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -587,7 +587,6 @@ void TextureCacheVulkan::BindTexture(TexCacheEntry *entry, bool flatZ) {
 	curSampler_ = samplerCache_.GetOrCreateSampler(samplerKey);
 	imageView_ = entry->vkTex->GetImageView();
 	drawEngine_->SetDepalTexture(VK_NULL_HANDLE, false);
-	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 }
 
 void TextureCacheVulkan::ApplySamplingParams(const SamplerCacheKey &key) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -19,8 +19,6 @@
 #include <cstring>
 #include <memory>
 
-#include "ext/xxhash.h"
-
 #include "Common/File/VFS/VFS.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/LogReporting.h"
@@ -580,42 +578,6 @@ void TextureCacheVulkan::StartFrame() {
 	// TODO: For low memory detection, maybe use some indication from VMA.
 	// Maybe see https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/staying_within_budget.html#staying_within_budget_querying_for_budget .
 	computeShaderManager_.BeginFrame();
-}
-
-void TextureCacheVulkan::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) {
-	const u32 clutBaseBytes = clutFormat == GE_CMODE_32BIT_ABGR8888 ? (clutBase * sizeof(u32)) : (clutBase * sizeof(u16));
-	// Technically, these extra bytes weren't loaded, but hopefully it was loaded earlier.
-	// If not, we're going to hash random data, which hopefully doesn't cause a performance issue.
-	//
-	// TODO: Actually, this seems like a hack.  The game can upload part of a CLUT and reference other data.
-	// clutTotalBytes_ is the last amount uploaded.  We should hash clutMaxBytes_, but this will often hash
-	// unrelated old entries for small palettes.
-	// Adding clutBaseBytes may just be mitigating this for some usage patterns.
-	const u32 clutExtendedBytes = std::min(clutTotalBytes_ + clutBaseBytes, clutMaxBytes_);
-
-	if (replacer_.Enabled())
-		clutHash_ = XXH32((const char *)clutBufRaw_, clutExtendedBytes, 0xC0108888);
-	else
-		clutHash_ = XXH3_64bits((const char *)clutBufRaw_, clutExtendedBytes) & 0xFFFFFFFF;
-	clutBuf_ = clutBufRaw_;
-
-	// Special optimization: fonts typically draw clut4 with just alpha values in a single color.
-	clutAlphaLinear_ = false;
-	clutAlphaLinearColor_ = 0;
-	if (clutFormat == GE_CMODE_16BIT_ABGR4444 && clutIndexIsSimple) {
-		const u16_le *clut = GetCurrentClut<u16_le>();
-		clutAlphaLinear_ = true;
-		clutAlphaLinearColor_ = clut[15] & 0x0FFF;
-		for (int i = 0; i < 16; ++i) {
-			u16 step = clutAlphaLinearColor_ | (i << 12);
-			if (clut[i] != step) {
-				clutAlphaLinear_ = false;
-				break;
-			}
-		}
-	}
-
-	clutLastFormat_ = gstate.clutformat;
 }
 
 void TextureCacheVulkan::BindTexture(TexCacheEntry *entry, bool flatZ) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -216,11 +216,9 @@ void TextureCacheVulkan::SetFramebufferManager(FramebufferManagerVulkan *fbManag
 }
 
 void TextureCacheVulkan::DeviceLost() {
-	textureShaderCache_->DeviceLost();
+	TextureCacheCommon::DeviceLost();
 	
 	VulkanContext *vulkan = draw_ ? (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT) : nullptr;
-
-	Clear(true);
 
 	samplerCache_.DeviceLost();
 	if (samplerNearest_)
@@ -236,13 +234,11 @@ void TextureCacheVulkan::DeviceLost() {
 }
 
 void TextureCacheVulkan::DeviceRestore(Draw::DrawContext *draw) {
-	draw_ = draw;
+	TextureCacheCommon::DeviceRestore(draw);
 
 	VulkanContext *vulkan = (VulkanContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
 	_assert_(vulkan);
-
 	samplerCache_.DeviceRestore(vulkan);
-	textureShaderCache_->DeviceRestore(draw);
 
 	VkSamplerCreateInfo samp{ VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO };
 	samp.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -118,7 +118,6 @@ private:
 
 	void LoadVulkanTextureLevel(TexCacheEntry &entry, uint8_t *writePtr, int rowPitch,  int level, int scaleFactor, VkFormat dstFmt);
 	static VkFormat GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) ;
-	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
 	void BuildTexture(TexCacheEntry *const entry) override;
 


### PR DESCRIPTION
When fully implemented, this will help various issues like #15251 where games change the CLUT a lot while keeping the textures the same.

This PR just lays the groundwork and adds the needed plumbing, it should not change anything. Therefore I want to get it in separately to catch any regressions.

Also does a bunch of code cleanup.