### PR TITLE
Add compat flag for shader palette lookups

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -168,6 +168,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "FastEmulatedGPU", &flags_.FastEmulatedGPU);
 	CheckSetting(iniFile, gameID, "CorrectCullAfterClip", &flags_.CorrectCullAfterClip);
 	CheckSetting(iniFile, gameID, "SpriteBorderFix", &flags_.SpriteBorderFix);
+	CheckSetting(iniFile, gameID, "TextureCLUTInShader", &flags_.TextureCLUTInShader);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -123,6 +123,7 @@ struct CompatFlags {
 	bool FastEmulatedGPU;
 	bool CorrectCullAfterClip;
 	float SpriteBorderFix;
+	bool TextureCLUTInShader;
 };
 
 struct VRCompat {

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -61,10 +61,15 @@ static s64 idledCycles;
 static s64 lastGlobalTimeTicks;
 static s64 lastGlobalTimeUs;
 
-void SetClockFrequencyHz(int cpuHz) {
+bool SetClockFrequencyHz(int cpuHz) {
 	if (cpuHz <= 0) {
 		// Paranoid check, protecting against division by zero and similar nonsense.
-		return;
+		return true;  // encourage logging
+	}
+
+	if (cpuHz == CPU_HZ) {
+		// Already at the correct frequency. Bail, false means we'll log at a lower level.
+		return false;
 	}
 
 	// When the mhz changes, we keep track of what "time" it was before hand.
@@ -76,6 +81,7 @@ void SetClockFrequencyHz(int cpuHz) {
 
 	// TODO: Rescale times of scheduled events?
 	__AudioCPUMHzChange();
+	return true;
 }
 
 int GetClockFrequencyHz() {

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -56,7 +56,7 @@ static Event *eventPool = 0;
 // as we can already reach that structure through a register.
 int slicelength;
 
-static alignas(16) s64 globalTimer;
+alignas(16) static s64 globalTimer;
 static s64 idledCycles;
 static s64 lastGlobalTimeTicks;
 static s64 lastGlobalTimeUs;

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -31,6 +31,7 @@
 #include "Core/Core.h"
 #include "Core/Config.h"
 #include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/__sceAudio.h"
 #include "Core/MIPS/MIPS.h"
 
 static const int initialHz = 222000000;
@@ -48,25 +49,17 @@ static std::set<int> usedEventTypes;
 static std::set<int> restoredEventTypes;
 static int nextEventTypeRestoreId = -1;
 
-Event *first;
-Event *eventPool = 0;
+static Event *first;
+static Event *eventPool = 0;
 
 // Downcount has been moved to currentMIPS, to save a couple of clocks in every ARM JIT block
 // as we can already reach that structure through a register.
 int slicelength;
 
-alignas(16) s64 globalTimer;
-s64 idledCycles;
-s64 lastGlobalTimeTicks;
-s64 lastGlobalTimeUs;
-
-std::vector<MHzChangeCallback> mhzChangeCallbacks;
-
-void FireMhzChange() {
-	for (MHzChangeCallback cb : mhzChangeCallbacks) {
-		cb();
-	}
-}
+static alignas(16) s64 globalTimer;
+static s64 idledCycles;
+static s64 lastGlobalTimeTicks;
+static s64 lastGlobalTimeUs;
 
 void SetClockFrequencyHz(int cpuHz) {
 	if (cpuHz <= 0) {
@@ -80,9 +73,9 @@ void SetClockFrequencyHz(int cpuHz) {
 	lastGlobalTimeTicks = GetTicks();
 
 	CPU_HZ = cpuHz;
-	// TODO: Rescale times of scheduled events?
 
-	FireMhzChange();
+	// TODO: Rescale times of scheduled events?
+	__AudioCPUMHzChange();
 }
 
 int GetClockFrequencyHz() {
@@ -187,7 +180,6 @@ void Init()
 	idledCycles = 0;
 	lastGlobalTimeTicks = 0;
 	lastGlobalTimeUs = 0;
-	mhzChangeCallbacks.clear();
 	CPU_HZ = initialHz;
 }
 
@@ -303,12 +295,7 @@ s64 UnscheduleEvent(int event_type, u64 userdata)
 	return result;
 }
 
-void RegisterMHzChangeCallback(MHzChangeCallback callback) {
-	mhzChangeCallbacks.push_back(callback);
-}
-
-bool IsScheduled(int event_type)
-{
+bool IsScheduled(int event_type) {
 	if (!first)
 		return false;
 	Event *e = first;
@@ -529,7 +516,7 @@ void DoState(PointerWrap &p) {
 		lastGlobalTimeUs = 0;
 	}
 
-	FireMhzChange();
+	__AudioCPUMHzChange();
 }
 
 }	// namespace

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -73,7 +73,6 @@ inline s64 cyclesToUs(s64 cycles) {
 }
 
 namespace CoreTiming {
-	typedef void (*MHzChangeCallback)();
 	typedef void (*TimedCallback)(u64 userdata, int cyclesLate);
 
 	struct EventType {
@@ -122,9 +121,6 @@ namespace CoreTiming {
 	void ClearPendingEvents();
 
 	void LogPendingEvents();
-
-	// Warning: not included in save states.
-	void RegisterMHzChangeCallback(MHzChangeCallback callback);
 
 	std::string GetScheduledEventsSummary();
 

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -126,7 +126,7 @@ namespace CoreTiming {
 
 	void DoState(PointerWrap &p);
 
-	void SetClockFrequencyHz(int cpuHz);
+	bool SetClockFrequencyHz(int cpuHz);  // Return false if the frequency was already set.
 	int GetClockFrequencyHz();
 
 	// TODO: Add accessors?

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -88,7 +88,7 @@ static void hleHostAudioUpdate(u64 userdata, int cyclesLate) {
 	CoreTiming::ScheduleEvent(audioHostIntervalCycles - cyclesLate, eventHostAudioUpdate, 0);
 }
 
-static void __AudioCPUMHzChange() {
+void __AudioCPUMHzChange() {
 	audioIntervalCycles = (int)(usToCycles(1000000ULL) * hwBlockSize / hwSampleRate);
 
 	// Soon to be removed.
@@ -120,7 +120,6 @@ void __AudioInit() {
 	memset(mixBuffer, 0, hwBlockSize * 2 * sizeof(s32));
 
 	System_AudioClear();
-	CoreTiming::RegisterMHzChangeCallback(&__AudioCPUMHzChange);
 }
 
 void __AudioDoState(PointerWrap &p) {

--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -46,6 +46,8 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking);
 void __AudioWakeThreads(AudioChannel &chan, int result, int step);
 void __AudioWakeThreads(AudioChannel &chan, int result);
 
+void __AudioCPUMHzChange();
+
 // AUDIO Dumping stuff
 void __StartLogAudio(const Path &filename);
 void __StopLogAudio();

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -442,12 +442,6 @@ static u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
 	if (busfreq == 0 || busfreq > 166) {
 		return hleLogWarning(Log::sceMisc, SCE_KERNEL_ERROR_INVALID_VALUE, "invalid bus frequency");
 	}
-	// TODO: More restrictions.
-	if (GetLockedCPUSpeedMhz() > 0) {
-		INFO_LOG(Log::HLE, "scePowerSetClockFrequency(%i,%i,%i): locked by user config at %i, %i, %i", pllfreq, cpufreq, busfreq, GetLockedCPUSpeedMhz(), GetLockedCPUSpeedMhz(), busFreq);
-	} else {
-		INFO_LOG(Log::HLE, "scePowerSetClockFrequency(%i,%i,%i)", pllfreq, cpufreq, busfreq);
-	}
 	// Only reschedules when the stepped PLL frequency changes.
 	// It seems like the busfreq parameter has no effect (but can cause errors.)
 	if (RealpllFreq != PowerPllMhzToHz(pllfreq)) {
@@ -471,8 +465,15 @@ static u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
 
 		return hleDelayResult(hleNoLog(0), "scepower set clockFrequency", usec);
 	}
-	if (GetLockedCPUSpeedMhz() <= 0)
-		CoreTiming::SetClockFrequencyHz(PowerCpuMhzToHz(cpufreq, pllFreq));
+	if (GetLockedCPUSpeedMhz() <= 0) {
+		if (CoreTiming::SetClockFrequencyHz(PowerCpuMhzToHz(cpufreq, pllFreq))) {
+			return hleLogInfo(Log::HLE, 0);
+		} else {
+			return hleLogDebug(Log::HLE, 0);
+		}
+	} else {
+		return hleLogInfo(Log::HLE, 0, "locked by user config at %i, %i, %i", GetLockedCPUSpeedMhz(), GetLockedCPUSpeedMhz(), busFreq);
+	}
 	return hleNoLog(0);
 }
 

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -59,6 +59,10 @@ bool NeedsTestDiscard();
 bool IsDepthTestEffectivelyDisabled();
 bool IsStencilTestOutputDisabled();
 
+inline bool CanForceBilinear(const GPUgstate &gstate) {
+	return ((!gstate.isColorTestEnabled() || IsColorTestTriviallyTrue()) && (!gstate.isAlphaTestEnabled() || IsAlphaTestTriviallyTrue()));
+}
+
 StencilValueType ReplaceAlphaWithStencilType();
 ReplaceAlphaType ReplaceAlphaWithStencil(ReplaceBlendType replaceBlend);
 ReplaceBlendType ReplaceBlendWithShader(GEBufferFormat bufferFormat);

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -38,7 +38,6 @@ static std::vector<ShaderInfo> shaderInfo;
 static std::vector<TextureShaderInfo> textureShaderInfo;
 
 static Draw::GPUVendor VendorFromString(const std::string &vendor) {
-	Draw::GPUVendor::VENDOR_UNKNOWN;
 	// TODO: This should probably be a function somewhere.
 	if (vendor == "ARM") {
 		return Draw::GPUVendor::VENDOR_ARM;

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -188,31 +188,37 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool useBuffe
 	}
 
 	if (dirtyUniforms & DIRTY_DEPAL) {
-		int indexMask = gstate.getClutIndexMask();
-		int indexShift = gstate.getClutIndexShift();
-		int indexOffset = gstate.getClutIndexStartPos() >> 4;
-		int format = gstate_c.depalTextureFormat;
-		uint32_t val = BytesToUint32(indexMask, indexShift, indexOffset, format);
-		// NOTE: This must follow similar logic to TextureCacheCommon::GetSamplingParams -
-		// maybe we can share it somehow.
-		// TOOD: Handle replaced textures.
-		bool bilinear = gstate.isMagnifyFilteringEnabled() && !gstate_c.pixelMapped;
-		switch (g_Config.iTexFiltering) {
-		case TEX_FILTER_FORCE_NEAREST:
-			bilinear = false;
-			break;
-		case TEX_FILTER_FORCE_LINEAR:
-			bilinear = true;
-			break;
-		default:
-			break;
-		}
-		if (bilinear) {
-			// Poke in a bilinear filter flag in the top bit.
-			val |= 0x80000000;
-		}
-		ub->depal_mask_shift_off_fmt = val;
+		ub->depal_mask_shift_off_fmt = PackDepalBits();
 	}
+}
+
+uint32_t PackDepalBits() {
+	const int indexMask = gstate.getClutIndexMask();
+	const int indexShift = gstate.getClutIndexShift();
+	const int indexOffset = gstate.getClutIndexStartPos() >> 4;
+	const int format = gstate_c.depalTextureFormat;
+	uint32_t val = BytesToUint32(indexMask, indexShift, indexOffset, format);
+	// NOTE: This must follow similar logic to TextureCacheCommon::GetSamplingParams -
+	// maybe we can share it somehow.
+	// TOOD: Handle replaced textures.
+	bool bilinear = gstate.isMagnifyFilteringEnabled() && !gstate_c.pixelMapped;
+	switch (g_Config.iTexFiltering) {
+	case TEX_FILTER_FORCE_NEAREST:
+		bilinear = false;
+		break;
+	case TEX_FILTER_FORCE_LINEAR:
+		if (CanForceBilinear(gstate)) {
+			bilinear = true;
+		}
+		break;
+	default:
+		break;
+	}
+	if (bilinear) {
+		// Poke in a bilinear filter flag in the top bit.
+		val |= 0x80000000;
+	}
+	return val;
 }
 
 // For "light ubershader" bits.

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -119,3 +119,4 @@ void LightUpdateUniforms(UB_VS_Lights *ub, uint64_t dirtyUniforms);
 void BoneUpdateUniforms(UB_VS_Bones *ub, uint64_t dirtyUniforms);
 
 uint32_t PackLightControlBits();
+uint32_t PackDepalBits();

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -1669,6 +1669,8 @@ bool GetCurrentDrawAsDebugVertices(DrawEngineCommon *drawEngine, GECommand cmd, 
 	case GE_PRIM_TRIANGLE_STRIP:
 		prim = GE_PRIM_TRIANGLES;
 		break;
+	default:
+		break;
 	}
 
 	int generatedIndices = indexGen.VertexCount();

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -873,7 +873,7 @@ void TextureCacheCommon::Decimate(TexCacheEntry *exceptThisOne, bool forcePressu
 			}
 		}
 
-		VERBOSE_LOG(Log::G3D, "Decimated texture cache, saved %d estimated bytes - now %d bytes", had - cacheSizeEstimate, cacheSizeEstimate);
+		VERBOSE_LOG(Log::G3D, "Decimated texture cache, saved %d estimated bytes - now %d bytes", (int)(had - cacheSizeEstimate), (int)cacheSizeEstimate);
 	}
 
 	s64 secondCacheSizeEstimate = SecondCacheSizeEstimate();
@@ -896,7 +896,7 @@ void TextureCacheCommon::Decimate(TexCacheEntry *exceptThisOne, bool forcePressu
 			}
 		}
 
-		VERBOSE_LOG(Log::G3D, "Decimated second texture cache, saved %d estimated bytes - now %d bytes", had - secondCacheSizeEstimate, secondCacheSizeEstimate);
+		VERBOSE_LOG(Log::G3D, "Decimated second texture cache, saved %d estimated bytes - now %d bytes", (int)(had - secondCacheSizeEstimate), (int)secondCacheSizeEstimate);
 	}
 
 	// Decimate known videos.

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -481,9 +481,19 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 
 	bool hasClut = gstate.isTextureFormatIndexed();
 	bool hasClutGPU = false;
+	bool clutInShader = false;
 	u32 cluthash;
 	if (hasClut) {
-		if (clutRenderAddress_ != 0xFFFFFFFF) {
+		if (PSP_CoreParameter().compat.flags().TextureCLUTInShader && !replacer_.Enabled() && (texFormat == GE_TFMT_CLUT8 || texFormat == GE_TFMT_CLUT4)) {
+			if (clutLastFormat_ != gstate.clutformat) {
+				// We update here because the clut format can be specified after the load.
+				// TODO: Unify this as far as possible (I think only GLES backend really needs its own implementation due to different component order).
+				UpdateCurrentClut(gstate.getClutPaletteFormat(), gstate.getClutIndexStartPos(), gstate.isClutIndexSimple());
+			}
+			// We computed clutHash_ (with underscore) above. But cluthash we set to 0, so the cache will collapse all the textures with various palettes.
+			cluthash = 0;
+			clutInShader = true;
+		} else if (clutRenderAddress_ != 0xFFFFFFFF) {
 			gstate_c.curTextureXOffset = 0.0f;
 			gstate_c.curTextureYOffset = 0.0f;
 			hasClutGPU = true;
@@ -706,13 +716,9 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 
 	entry->cluthash = cluthash;
 
-	/*
-	if (entry->maxLevel == 0 && (entry->format == GE_TFMT_CLUT8 || entry->format == GE_TFMT_CLUT4) &&
-		!(entry->status & TexStatus::TO_REPLACE) && !(entry->status & TexStatus::TO_SCALE) && !(entry->status & TexStatus::RELIABLE)) {
-		// Experiment with CLUT8 decoding for regular textures.
+	if (clutInShader) {
 		entry->status |= TexStatus::CLUT8_INDEXED;
 	}
-	*/
 
 	gstate_c.curTextureWidth = w;
 	gstate_c.curTextureHeight = h;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -282,8 +282,7 @@ SamplerCacheKey TextureCacheCommon::GetSamplingParams(int maxLevel, const TexCac
 			break;
 		case TEX_FILTER_FORCE_LINEAR:
 			// Override to linear filtering if there's no alpha or color testing going on.
-			if ((!gstate.isColorTestEnabled() || IsColorTestTriviallyTrue()) &&
-				(!gstate.isAlphaTestEnabled() || IsAlphaTestTriviallyTrue())) {
+			if (CanForceBilinear(gstate)) {
 				forceFiltering = TEX_FILTER_FORCE_LINEAR;
 			}
 			break;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -358,10 +358,12 @@ public:
 	void NotifyFramebuffer(VirtualFramebuffer *framebuffer, FramebufferNotification msg);
 	void NotifyWriteFormattedFromMemory(u32 addr, int size, int width, GEBufferFormat fmt);
 
-	size_t NumLoadedTextures() const {
-		return cache_.size();
+	int NumLoadedTextures() const {
+		return (int)cache_.size();
 	}
-
+	size_t NumSecondaryTextures() const {
+		return (int)secondCache_.size();
+	}
 	bool IsFakeMipmapChange() {
 		return PSP_CoreParameter().compat.flags().FakeMipmapChange && gstate.getTexLevelMode() == GE_TEXLEVEL_MODE_CONST;
 	}

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -374,14 +374,7 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, const ShaderLanguageDesc
 		return;
 
 	if (dirty & DIRTY_DEPAL) {
-		int indexMask = gstate.getClutIndexMask();
-		int indexShift = gstate.getClutIndexShift();
-		int indexOffset = gstate.getClutIndexStartPos() >> 4;
-		int format = gstate_c.depalTextureFormat;
-		uint32_t val = BytesToUint32(indexMask, indexShift, indexOffset, format);
-		// Poke in a bilinear filter flag in the top bit.
-		val |= gstate.isMagnifyFilteringEnabled() << 31;
-		render_->SetUniformUI1(&u_depal_mask_shift_off_fmt, val);
+		render_->SetUniformUI1(&u_depal_mask_shift_off_fmt, PackDepalBits());
 	}
 
 	// Set HUD mode

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -77,5 +77,3 @@ private:
 
 	enum { INVALID_TEX = -1 };
 };
-
-static Draw::DataFormat getClutDestFormat(GEPaletteFormat format);

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1797,7 +1797,7 @@ void GPUCommonHW::FormatGPUStatsCommon(StringWriter &w) {
 		"Draw: %d (%d dec, %d culled), flushes %d, clears %d, bbox jumps %d\n"
 		"%d soft. Vertices: %d dec: %d drawn: %d clipped tris: %d\n"
 		"FBOs active: %d (evaluations: %d, created %d)\n"
-		"Textures: %d, dec: %d, invalidated: %d, changed %d, hashed: %d kB, clut %d\n"
+		"Textures: %d (s: %d), dec: %d, invalidated: %d, changed %d, hashed: %d kB, clut %d\n"
 		"readbacks %d (%d non-block), upload %d (cached %d), depal %d\n"
 		"block transfers: %d\n"
 		"replacer: tracks %d references, %d unique textures\n"
@@ -1825,6 +1825,7 @@ void GPUCommonHW::FormatGPUStatsCommon(StringWriter &w) {
 		gpuStats.perFrame.numFramebufferEvaluations,
 		gpuStats.perFrame.numFBOsCreated,
 		(int)textureCache_->NumLoadedTextures(),
+		(int)textureCache_->NumSecondaryTextures(),
 		gpuStats.perFrame.numTexturesDecoded,
 		gpuStats.perFrame.numTextureInvalidations,
 		gpuStats.perFrame.numTexturesChanged,

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -716,4 +716,3 @@ class GPUInterface;
 class GPUCommon;
 
 extern GPUStateCache gstate_c;
-

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -112,7 +112,8 @@ struct ImConfig {
 	int selectedMemoryBlock = 0;
 	u32 selectedMpegCtx = 0;
 
-	uint64_t selectedTexAddr = 0;
+	uint64_t selectedTexId = 0;
+	bool selectedTexSecondary = false;
 
 	bool realtimePixelPreview = false;
 	int breakCount = 0;

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -156,7 +156,34 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 	}
 
 	if (!textureCache->SecondCache().empty()) {
-		ImGui::Text("Secondary Cache (%d): TODO", (int)textureCache->SecondCache().size());
+		ImGui::Text("Secondary Cache (%d):", (int)textureCache->SecondCache().size());
+
+		for (auto &iter : textureCache->SecondCache()) {
+			u64 id = iter.first;
+			const TexCacheEntry *entry = iter.second.get();
+			void *nativeView = textureCache->GetNativeTextureView(iter.second.get(), true);
+			int w = 128;
+			int h = 128;
+
+			if (entry->replacedTexture) {
+				replacementStateCounts[(int)entry->replacedTexture->State()]++;
+			}
+
+			ImTextureID texId = ImGui_ImplThin3d_AddNativeTextureTemp(nativeView);
+			float last_button_x2 = ImGui::GetItemRectMax().x;
+			float next_button_x2 = last_button_x2 + style.ItemSpacing.x + w; // Expected position if next button was on same line
+			if (next_button_x2 < window_visible_x2)
+				ImGui::SameLine();
+
+			float x = ImGui::GetCursorPosX();
+			if (ImGui::Selectable(("##Image" + std::to_string(id)).c_str(), cfg.selectedTexAddr == id, 0, ImVec2(w, h))) {
+				cfg.selectedTexAddr = id; // Update the selected index if clicked
+			}
+
+			ImGui::SameLine();
+			ImGui::SetCursorPosX(x + 2.0f);
+			ImGui::Image(texId, ImVec2(128, 128));
+		}
 		// TODO
 	}
 

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -128,40 +128,12 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 		ImGui::Text("Primary Cache");
 	}
 
-	for (auto &iter : textureCache->Cache()) {
-		u64 id = iter.first;
-		const TexCacheEntry *entry = iter.second.get();
-		void *nativeView = textureCache->GetNativeTextureView(iter.second.get(), true);
-		int w = 128;
-		int h = 128;
-
-		if (entry->replacedTexture) {
-			replacementStateCounts[(int)entry->replacedTexture->State()]++;
-		}
-
-		ImTextureID texId = ImGui_ImplThin3d_AddNativeTextureTemp(nativeView);
-		float last_button_x2 = ImGui::GetItemRectMax().x;
-		float next_button_x2 = last_button_x2 + style.ItemSpacing.x + w; // Expected position if next button was on same line
-		if (next_button_x2 < window_visible_x2)
-			ImGui::SameLine();
-
-		float x = ImGui::GetCursorPosX();
-		if (ImGui::Selectable(("##Image" + std::to_string(id)).c_str(), cfg.selectedTexAddr == id, 0, ImVec2(w, h))) {
-			cfg.selectedTexAddr = id; // Update the selected index if clicked
-		}
-
-		ImGui::SameLine();
-		ImGui::SetCursorPosX(x + 2.0f);
-		ImGui::Image(texId, ImVec2(128, 128));
-	}
-
-	if (!textureCache->SecondCache().empty()) {
-		ImGui::Text("Secondary Cache (%d):", (int)textureCache->SecondCache().size());
-
-		for (auto &iter : textureCache->SecondCache()) {
-			u64 id = iter.first;
-			const TexCacheEntry *entry = iter.second.get();
-			void *nativeView = textureCache->GetNativeTextureView(iter.second.get(), true);
+	auto listTextureCache = [&cfg, &textureCache, &style, window_visible_x2, &replacementStateCounts](const TexCache &cache, bool isSecondary) {
+		for (auto &[key, value] : cache) {
+			u64 id = key;
+			ImGui::PushID((void *)id);
+			const TexCacheEntry *entry = value.get();
+			void *nativeView = textureCache->GetNativeTextureView(value.get(), true);
 			int w = 128;
 			int h = 128;
 
@@ -176,15 +148,24 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 				ImGui::SameLine();
 
 			float x = ImGui::GetCursorPosX();
-			if (ImGui::Selectable(("##Image" + std::to_string(id)).c_str(), cfg.selectedTexAddr == id, 0, ImVec2(w, h))) {
-				cfg.selectedTexAddr = id; // Update the selected index if clicked
+			if (ImGui::Selectable(("##Image" + std::to_string(id)).c_str(), cfg.selectedTexId == id, 0, ImVec2(w, h))) {
+				cfg.selectedTexId = id; // Update the selected index if clicked
+				cfg.selectedTexSecondary = isSecondary;
 			}
 
 			ImGui::SameLine();
 			ImGui::SetCursorPosX(x + 2.0f);
 			ImGui::Image(texId, ImVec2(128, 128));
+			ImGui::PopID();
 		}
-		// TODO
+	};
+
+	listTextureCache(textureCache->Cache(), false);
+
+	if (!textureCache->SecondCache().empty()) {
+		ImGui::Text("Secondary Cache (%d):", (int)textureCache->SecondCache().size());
+
+		listTextureCache(textureCache->SecondCache(), true);
 	}
 
 	ImGui::EndChild();
@@ -192,9 +173,10 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 	ImGui::SameLine();
 	ImGui::BeginChild("right", ImVec2(0.f, 0.0f));
 	if (ImGui::CollapsingHeader("Texture", nullptr, ImGuiTreeNodeFlags_DefaultOpen)) {
-		if (cfg.selectedTexAddr) {
-			auto iter = textureCache->Cache().find(cfg.selectedTexAddr);
-			if (iter != textureCache->Cache().end()) {
+		if (cfg.selectedTexId) {
+			auto &cache = cfg.selectedTexSecondary ? textureCache->SecondCache() : textureCache->Cache();
+			auto iter = cache.find(cfg.selectedTexId);
+			if (iter != cache.end()) {
 				void *nativeView = textureCache->GetNativeTextureView(iter->second.get(), true);
 				ImTextureID texId = ImGui_ImplThin3d_AddNativeTextureTemp(nativeView);
 				const TexCacheEntry *entry = iter->second.get();
@@ -202,7 +184,13 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 				int w = dimWidth(dim);
 				int h = dimHeight(dim);
 				ImGui::Image(texId, ImVec2(w, h));
-				ImGui::Text("%08x: %dx%d, %d mips, %s", (uint32_t)(cfg.selectedTexAddr & 0xFFFFFFFF), w, h, entry->maxLevel + 1, GeTextureFormatToString((GETextureFormat)entry->format));
+				if (cfg.selectedTexSecondary) {
+					// For the secondary cache, the ID is based on the contents.
+					ImGui::Text("Hash: %08x: %dx%d, %d mips, %s", (uint32_t)(cfg.selectedTexId & 0xFFFFFFFF), w, h, entry->maxLevel + 1, GeTextureFormatToString((GETextureFormat)entry->format));
+				} else {
+					// Address is packed in the ID
+					ImGui::Text("Addr: %08x: %dx%d, %d mips, %s", (uint32_t)(cfg.selectedTexId & 0xFFFFFFFF), w, h, entry->maxLevel + 1, GeTextureFormatToString((GETextureFormat)entry->format));
+				}
 				ImGui::Text("Stride: %d", entry->bufw);
 				ImGui::Text("Status: %08x: %s", entry->status, TexStatusToString(entry->status).c_str());
 				ImGui::Text("Hash: %08x", entry->fullhash);
@@ -229,7 +217,7 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 					ImGui::Text("Not replaced");
 				}
 			} else {
-				cfg.selectedTexAddr = 0;
+				cfg.selectedTexId = 0;
 			}
 		} else {
 			ImGui::Text("(no texture selected)");

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2140,3 +2140,8 @@ ULKS46087 = 0.5
 # Tokiden (issue #19422)
 # This works in the provided dump, but needs more testing.
 # NPJH50878 = -0.4
+
+[TextureCLUTInShader]
+# See #15251. This drastically reduces the amount of textures decoded by the game, but due to lots of tile modifications
+# the number is still pretty high.
+# NPJH50698 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2142,6 +2142,6 @@ ULKS46087 = 0.5
 # NPJH50878 = -0.4
 
 [TextureCLUTInShader]
-# See #15251. This drastically reduces the amount of textures decoded by the game, but due to lots of tile modifications
-# the number is still pretty high.
-# NPJH50698 = true
+# Fushigi no Dungeon 4. See #15251. This drastically reduces the amount of textures decoded by the game,
+# but due to lots of tile modifications the number is still pretty high.
+NPJH50698 = true


### PR DESCRIPTION
Also adds support for the secondary texture cache in the ImGe debugger, and cleans up some logging.

The compat flag can be used to improve things like #15251 .