### PR TITLE
Windows 7 font rendering fix

### DIFF
--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -21,7 +21,7 @@
 #include "Common/Render/Text/draw_text_sdl.h"
 #include "Common/Render/Text/draw_text_uwp.h"
 #include "Common/StringUtils.h"
-
+#include "Common/OSVersion.h"
 
 // TODO: Move this to somewhere more appropriate.
 static bool IsRenderDocLoaded() {
@@ -304,7 +304,8 @@ TextDrawer *TextDrawer::Create(Draw::DrawContext *draw) {
 #elif defined(_WIN32) && !defined(USING_QT_UI)
 	// If RenderDoc is active, we can't use the UWP drawer since it uses D3D11 to initialize D2D,
 	// and RenderDoc doesn't permit multiple graphics contexts.
-	if (IsRenderDocLoaded()) {
+	// Also, this seems to cause failures under Windows 7, so let's gate on Win 10 to be safe.
+	if (IsRenderDocLoaded() || !IsWin10OrHigher()) {
 		drawer = new TextDrawerWin32(draw);
 	} else {
 		drawer = new TextDrawerUWP(draw);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -94,7 +94,6 @@
 #include "sceOpenPSID.h"
 #include "sceHttp.h"
 #include "Core/Util/PPGeDraw.h"
-#include "sceHttp.h"
 
 /*
 17: [MIPS32 R4K 00000000 ]: Loader: Type: 1 Vaddr: 00000000 Filesz: 2856816 Memsz: 2856816 
@@ -945,6 +944,7 @@ const HLEFunction ThreadManForKernel[] =
 	{0xB736E9FF, &WrapI_IU<sceKernelFreeVpl>,                        "sceKernelFreeVpl",                          'i', "ix",     HLE_KERNEL_SYSCALL },
 	{0x1D371B8A, &WrapI_IU<sceKernelCancelVpl>,                      "sceKernelCancelVpl",                        'i', "ix",     HLE_KERNEL_SYSCALL },
 	{0x39810265, &WrapI_IU<sceKernelReferVplStatus>,                 "sceKernelReferVplStatus",                   'i', "ip",     HLE_KERNEL_SYSCALL },
+	{0xBC31C1B9, nullptr, "sceKernelExtendKernelStack"},
 };
 
 void Register_ThreadManForUser()
@@ -974,6 +974,7 @@ const HLEFunction LoadExecForKernel[] =
 	{0XA3D5E142, nullptr,                                            "sceKernelExitVSHVSH",                       '?', ""        },
 	{0X28D0D249, &WrapI_CU<sceKernelLoadExec>,                       "sceKernelLoadExecVSHMs2",                   'i', "sx"      },
 	{0x6D302D3D, &WrapV_V<sceKernelExitGame>,                        "sceKernelExitVSHKernel",                    'v', "x", HLE_KERNEL_SYSCALL },// when called in game mode it will have the same effect that sceKernelExitGame 	
+	{0x05572A5F, &WrapV_V<sceKernelExitGame>,                        "sceKernelExitGame",                         'v', "", HLE_KERNEL_SYSCALL },
 };
  
 void Register_LoadExecForKernel()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -3490,6 +3490,7 @@ int sceKernelRegisterExitCallback(SceUID cbId)
 	return hleLogDebug(Log::sceKernel, 0);
 }
 
+// Update the exit callback status?
 int LoadExecForUser_362A956B()
 {
 	WARN_LOG_REPORT(Log::sceKernel, "LoadExecForUser_362A956B()");

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -1591,6 +1591,10 @@ const HLEFunction sceUtility[] =
 	{0XECE1D3E5, nullptr,                                          "sceUtility_ECE1D3E5",                    '?', ""   },
 	{0XEF3582B2, nullptr,                                          "sceUtility_EF3582B2",                    '?', ""   },
 
+	{0x05e242a1, nullptr,                                          "sceUtility_05e242a1",                    '?', ""   },
+	{0x644b513b, nullptr,                                          "sceUtility_644b513b",                    '?', ""   },
+	{0x043ebe3e, nullptr,                                          "sceUtility_043ebe3e",                    '?', ""   },
+
 	// Fake functions for PPSSPP's use.
 	{0xC0DE0001, &WrapI_I<UtilityFinishDialog>,                    "__UtilityFinishDialog",                  'i', "i"  },
 	{0xC0DE0002, &WrapI_I<UtilityWorkUs>,                          "__UtilityWorkUs",                        'i', "i"  },

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -88,6 +88,7 @@ static u32 sceVaudioSetEffectType(int effectType, int vol) {
 	return 0;
 }
 
+// SensMe shows that this controls the automatic audio volume normalizer
 static u32 sceVaudioSetAlcMode(int alcMode) {
 	ERROR_LOG_REPORT(Log::sceAudio, "UNIMPL sceVaudioSetAlcMode(%i)", alcMode);
 	return 0;


### PR DESCRIPTION
Turn off the new D2D font rendering in Windows versions before 10.

Hopefully fixes #21834 

Also throws in some new function NIDs I came across.