### PR TITLE
Apply compat settings for TOS: FVE and Metal Gear Solid: Portable Ops

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2034,6 +2034,9 @@ ULKS46257 = true
 ULJS19073 = true
 NPJH50848 = true
 
+# Tales of Phantasia FVE
+ULJS00079 = true
+
 [PersistentFramebuffers]
 # A few games render to framebuffers and count on them sticking around "forever", like Mahjong Artifacts.
 NPUZ00062 = true  # Mahjong Artifacts (MJA)

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1299,6 +1299,10 @@ NPUG80135 = true
 # Webfest homebrew game (wireframe 3D rendering) looks substantially better with this.
 WEBF00752 = true
 
+# Metal Gear Solid: Portable Ops (see #20142)
+ULUS10202 = true
+ULES00645 = true
+
 [ZZT3SelectHack]
 # Bypass softlock on Zettai Zetsumei Toshi 3 character select screen #4901
 # This problem affects the game also on PS3


### PR DESCRIPTION
For TOS it works around a problem that caused some flicker and glitches.

For MGS, it's just line drawing. Fixes #20142