### PR TITLE
Misc optimizations and tweaks, always enable secondary texture cache

### DIFF
--- a/Common/Data/Convert/SmallDataConvert.h
+++ b/Common/Data/Convert/SmallDataConvert.h
@@ -107,7 +107,7 @@ inline void Uint8x3ToFloat4(float f[4], uint32_t u) {
 	f[0] = ((u >> 0) & 0xFF) * (1.0f / 255.0f);
 	f[1] = ((u >> 8) & 0xFF) * (1.0f / 255.0f);
 	f[2] = ((u >> 16) & 0xFF) * (1.0f / 255.0f);
-	f[3] = ((u >> 24) & 0xFF) * (1.0f / 255.0f);
+	f[3] = 0.0f;
 #endif
 }
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -977,10 +977,9 @@ void VulkanRenderManager::EndCurRenderStep() {
 		}
 	}
 
-	compileQueueMutex_.lock();
-	if (needsCompile)
+	if (needsCompile) {
 		compileCond_.notify_one();
-	compileQueueMutex_.unlock();
+	}
 	pipelinesToCheck_.clear();
 
 	// We don't do this optimization for very small targets, probably not worth it.
@@ -1865,7 +1864,7 @@ void VKRPipelineLayout::FlushDescSets(VulkanContext *vulkan, int frame, QueuePro
 
 	pool.Reset();
 
-	VkDescriptorSet setCache[8];
+	VkDescriptorSet setCache[16];
 	VkDescriptorSetLayout layoutsForAlloc[ARRAY_SIZE(setCache)];
 	for (int i = 0; i < ARRAY_SIZE(setCache); i++) {
 		layoutsForAlloc[i] = descriptorSetLayout;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <unordered_map>
 
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
@@ -598,6 +599,8 @@ private:
 	AutoRef<VKSamplerState> boundSamplers_[MAX_BOUND_TEXTURES];
 	VkImageView boundImageView_[MAX_BOUND_TEXTURES]{};
 	TextureBindFlags boundTextureFlags_[MAX_BOUND_TEXTURES]{};
+
+	mutable std::unordered_map<DataFormat, uint32_t> dataFormatSupportCache_;
 
 	VulkanPushPool *push_ = nullptr;
 
@@ -1730,6 +1733,11 @@ std::vector<std::string> VKContext::GetExtensionList(bool device, bool enabledOn
 }
 
 uint32_t VKContext::GetDataFormatSupport(DataFormat fmt) const {
+	auto iter = dataFormatSupportCache_.find(fmt);
+	if (iter != dataFormatSupportCache_.end()) {
+		return iter->second;
+	}
+
 	VkFormat vulkan_format = DataFormatToVulkan(fmt);
 	VkFormatProperties properties;
 	vkGetPhysicalDeviceFormatProperties(vulkan_->GetCurrentPhysicalDevice(), vulkan_format, &properties);
@@ -1752,6 +1760,7 @@ uint32_t VKContext::GetDataFormatSupport(DataFormat fmt) const {
 	if (properties.optimalTilingFeatures & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) {
 		flags |= FMT_STORAGE_IMAGE;
 	}
+	dataFormatSupportCache_[fmt] = flags;
 	return flags;
 }
 

--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -84,24 +84,6 @@ void DrawBuffer::Flush(bool set_blend_state) {
 	count_ = 0;
 }
 
-void DrawBuffer::V(float x, float y, float z, uint32_t color, float u, float v) {
-	_dbg_assert_msg_(count_ < MAX_VERTS, "Overflowed the DrawBuffer");
-
-#ifdef _DEBUG
-	if (my_isnanorinf(x) || my_isnanorinf(y) || my_isnanorinf(z)) {
-		_assert_(false);
-	}
-#endif
-
-	Vertex *vert = &verts_[count_++];
-	vert->x = x;
-	vert->y = y;
-	vert->z = z;
-	vert->rgba = alpha_ == 1.0f ? color : alphaMul(color, alpha_);
-	vert->u = u;
-	vert->v = v;
-}
-
 void DrawBuffer::Rect(float x, float y, float w, float h, uint32_t color, int align) {
 	DoAlign(align, &x, &y, &w, &h);
 	RectVGradient(x, y, x + w, y + h, color, color);

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -87,7 +87,22 @@ public:
 	}
 	void Rect(float x, float y, float w, float h, float u, float v, float uw, float uh, uint32_t color);
 
-	void V(float x, float y, float z, uint32_t color, float u, float v);
+	void V(float x, float y, float z, uint32_t color, float u, float v) {
+		_dbg_assert_msg_(count_ < MAX_VERTS, "Overflowed the DrawBuffer");
+
+#ifdef _DEBUG
+		if (my_isnanorinf(x) || my_isnanorinf(y) || my_isnanorinf(z)) {
+			_assert_(false);
+		}
+#endif
+		Vertex *vert = &verts_[count_++];
+		vert->x = x;
+		vert->y = y;
+		vert->z = z;
+		vert->rgba = alpha_ == 1.0f ? color : alphaMul(color, alpha_);
+		vert->u = u;
+		vert->v = v;
+	}
 	void V(float x, float y, uint32_t color, float u, float v) {
 		V(x, y, curZ_, color, u, v);
 	}

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -9,6 +9,7 @@
 #include "Common/Render/TextureAtlas.h"
 #include "Common/Math/geom2d.h"
 #include "Common/Math/lin/matrix4x4.h"
+#include "Common/Math/math_util.h"
 #include "Common/GPU/thin3d.h"
 
 struct Atlas;

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -134,7 +134,6 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceLowerResolutionForEffectsOff", &flags_.ForceLowerResolutionForEffectsOff);
 	CheckSetting(iniFile, gameID, "AllowDownloadCLUT", &flags_.AllowDownloadCLUT);
 	CheckSetting(iniFile, gameID, "NearestFilteringOnFramebufferCreate", &flags_.NearestFilteringOnFramebufferCreate);
-	CheckSetting(iniFile, gameID, "SecondaryTextureCache", &flags_.SecondaryTextureCache);
 	CheckSetting(iniFile, gameID, "EnglishOrJapaneseOnly", &flags_.EnglishOrJapaneseOnly);
 	CheckSetting(iniFile, gameID, "OldAdrenoPixelDepthRoundingGL", &flags_.OldAdrenoPixelDepthRoundingGL);
 	CheckSetting(iniFile, gameID, "ForceCircleButtonConfirm", &flags_.ForceCircleButtonConfirm);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -89,7 +89,6 @@ struct CompatFlags {
 	bool ForceLowerResolutionForEffectsOff;
 	bool AllowDownloadCLUT;
 	bool NearestFilteringOnFramebufferCreate;
-	bool SecondaryTextureCache;
 	bool EnglishOrJapaneseOnly;
 	bool OldAdrenoPixelDepthRoundingGL;
 	bool ForceCircleButtonConfirm;

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -128,46 +128,6 @@ public:
 	void Comp_ColorConv(MIPSOpcode op) override;
 	void Comp_Vbfy(MIPSOpcode op) override;
 
-	// Non-NEON: VPFX
-
-	// NEON implementations of the VFPU ops.
-	void CompNEON_SV(MIPSOpcode op);
-	void CompNEON_SVQ(MIPSOpcode op);
-	void CompNEON_VVectorInit(MIPSOpcode op);
-	void CompNEON_VMatrixInit(MIPSOpcode op);
-	void CompNEON_VDot(MIPSOpcode op);
-	void CompNEON_VecDo3(MIPSOpcode op);
-	void CompNEON_VV2Op(MIPSOpcode op);
-	void CompNEON_Mftv(MIPSOpcode op);
-	void CompNEON_Vmfvc(MIPSOpcode op);
-	void CompNEON_Vmtvc(MIPSOpcode op);
-	void CompNEON_Vmmov(MIPSOpcode op);
-	void CompNEON_VScl(MIPSOpcode op);
-	void CompNEON_Vmmul(MIPSOpcode op);
-	void CompNEON_Vmscl(MIPSOpcode op);
-	void CompNEON_Vtfm(MIPSOpcode op);
-	void CompNEON_VHdp(MIPSOpcode op);
-	void CompNEON_VCrs(MIPSOpcode op);
-	void CompNEON_VDet(MIPSOpcode op);
-	void CompNEON_Vi2x(MIPSOpcode op);
-	void CompNEON_Vx2i(MIPSOpcode op);
-	void CompNEON_Vf2i(MIPSOpcode op);
-	void CompNEON_Vi2f(MIPSOpcode op);
-	void CompNEON_Vh2f(MIPSOpcode op);
-	void CompNEON_Vcst(MIPSOpcode op);
-	void CompNEON_Vhoriz(MIPSOpcode op);
-	void CompNEON_VRot(MIPSOpcode op);
-	void CompNEON_VIdt(MIPSOpcode op);
-	void CompNEON_Vcmp(MIPSOpcode op);
-	void CompNEON_Vcmov(MIPSOpcode op);
-	void CompNEON_Viim(MIPSOpcode op);
-	void CompNEON_Vfim(MIPSOpcode op);
-	void CompNEON_VCrossQuat(MIPSOpcode op);
-	void CompNEON_Vsgn(MIPSOpcode op);
-	void CompNEON_Vocp(MIPSOpcode op);
-	void CompNEON_ColorConv(MIPSOpcode op);
-	void CompNEON_Vbfy(MIPSOpcode op);
-
 	int Replace_fabsf() override;
 
 	JitBlockCache *GetBlockCache() override { return &blocks; }

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -118,20 +118,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool useBuffe
 	}
 
 	if (dirtyUniforms & DIRTY_FOGCOEF) {
-		float fogcoef[2] = {
-			getFloat24(gstate.fog1),
-			getFloat24(gstate.fog2),
-		};
-		// The PSP just ignores infnan here (ignoring IEEE), so take it down to a valid float.
-		// Workaround for https://github.com/hrydgard/ppsspp/issues/5384#issuecomment-38365988
-		if (my_isnanorinf(fogcoef[0])) {
-			// Not really sure what a sensible value might be, but let's try 64k.
-			fogcoef[0] = std::signbit(fogcoef[0]) ? -65535.0f : 65535.0f;
-		}
-		if (my_isnanorinf(fogcoef[1])) {
-			fogcoef[1] = std::signbit(fogcoef[1]) ? -65535.0f : 65535.0f;
-		}
-		CopyFloat2(ub->fogCoef, fogcoef);
+		UpdateFogCoef(gstate, ub->fogCoef);
 	}
 
 	if (dirtyUniforms & DIRTY_TEX_ALPHA_MUL) {
@@ -158,29 +145,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool useBuffe
 
 	// Texturing
 	if (dirtyUniforms & DIRTY_UVSCALEOFFSET) {
-		float widthFactor = 1.0f;
-		float heightFactor = 1.0f;
-		if (gstate_c.textureIsFramebuffer) {
-			const float invW = 1.0f / (float)gstate_c.curTextureWidth;
-			const float invH = 1.0f / (float)gstate_c.curTextureHeight;
-			const int w = gstate.getTextureWidth(0);
-			const int h = gstate.getTextureHeight(0);
-			widthFactor = (float)w * invW;
-			heightFactor = (float)h * invH;
-		}
-		if (gstate_c.submitType == SubmitType::HW_BEZIER || gstate_c.submitType == SubmitType::HW_SPLINE) {
-			// When we are generating UV coordinates through the bezier/spline, we need to apply the scaling.
-			// However, this is missing a check that we're not getting our UV:s supplied for us in the vertices.
-			ub->uvScaleOffset[0] = gstate_c.uv.uScale * widthFactor;
-			ub->uvScaleOffset[1] = gstate_c.uv.vScale * heightFactor;
-			ub->uvScaleOffset[2] = gstate_c.uv.uOff * widthFactor;
-			ub->uvScaleOffset[3] = gstate_c.uv.vOff * heightFactor;
-		} else {
-			ub->uvScaleOffset[0] = widthFactor;
-			ub->uvScaleOffset[1] = heightFactor;
-			ub->uvScaleOffset[2] = 0.0f;
-			ub->uvScaleOffset[3] = 0.0f;
-		}
+		UpdateUVScaleOff(gstate, ub->uvScaleOffset);
 	}
 
 	if (dirtyUniforms & DIRTY_BEZIERSPLINE) {
@@ -290,5 +255,19 @@ void BoneUpdateUniforms(UB_VS_Bones *ub, uint64_t dirtyUniforms) {
 		if (dirtyUniforms & (DIRTY_BONEMATRIX0 << i)) {
 			ConvertMatrix4x3To3x4Transposed(ub->bones[i], gstate.boneMatrix + 12 * i);
 		}
+	}
+}
+
+void UpdateFogCoef(const GPUgstate &state, float fogCoef[2]) {
+	fogCoef[0] = getFloat24(gstate.fog1);
+	fogCoef[1] = getFloat24(gstate.fog2);
+	// The PSP just ignores infnan here (ignoring IEEE), so take it down to a valid float.
+	// Workaround for https://github.com/hrydgard/ppsspp/issues/5384#issuecomment-38365988
+	if (my_isnanorinf(fogCoef[0])) {
+		// Not really sure what a sensible value might be, but let's try 64k.
+		fogCoef[0] = std::signbit(fogCoef[0]) ? -65535.0f : 65535.0f;
+	}
+	if (my_isnanorinf(fogCoef[1])) {
+		fogCoef[1] = std::signbit(fogCoef[1]) ? -65535.0f : 65535.0f;
 	}
 }

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 
 #include "ShaderCommon.h"
+#include "Common/Math/math_util.h"
+#include "GPU/GPUState.h"
 
 // Used by the "modern" backends that use uniform buffers. They can share this without issue.
 
@@ -120,3 +122,31 @@ void BoneUpdateUniforms(UB_VS_Bones *ub, uint64_t dirtyUniforms);
 
 uint32_t PackLightControlBits();
 uint32_t PackDepalBits();
+
+void UpdateFogCoef(const GPUgstate &state, float fogCoef[2]);
+
+// This happens so much that I want it inline.
+inline void UpdateUVScaleOff(const GPUgstate &state, float uvScaleOff[4]) {
+	float widthFactor;
+	float heightFactor;
+	if (gstate_c.textureIsFramebuffer) {
+		widthFactor = (float)gstate.getTextureWidth(0) / (float)gstate_c.curTextureWidth;
+		heightFactor = (float)gstate.getTextureHeight(0) / (float)gstate_c.curTextureHeight;
+	} else {
+		widthFactor = 1.0f;
+		heightFactor = 1.0f;
+	}
+	if (gstate_c.submitType == SubmitType::HW_BEZIER || gstate_c.submitType == SubmitType::HW_SPLINE) {
+		// When we are generating UV coordinates through the bezier/spline, we need to apply the scaling.
+		// However, this is missing a check that we're not getting our UV:s supplied for us in the vertices.
+		uvScaleOff[0] = gstate_c.uv.uScale * widthFactor;
+		uvScaleOff[1] = gstate_c.uv.vScale * heightFactor;
+		uvScaleOff[2] = gstate_c.uv.uOff * widthFactor;
+		uvScaleOff[3] = gstate_c.uv.vOff * heightFactor;
+	} else {
+		uvScaleOff[0] = widthFactor;
+		uvScaleOff[1] = heightFactor;
+		uvScaleOff[2] = 0.0f;
+		uvScaleOff[3] = 0.0f;
+	}
+}

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -31,6 +31,7 @@
 #include "GPU/Common/FramebufferManagerCommon.h"
 #include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/SoftwareTransformCommon.h"
+#include "GPU/Common/ShaderUniforms.h"
 #include "GPU/Common/TransformCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/Common/VertexReader.h"
@@ -62,7 +63,8 @@ static SoftwareTransformAction ProjectClipAndExpand(SoftwareTransformParams &par
 // Note: 0 is BR and 2 is TL.
 
 // The PSP has a funky mechanism where the UV direction of screen-space rectangles is decided by the relative positioning
-// of the two corners defining the rectangle.
+// of the two corners defining the rectangle. This all boils down to a simple swap of the UVs of the two middle vertices,
+// after a check.
 static void RotateUV(TransformedVertex v[4]) {
 	const float x1 = v[2].x;
 	const float x2 = v[0].x;
@@ -212,17 +214,10 @@ SoftwareTransformAction RunSoftwareTransform(SoftwareTransformParams &params, in
 		}
 	} else {
 		Lighter lighter(vertType);
-		float fog_end = getFloat24(gstate.fog1);
-		float fog_slope = getFloat24(gstate.fog2);
-		// Same fixup as in ShaderManagerGLES.cpp
-		// Not really sure what a sensible value might be, but let's try 64k.
-		constexpr float largeFogValue = 65535.0f;
-		if (my_isnanorinf(fog_end)) {
-			fog_end = std::signbit(fog_end) ? -largeFogValue : largeFogValue;
-		}
-		if (my_isnanorinf(fog_slope)) {
-			fog_slope = std::signbit(fog_slope) ? -largeFogValue : largeFogValue;
-		}
+		float fogVal[2];
+		UpdateFogCoef(gstate, fogVal);
+		const float fog_end = fogVal[0];
+		const float fog_slope = fogVal[1];
 
 		const int texW = gstate.getTextureWidth(0);
 		const int texH = gstate.getTextureHeight(0);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -877,7 +877,7 @@ void TextureCacheCommon::Decimate(TexCacheEntry *exceptThisOne, bool forcePressu
 
 	s64 secondCacheSizeEstimate = SecondCacheSizeEstimate();
 	// If enabled, we also need to clear the secondary cache.
-	if (PSP_CoreParameter().compat.flags().SecondaryTextureCache && (forcePressure || secondCacheSizeEstimate >= TEXCACHE_SECOND_MIN_PRESSURE)) {
+	if (forcePressure || secondCacheSizeEstimate >= TEXCACHE_SECOND_MIN_PRESSURE) {
 		const u32 had = secondCacheSizeEstimate;
 
 		for (TexCache::iterator iter = secondCache_.begin(); iter != secondCache_.end(); ) {
@@ -2651,8 +2651,8 @@ bool TextureCacheCommon::CheckFullHash(TexCacheEntry *entry, bool &doDelete) {
 	}
 
 	// Don't give up just yet.
-	// Let's try the secondary cache if it's been invalidated before.
-	if (PSP_CoreParameter().compat.flags().SecondaryTextureCache) {
+	// Let's try the secondary cache if it's been invalidated before (and we're not dealing with detected video).
+	if (!isVideo) {
 		// If it's failed a bunch of times, then the second cache is just wasting time and VRAM.
 		// In that case, skip.
 		if (entry->numInvalidated > 2 && entry->numInvalidated < 128 && !lowMemoryMode_) {

--- a/GPU/Common/VertexDecoderHandwritten.cpp
+++ b/GPU/Common/VertexDecoderHandwritten.cpp
@@ -177,14 +177,14 @@ void VtxDec_Tu8_C5551_Ps16(const u8 *srcp, u8 *dstp, int numVerts, const UVScale
 		__m128 pos0_ext = _mm_mul_ps(_mm_cvtepi32_ps(pos0_32), posScale);
 		__m128 pos1_ext = _mm_mul_ps(_mm_cvtepi32_ps(pos1_32), posScale);
 
-		__m128i uv8 = _mm_set1_epi32(uv0);
+		__m128i uv8 = _mm_cvtsi32_si128(uv0);
 		__m128i uv16 = _mm_unpacklo_epi8(uv8, uv8);
 		__m128i uv32 = _mm_srli_epi32(_mm_unpacklo_epi16(uv16, uv16), 24);
 		__m128d uvf = _mm_castps_pd(_mm_add_ps(_mm_mul_ps(_mm_cvtepi32_ps(uv32), uvScale), uvOff));
 		alpha &= col0;
 
 		// Combined 5551 -> 8888 RGBA. Nasty.
-		__m128i col = _mm_set1_epi64x(col0);
+		__m128i col = _mm_cvtsi64_si128(col0);
 		__m128i r = _mm_slli_epi32(_mm_and_si128(col, rmask), 8 - 5);
 		__m128i g = _mm_slli_epi32(_mm_and_si128(col, gmask), 16 - 10);
 		__m128i b = _mm_slli_epi32(_mm_and_si128(col, bmask), 24 - 15);

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -324,7 +324,7 @@ void DrawEngineD3D11::Flush() {
 		bool useElements;
 		DecodeVerts(dec_, decoded_);
 		DecodeIndsAndGetData(&prim, &vertexCount, &maxIndex, &useElements, false);
-		gpuStats.perFrame.numUncachedVertsDrawn += vertexCount;
+		gpuStats.perFrame.numVertsDrawn += vertexCount;
 
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
@@ -412,7 +412,6 @@ void DrawEngineD3D11::Flush() {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		gpuStats.perFrame.numUncachedVertsDrawn += vertexCount;
 		prim = IndexGenerator::GeneralPrim((GEPrimitiveType)drawInds_[0].prim);
 		VERBOSE_LOG(Log::G3D, "Flush prim %i SW! %i verts in one go", prim, vertexCount);
 
@@ -492,6 +491,7 @@ void DrawEngineD3D11::Flush() {
 			pushInds_->EndPush(context_);
 			context_->IASetIndexBuffer(pushInds_->Buf(), DXGI_FORMAT_R16_UINT, iOffset);
 			context_->DrawIndexed(result.drawIndexCount, 0, 0);
+			gpuStats.perFrame.numVertsDrawn += result.drawIndexCount;
 		} else if (action == SW_CLEAR) {
 			u32 clearColor = result.color;
 			float clearDepth = result.depth;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -303,6 +303,7 @@ void DrawEngineGLES::Flush() {
 		bool useElements;
 		DecodeVerts(dec_, decoded_);
 		DecodeIndsAndGetData(&prim, &vertexCount, &maxIndex, &useElements, false);
+		gpuStats.perFrame.numVertsDrawn += vertexCount;
 
 		if (useElements) {
 			uint32_t esz = sizeof(uint16_t) * vertexCount;
@@ -361,7 +362,6 @@ void DrawEngineGLES::Flush() {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		gpuStats.perFrame.numUncachedVertsDrawn += vertexCount;
 		prim = IndexGenerator::GeneralPrim((GEPrimitiveType)drawInds_[0].prim);
 
 		int maxIndex = numDecodedVerts_;
@@ -424,6 +424,7 @@ void DrawEngineGLES::Flush() {
 			render_->DrawIndexed(
 				softwareInputLayout_, vertexBuffer, vertexBufferOffset, indexBuffer, indexBufferOffset,
 				glprim[prim], result.drawIndexCount, GL_UNSIGNED_SHORT);
+			gpuStats.perFrame.numVertsDrawn += result.drawIndexCount;
 		} else if (action == SW_CLEAR) {
 			u32 clearColor = result.color;
 			float clearDepth = result.depth;

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -447,46 +447,13 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, const ShaderLanguageDesc
 		}
 	}
 	if (dirty & DIRTY_FOGCOEF) {
-		float fogcoef[2] = {
-			getFloat24(gstate.fog1),
-			getFloat24(gstate.fog2),
-		};
-		// The PSP just ignores infnan here (ignoring IEEE), so take it down to a valid float.
-		// Workaround for https://github.com/hrydgard/ppsspp/issues/5384#issuecomment-38365988
-		if (my_isnanorinf(fogcoef[0])) {
-			// Not really sure what a sensible value might be, but let's try 64k.
-			fogcoef[0] = std::signbit(fogcoef[0]) ? -65535.0f : 65535.0f;
-		}
-		if (my_isnanorinf(fogcoef[1])) {
-			fogcoef[1] = std::signbit(fogcoef[1]) ? -65535.0f : 65535.0f;
-		}
+		float fogcoef[2];
+		UpdateFogCoef(gstate, fogcoef);
 		render_->SetUniformF(&u_fogcoef, 2, fogcoef);
 	}
 	if (dirty & DIRTY_UVSCALEOFFSET) {
-		float widthFactor = 1.0f;
-		float heightFactor = 1.0f;
-		if (gstate_c.textureIsFramebuffer) {
-			const float invW = 1.0f / (float)gstate_c.curTextureWidth;
-			const float invH = 1.0f / (float)gstate_c.curTextureHeight;
-			const int w = gstate.getTextureWidth(0);
-			const int h = gstate.getTextureHeight(0);
-			widthFactor = (float)w * invW;
-			heightFactor = (float)h * invH;
-		}
 		float uvscaleoff[4];
-		if (gstate_c.submitType == SubmitType::HW_BEZIER || gstate_c.submitType == SubmitType::HW_SPLINE) {
-			// When we are generating UV coordinates through the bezier/spline, we need to apply the scaling.
-			// However, this is missing a check that we're not getting our UV:s supplied for us in the vertices.
-			uvscaleoff[0] = gstate_c.uv.uScale * widthFactor;
-			uvscaleoff[1] = gstate_c.uv.vScale * heightFactor;
-			uvscaleoff[2] = gstate_c.uv.uOff * widthFactor;
-			uvscaleoff[3] = gstate_c.uv.vOff * heightFactor;
-		} else {
-			uvscaleoff[0] = widthFactor;
-			uvscaleoff[1] = heightFactor;
-			uvscaleoff[2] = 0.0f;
-			uvscaleoff[3] = 0.0f;
-		}
+		UpdateUVScaleOff(gstate, uvscaleoff);
 		render_->SetUniformF(&u_uvscaleoffset, 4, uvscaleoff);
 	}
 

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -104,7 +104,7 @@ struct GPUStatsPerFrame {
 	int numBBOXJumps;
 	int numVertsSubmitted;
 	int numVertsDecoded;
-	int numUncachedVertsDrawn;
+	int numVertsDrawn;
 	int numTextureInvalidations;
 	int numTexturesChanged;
 	int numTextureInvalidationsByFramebuffer;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1819,7 +1819,7 @@ void GPUCommonHW::FormatGPUStatsCommon(StringWriter &w) {
 		gpuStats.perFrame.numSoftTransformedDraws,
 		gpuStats.perFrame.numVertsSubmitted,
 		gpuStats.perFrame.numVertsDecoded,
-		gpuStats.perFrame.numUncachedVertsDrawn,
+		gpuStats.perFrame.numVertsDrawn,
 		gpuStats.perFrame.numSoftClippedTriangles,
 		(int)framebufferManager_->NumVFBs(),
 		gpuStats.perFrame.numFramebufferEvaluations,

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -20,6 +20,7 @@
 #include "Common/Math/SIMDHeaders.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
+#include "Common/Math/CrossSIMD.h"
 #include "Core/MemMap.h"
 #include "GPU/ge_constants.h"
 #include "GPU/GPUCommon.h"
@@ -168,7 +169,7 @@ void GPUgstate::Save(u32_le *ptr) {
 }
 
 void GPUgstate::FastLoadBoneMatrix(u32 addr) {
-	const u32_le *src = (const u32_le *)Memory::GetPointerUnchecked(addr);
+	const u32 *src = (const u32 *)Memory::GetPointerUnchecked(addr);
 	u32 num = boneMatrixNumber;
 	u32 *dst = (u32 *)(boneMatrix + (num & 0x7F));
 
@@ -186,6 +187,13 @@ void GPUgstate::FastLoadBoneMatrix(u32 addr) {
 	vst1q_u32(dst, row1);
 	vst1q_u32(dst + 4, row2);
 	vst1q_u32(dst + 8, row3);
+#elif !CROSSSIMD_SLOW
+	Vec4F32 row1 = Vec4F32::LoadF24x4(src);
+	Vec4F32 row2 = Vec4F32::LoadF24x4(src + 4);
+	Vec4F32 row3 = Vec4F32::LoadF24x4(src + 8);
+	row1.Store((float *)dst);
+	row2.Store((float *)(dst + 4));
+	row3.Store((float *)(dst + 8));
 #else
 	for (int i = 0; i < 12; i++) {
 		dst[i] = src[i] << 8;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -292,6 +292,7 @@ void DrawEngineVulkan::Flush() {
 		int maxIndex;
 		bool useElements;
 		DecodeIndsAndGetData(&prim, &vertexCount, &maxIndex, &useElements, false);
+		gpuStats.perFrame.numVertsDrawn += vertexCount;
 
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
@@ -420,7 +421,7 @@ void DrawEngineVulkan::Flush() {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		gpuStats.perFrame.numUncachedVertsDrawn += vertexCount;
+		gpuStats.perFrame.numVertsDrawn += vertexCount;
 		prim = IndexGenerator::GeneralPrim((GEPrimitiveType)drawInds_[0].prim);
 
 		// At this point, the output is always an indexed triangle/line/point list, no strips/fans.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -140,6 +140,7 @@ android {
 	}
 	buildTypes {
 		getByName("debug") {
+			isDefault = true
 			isMinifyEnabled = false
 			isJniDebuggable = true
 			signingConfig = signingConfigs.getByName("debug")
@@ -191,6 +192,7 @@ android {
 	}
 	productFlavors {
 		create("normal") {
+			isDefault = true
 			applicationId = "org.ppsspp.ppsspp"
 			dimension = "variant"
 			externalNativeBuild {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1580,30 +1580,6 @@ NPJH50366 = true
 # Temporary compatibility option, while working on the GPU CLUT-from-framebuffer path.
 # Not required for any games now that it works, but might be useful for development.
 
-[SecondaryTextureCache]
-# Was previously the "Retain changed textures" setting.
-# See https://github.com/hrydgard/ppsspp/issues/16339#issuecomment-1304826656
-
-# Popolocrois
-UCJS10005 = true
-UCAS40009 = true
-ULUS10018 = true
-UCJS18003 = true
-ULES00291 = true
-NPJG00033 = true
-
-# Fushigi no Dungeon: Fuurai no Shiren 4 Plus - Kami no Hitomi to Akuma no Heso
-ULJS00547 = true
-NPJH50698 = true
-
-# Gran Turismo text rendering
-UCES01245 = true
-UCUS98632 = true
-UCJS10100 = true
-UCKS45127 = true
-UCJS18055 = true
-NPJG00027 = true
-
 [EnglishOrJapaneseOnly]
 # Twinbee Portable, see issue #16382
 ULAS42089 = true


### PR DESCRIPTION
Just a bunch of small stuff found after doing some profiling on Android.

Also, we now always enable the "secondary texture cache", or "retain changed textures" which was the slightly more descriptive old name, instead of using a compat flag. It moves changed textures to a secondary cache so that if the same texture appears again later, it doesn't need to be decoded again. It seems to be very low overhead now and working well, after I made it exclude video textures...