### PR TITLE
Vulkan pipeline checker: Check for duplicate pipelines with different vertex formats

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -999,7 +999,7 @@ bool DrawEngineCommon::DescribeCodePtr(const u8 *ptr, std::string &name) const {
 
 	if (found) {
 		char temp[256];
-		found->ToString(temp, false);
+		found->ToString(temp, sizeof(temp), false);
 		name = temp;
 		snprintf(temp, sizeof(temp), "_%08X", foundKey);
 		name += temp;

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -19,11 +19,13 @@ std::string ShaderID::ToDebugString() const {
 	return StringFromFormat("%08x:%08x", d >> 32, d & 0xFFFFFFFF);
 }
 
-std::string VShaderID::Description() const {
+std::string VShaderID::Description(bool includeID) const {
 	char buffer[512];
 	StringWriter desc(buffer, sizeof(buffer));
 
-	desc.W(ToDebugString()).C(" ");
+	if (includeID) {
+		desc.W(ToDebugString()).C(" ");
+	}
 	if (Bit(VS_BIT_IS_THROUGH)) desc.C("THR ");
 	if (Bit(VS_BIT_USE_HW_TRANSFORM)) desc.C("HWX "); else desc.C("SWX ");
 	if (Bit(VS_BIT_HAS_NORMAL)) desc.C("N ");
@@ -176,11 +178,13 @@ static bool MatrixNeedsProjection(const float m[12], GETexProjMapMode mode) {
 	return m[2] != 0.0f || m[5] != 0.0f || (m[8] != 0.0f && mode != GE_PROJMAP_UV) || m[11] != 1.0f;
 }
 
-std::string FShaderID::Description() const {
+std::string FShaderID::Description(bool includeID) const {
 	char buffer[512];
 	StringWriter desc(buffer, sizeof(buffer));
+	if (includeID) {
+		desc.W(ToDebugString()).C(" ");
+	}
 
-	desc.W(ToDebugString()).C(" ");
 	if (Bit(FS_BIT_CLEARMODE)) desc.C("Clear ");
 	if (Bit(FS_BIT_DO_TEXTURE)) {
 		desc.W(Bit(FS_BIT_3D_TEXTURE) ? "Tex3D" : "Tex");

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -343,6 +343,11 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 			id.SetBits(FS_BIT_SHADER_DEPAL_MODE, 2, (int)shaderDepalMode);
 			id.SetBits(FS_BIT_SHADER_DEPAL_FORMAT, 3, (int)shaderDepalFormat);
 			id.SetBit(FS_BIT_3D_TEXTURE, gstate_c.curTextureIs3D);
+			// All framebuffers are array textures in Vulkan now.
+			if (gstate_c.textureIsArray && gstate_c.Use(GPU_USE_FRAMEBUFFER_ARRAYS)) {
+				id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
+			}
+			id.SetBit(FS_BIT_DO_TEXTURE_PROJ, doTextureProjection);
 		}
 
 		id.SetBit(FS_BIT_LMODE, lmode);
@@ -364,7 +369,6 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		}
 
 		id.SetBit(FS_BIT_ENABLE_FOG, enableFog);  // TODO: Will be moved back to the ubershader.
-		id.SetBit(FS_BIT_DO_TEXTURE_PROJ, doTextureProjection);
 
 		// 2 bits
 		id.SetBits(FS_BIT_STENCIL_TO_ALPHA, 2, stencilToAlpha);
@@ -394,11 +398,6 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		}
 		id.SetBit(FS_BIT_FLATSHADE, doFlatShading);
 		id.SetBit(FS_BIT_COLOR_WRITEMASK, colorWriteMask);
-
-		// All framebuffers are array textures in Vulkan now.
-		if (gstate_c.textureIsArray && gstate_c.Use(GPU_USE_FRAMEBUFFER_ARRAYS)) {
-			id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
-		}
 
 		// Stereo support
 		if (gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -208,7 +208,7 @@ struct VShaderID : public ShaderID {
 
 	// Generates a compact string that describes the shader. Useful in a list to get an overview
 	// of the current flora of shaders.
-	std::string Description() const;
+	std::string Description(bool includeID = true) const;
 };
 
 struct FShaderID : public ShaderID {
@@ -235,7 +235,7 @@ struct FShaderID : public ShaderID {
 		ShaderID::SetBits((int)bit, count, value);
 	}
 
-	std::string Description() const;
+	std::string Description(bool includeID = true) const;
 };
 
 static_assert(sizeof(VShaderID) == sizeof(uint64_t), "VShaderID size mismatch");

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -259,7 +259,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			// Reset the code ptr and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
 			char temp[1024]{};
-			dec.ToString(temp, true);
+			dec.ToString(temp, sizeof(temp), true);
 			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return 0;
 		}
@@ -287,7 +287,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	/*
 	DisassembleArm(start, GetCodePtr() - start);
 	char temp[1024] = {0};
-	dec.ToString(temp, true);
+	dec.ToString(temp, sizeof(temp), true);
 	INFO_LOG(Log::G3D, "%s", temp);
 	*/
 

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -256,7 +256,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			// Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
 			char temp[1024]{};
-			dec.ToString(temp, true);
+			dec.ToString(temp, sizeof(temp), true);
 			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return nullptr;
 		}
@@ -291,7 +291,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	if (log) {
 		char temp[1024] = { 0 };
-		dec.ToString(temp, true);
+		dec.ToString(temp, sizeof(temp), true);
 		INFO_LOG(Log::JIT, "=== %s (%d bytes) ===", temp, (int)(GetCodePtr() - start));
 		std::vector<std::string> lines = DisassembleArm64(start, (int)(GetCodePtr() - start));
 		for (auto line : lines) {

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -23,6 +23,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Data/Convert/ColorConv.h"
+#include "Common/Data/Text/StringWriter.h"
 #include "Common/Math/CrossSIMD.h"
 #include "Common/Log.h"
 #include "Common/LogReporting.h"
@@ -82,6 +83,41 @@ static int DecFmtSize(u8 fmt) {
 	default:
 		return 0;
 	}
+}
+
+const char *DecFmtComponentToString(u8 fmt) {
+	switch (fmt) {
+	case DEC_NONE: return "NONE";
+	case DEC_FLOAT_1: return "FLOAT_1";
+	case DEC_FLOAT_2: return "FLOAT_2";
+	case DEC_FLOAT_3: return "FLOAT_3";
+	case DEC_FLOAT_4: return "FLOAT_4";
+	case DEC_S8_3: return "S8_3";
+	case DEC_S16_3: return "S16_3";
+	case DEC_U8_1:  return "U8_1";
+	case DEC_U8_2:  return "U8_2";
+	case DEC_U8_3:  return "U8_3";
+	case DEC_U8_4:  return "U8_4";
+	case DEC_U16_1: return "U16_1";
+	case DEC_U16_2: return "U16_2";
+	case DEC_U16_3: return "U16_3";
+	case DEC_U16_4: return "U16_4";
+	default: return "UNKNOWN";
+	}
+}
+
+std::string DecVtxFormat::ToString() const {
+	char buf[256];
+	StringWriter w(buf, sizeof(buf));
+	if (w0fmt) {
+		w.F("W0: %s ", DecFmtComponentToString(w0fmt));
+	}
+	w.F("W1: %s ", DecFmtComponentToString(w1fmt));
+	w.F("UV: %s ", DecFmtComponentToString(uvfmt));
+	w.F("C0: %s ", DecFmtComponentToString(c0fmt));
+	w.F("C1: %s ", DecFmtComponentToString(c1fmt));
+	w.F("N: %s", DecFmtComponentToString(nrmfmt));
+	return w.as_string();
 }
 
 void DecVtxFormat::ComputeID() {
@@ -1413,7 +1449,7 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 
 	if (reportNoPos) {
 		char temp[256]{};
-		ToString(temp, true);
+		ToString(temp, sizeof(temp), true);
 		ERROR_LOG(Log::G3D, "Vertices without position found (and ignored): (%08x) %s", fmt_, temp);
 	}
 
@@ -1550,8 +1586,8 @@ void VertexDecoder::CompareToJit(const u8 *startPtr, u8 *decodedptr, int count, 
 		controlReader.Goto(i);
 		jittedReader.Goto(i);
 		if (!DecodedVertsAreSimilar(controlReader, jittedReader)) {
-			char name[512]{};
-			ToString(name, true);
+			char name[256]{};
+			ToString(name, sizeof(name), true);
 			ERROR_LOG(Log::G3D, "Encountered vertexjit mismatch at %d/%d for %s", i, count, name);
 			if (morphcount > 1) {
 				printf("Morph:\n");
@@ -1605,26 +1641,30 @@ static const char * const idxnames[4] = { "-", "u8", "u16", "?" };
 static const char * const weightnames[4] = { "-", "u8", "u16", "f" };
 static const char * const colnames[8] = { "", "?", "?", "?", "565", "5551", "4444", "8888" };
 
-int VertexDecoder::ToString(char *output, bool spaces) const {
-	char *start = output;
-	output += sprintf(output, "[%08x] ", fmt_);
-	output += sprintf(output, "P: %s ", posnames[pos]);
-	if (nrm)
-		output += sprintf(output, "N: %s ", nrmnames[nrm]);
-	if (col)
-		output += sprintf(output, "C: %s ", colnames[col]);
-	if (tc)
-		output += sprintf(output, "T: %s ", tcnames[tc]);
-	if (weighttype)
-		output += sprintf(output, "W: %s (%ix) ", weightnames[weighttype], nweights);
-	if (idx)
-		output += sprintf(output, "I: %s ", idxnames[idx]);
-	if (morphcount > 1)
-		output += sprintf(output, "Morph: %i ", morphcount);
-	if (throughmode)
-		output += sprintf(output, " (through)");
+// There's a direct ToString function for vertex types in the GPU debugger, GeDescribeVertexType.
 
-	output += sprintf(output, " (%ib)", VertexSize());
+int VertexDecoder::ToString(char *buf, int bufSize, bool spaces) const {
+	StringWriter w(buf, bufSize);
+
+	char *start = buf;
+	w.F("[%08x] ", fmt_);
+	w.F("P: %s ", posnames[pos]);
+	if (nrm)
+		w.F("N: %s ", nrmnames[nrm]);
+	if (col)
+		w.F("C: %s ", colnames[col]);
+	if (tc)
+		w.F("T: %s ", tcnames[tc]);
+	if (weighttype)
+		w.F("W: %s (%ix) ", weightnames[weighttype], nweights);
+	if (idx)
+		w.F("I: %s ", idxnames[idx]);
+	if (morphcount > 1)
+		w.F("Morph: %i ", morphcount);
+	if (throughmode)
+		w.F(" (through)");
+
+	w.F(" (%ib)", VertexSize());
 
 	if (!spaces) {
 		size_t len = strlen(start);
@@ -1635,17 +1675,16 @@ int VertexDecoder::ToString(char *output, bool spaces) const {
 	}
 
 #ifdef _DEBUG
-	output += sprintf(output, " (%llu)", (long long)decodedCount);
+	w.F(" (%llu)", (long long)decodedCount);
 #endif
-
-	return output - start;
+	return (int)w.size();
 }
 
 std::string VertexDecoder::GetString(DebugShaderStringType stringType) const {
 	char buffer[256];
 	switch (stringType) {
 	case SHADER_STRING_SHORT_DESC:
-		ToString(buffer, true);
+		ToString(buffer, sizeof(buffer), true);
 		return std::string(buffer);
 	case SHADER_STRING_SOURCE_CODE:
 		{

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -46,7 +46,7 @@
 
 // Keep this in 4 bits.
 enum {
-	DEC_NONE,
+	DEC_NONE = 0,
 	DEC_FLOAT_1,
 	DEC_FLOAT_2,
 	DEC_FLOAT_3,
@@ -62,6 +62,8 @@ enum {
 	DEC_U16_3,
 	DEC_U16_4,
 };
+
+const char *DecFmtComponentToString(u8 fmt);
 
 // DecVtxFormat - vertex formats for PC
 // Kind of like a D3D VertexDeclaration.
@@ -81,6 +83,8 @@ struct DecVtxFormat {
 	void InitializeFromID(uint32_t id);
 
 	static u8 PosFmt() { return DEC_FLOAT_3; }
+
+	std::string ToString() const;
 };
 
 void GetIndexBounds(const void *inds, int count, u32 vertType, u16 *indexLowerBound, u16 *indexUpperBound);
@@ -152,6 +156,8 @@ inline bool VertTypeIDSkinInDecode(uint32_t vertType) {
 inline GETexMapMode VertTypeIDUVGenMode(uint32_t vertType) {
 	return (GETexMapMode)((vertType >> 24) & 3);
 }
+
+std::string DecFmtIdToString(u32 id);
 
 class VertexDecoder {
 public:
@@ -258,7 +264,7 @@ public:
 	// output must be big for safety.
 	// Returns number of chars written.
 	// Ugly for speed.
-	int ToString(char *output, bool spaces) const;
+	int ToString(char *buf, int bufSize, bool spaces) const;
 
 	bool IsInSpace(const uint8_t *ptr) const {
 		return ptr >= (const uint8_t *)jitted_ && ptr < ((const uint8_t *)jitted_ + jittedSize_);

--- a/GPU/Common/VertexDecoderLoongArch64.cpp
+++ b/GPU/Common/VertexDecoderLoongArch64.cpp
@@ -297,7 +297,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
             // Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
             ResetCodePtr(GetOffset(start));
             char temp[1024]{};
-            dec.ToString(temp, true);
+            dec.ToString(temp, sizeof(temp), true);
             WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
             return nullptr;
         }
@@ -338,7 +338,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	if (log) {
 		char temp[1024]{};
-		dec.ToString(temp, true);
+		dec.ToString(temp, sizeof(temp), true);
 		INFO_LOG(Log::JIT, "=== %s (%d bytes) ===", temp, (int)(GetCodePtr() - start));
 		std::vector<std::string> lines = DisassembleLA64(start, (int)(GetCodePtr() - start));
 		for (auto line : lines) {

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -316,7 +316,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			// Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
 			char temp[1024]{};
-			dec.ToString(temp, true);
+			dec.ToString(temp, sizeof(temp), true);
 			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return nullptr;
 		}
@@ -349,7 +349,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	if (log) {
 		char temp[1024]{};
-		dec.ToString(temp, true);
+		dec.ToString(temp, sizeof(temp), true);
 		INFO_LOG(Log::JIT, "=== %s (%d bytes) ===", temp, (int)(GetCodePtr() - start));
 		std::vector<std::string> lines = DisassembleRV64(start, (int)(GetCodePtr() - start));
 		for (auto line : lines) {

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -281,8 +281,8 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			EndWrite();
 			// Reset the code ptr and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
-			char temp[1024]{};
-			dec.ToString(temp, true);
+			char temp[256]{};
+			dec.ToString(temp, sizeof(temp), true);
 			WARN_LOG(Log::G3D, "Could not compile vertex decoder, failed at step %s: %s", GetStepFunctionName(dec.steps_[i]), temp);
 			return 0;
 		}

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -45,7 +45,7 @@ struct VulkanPipelineKey {
 	VulkanPipelineRasterStateKey raster;  // prim is included here
 	VShaderID vid;
 	FShaderID fid;
-	uint32_t vtxFmtId;
+	uint32_t vtxFmtId;  // Note: This is the decoded format ID, not the source format!
 	bool useHWTransform;
 
 	void ToString(std::string *str) const {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -510,6 +510,10 @@ const bool IsSameExceptForShaders(const VulkanPipelineKey &a, const VulkanPipeli
 	return a.useHWTransform == b.useHWTransform && a.raster == b.raster && a.vtxFmtId == b.vtxFmtId;
 }
 
+const bool IsSameExceptForVertexFormat(const VulkanPipelineKey &a, const VulkanPipelineKey &b) {
+	return a.useHWTransform == b.useHWTransform && a.raster == b.raster && a.vid == b.vid && a.fid == b.fid;
+}
+
 void ShaderListScreen::AddPipelineAnalysis(UI::LinearLayout *tabContent) {
 #if !PPSSPP_PLATFORM(UWP)
 	GPU_Vulkan *vgpu = dynamic_cast<GPU_Vulkan *>(gpu);
@@ -536,6 +540,15 @@ void ShaderListScreen::AddPipelineAnalysis(UI::LinearLayout *tabContent) {
 				}
 				if (keyA.fid != keyB.fid) {
 					toBeMerged += "FShader: " + keyA.fid.Description() + " vs " + keyB.fid.Description() + "\n";
+				}
+			}
+			if (IsSameExceptForVertexFormat(keyA, keyB)) {
+				if (keyA.vtxFmtId != 0 && keyB.vtxFmtId != 0 && keyA.vtxFmtId != keyB.vtxFmtId) {
+					DecVtxFormat fmtA;
+					DecVtxFormat fmtB;
+					fmtA.InitializeFromID(keyA.vtxFmtId);
+					fmtB.InitializeFromID(keyB.vtxFmtId);
+					toBeMerged += "VertexFmt: " + fmtA.ToString() + " vs " + fmtB.ToString() + "\n";
 				}
 			}
 		}

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -536,10 +536,10 @@ void ShaderListScreen::AddPipelineAnalysis(UI::LinearLayout *tabContent) {
 			if (IsSameExceptForShaders(keyA, keyB)) {
 				// Found a pair of pipelines that are identical except for the shaders.
 				if (keyA.vid != keyB.vid) {
-					toBeMerged += "VShader: " + keyA.vid.Description() + " vs " + keyB.vid.Description() + "\n";
+					toBeMerged += "VShader: " + keyA.vid.Description(false) + " vs " + keyB.vid.Description(false) + "\n";
 				}
 				if (keyA.fid != keyB.fid) {
-					toBeMerged += "FShader: " + keyA.fid.Description() + " vs " + keyB.fid.Description() + "\n";
+					toBeMerged += "FShader: " + keyA.fid.Description(false) + " vs " + keyB.fid.Description(false) + "\n";
 				}
 			}
 			if (IsSameExceptForVertexFormat(keyA, keyB)) {
@@ -553,8 +553,8 @@ void ShaderListScreen::AddPipelineAnalysis(UI::LinearLayout *tabContent) {
 			}
 		}
 		if (!toBeMerged.empty()) {
-			tabContent->Add(new UI::TextView(keys[i].GetDescription(SHADER_STRING_SHORT_DESC), FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT, true));
-			tabContent->Add(new UI::TextView(toBeMerged, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT, true));
+			tabContent->Add(new UI::TextView(keys[i].GetDescription(SHADER_STRING_SHORT_DESC), FLAG_DYNAMIC_ASCII, true));
+			tabContent->Add(new UI::TextView(toBeMerged, FLAG_DYNAMIC_ASCII, true));
 		}
 	}
 #endif


### PR DESCRIPTION
Not very fruitful unfortunately.

The checker did yield more results though, corrected a few more shader bit checks, reducing the amount of shaders compiled slightly in some games.