### PR TITLE
Fix the ugly line on Ridge Racer lens flares

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2498,6 +2498,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 }
 
 // Applies depal to a normal (non-framebuffer) texture, pre-decoded to CLUT8 format.
+// TODO: Merge this function with the above.
 void TextureCacheCommon::ApplyTextureDepalFramebufferCLUT(TexCacheEntry *entry) {
 	uint32_t clutMode = gstate.clutformat & 0xFFFFFF;
 
@@ -2544,6 +2545,14 @@ void TextureCacheCommon::ApplyTextureDepalFramebufferCLUT(TexCacheEntry *entry) 
 		v2 = bounds.maxV + gstate_c.curTextureYOffset + 1.0f;
 		// We need to reapply the texture next time since we cropped UV.
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
+	}
+
+	// If it nearly covers, just make it cover. This fixes Ridge Racer where the UVs are slightly off and it causes a bright line on the lens flare.
+	if (u1 > 0 && u1 < 3) {
+		u1 = 0;
+	}
+	if (v1 > 0 && v1 < 3) {
+		v1 = 0;
 	}
 
 	Draw::Framebuffer *depalFBO = framebufferManager_->GetTempFBO(TempFBO::DEPAL, texWidth, texHeight);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2069,6 +2069,8 @@ ULES00968 = true
 ULES00969 = true
 
 [SpriteBorderFix]
+# TODO: We really need some kind of aggregation method... saying that Ridge racer is this list of IDs.
+
 # For more information see #21789
 
 # Pushes texture coordinates slightly inwards on detected 2D sprites, to avoid edge glitches.
@@ -2112,6 +2114,25 @@ ULJS00097 = -0.25
 ULES00262 = 0.5
 ULUS10064 = 0.5
 ULKS46087 = 0.5
+
+# Ridge Racer/Ridge Racer 2
+
+# Ridge Racer
+ULJS00001 = 0.5
+ULUS10001 = 0.5
+UCKS45002 = 0.5
+UCES00002 = 0.5
+ULJS19002 = 0.5
+UCKS45053 = 0.5
+NPJH50140 = 0.5
+
+# Ridge Racer 2
+ULJS00080 = 0.5
+UCKS45032 = 0.5
+UCES00422 = 0.5
+UCAS40273 = 0.5
+NPJH50366 = 0.5
+
 
 # Tokiden (issue #19422)
 # This works in the provided dump, but needs more testing.


### PR DESCRIPTION
Turns out we were not updating one column and row of the lens flare image, which is done in a strange way by the game (CLUT in framebuffer).

Some math of the game is a little off and for some reason it's not noticeable on hardware (probably 1x resolution, didn't test).

Fixes another part of #16083.