### PR TITLE
Allow to define and modify custom names for saved states

### DIFF
--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -66,6 +66,7 @@ constexpr int SCREENSHOT_FAILURE_RETRIES = 6;
 static const char * const STATE_EXTENSION = "ppst";
 static const char * const UNDO_STATE_EXTENSION = "undo.ppst";
 static const char * const UNDO_SCREENSHOT_EXTENSION = "undo.jpg";
+static const char * const NAME_EXTENSION = "txt";
 
 static const char * const LOAD_UNDO_NAME = "load_undo.ppst";
 
@@ -470,12 +471,10 @@ int g_screenshotFailures;
 		if (!NetworkAllowSaveState()) {
 			return;
 		}
-
 		Path fn = GenerateSaveSlotPath(gamePrefix, slot, STATE_EXTENSION);
 		Path fnUndo = GenerateSaveSlotPath(gamePrefix, slot, UNDO_STATE_EXTENSION);
 		if (!fn.empty()) {
 			Path shot = GenerateSaveSlotPath(gamePrefix, slot, SCREENSHOT_EXTENSION);
-
 			std::string prefix(gamePrefix);
 			auto renameCallback = [fn, fnUndo, prefix, slot, callback](Status status, std::string_view message, std::string_view metadata) {
 				if (status != Status::FAILURE) {
@@ -536,10 +535,12 @@ int g_screenshotFailures;
 	void DeleteSlot(std::string_view gamePrefix, int slot) {
 		Path fn = GenerateSaveSlotPath(gamePrefix, slot, STATE_EXTENSION);
 		Path shot = GenerateSaveSlotPath(gamePrefix, slot, SCREENSHOT_EXTENSION);
+		Path fnName = GenerateSaveSlotPath(gamePrefix, slot, NAME_EXTENSION);
 
 		if (File::Exists(fn)) {
 			DeleteIfExists(fn);
 			DeleteIfExists(shot);
+			DeleteIfExists(fnName);
 		}
 		Rescan(gamePrefix);
 	}
@@ -705,6 +706,17 @@ int g_screenshotFailures;
 	std::string GetSlotDateAsString(std::string_view gamePrefix, int slot) {
 		std::string fn = GenerateSaveSlotFilename(gamePrefix, slot, STATE_EXTENSION);
 		return GetSaveFileDateAsString(fn);
+	}
+
+	std::string GetSlotCustomName(std::string_view gamePrefix, int slot) {
+		Path path = GenerateSaveSlotPath(gamePrefix, slot, NAME_EXTENSION);
+		std::string result = "";
+		File::ReadBinaryFileToString(path, &result);
+		return result;
+	}
+
+	void SetSlotCustomName(std::string_view gamePrefix, int slot, std::string_view new_name){
+		File::WriteStringToFile(true, new_name, GenerateSaveSlotPath(gamePrefix, slot, NAME_EXTENSION));
 	}
 
 	std::vector<Operation> Flush() {

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -74,7 +74,10 @@ namespace SaveState {
 	int GetOldestSlot(std::string_view gamePrefix);
 	
 	std::string GetSlotDateAsString(std::string_view gamePrefix, int slot);
+
+	std::string GetSlotCustomName(std::string_view gamePrefix, int slot);
 	Path GenerateSaveSlotPath(std::string_view gamePrefix, int slot, const char *extension);
+	void SetSlotCustomName(std::string_view gamePrefix, int slot, std::string_view newName);
 
 	std::string GetTitle(const Path &filename);
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -134,6 +134,7 @@ protected:
 			grid->Add(undoButton)->OnClick.Handle(this, &ScreenshotViewScreen::OnUndoState);
 		}
 		grid->Add(new Choice(di->T("Back"), ImageID("I_NAVIGATE_BACK")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
+		grid->Add(new Choice(di->T("Modify State Name"), ImageID("I_EDIT_TEXT")))->OnClick.Handle(this, &ScreenshotViewScreen::OnChangeState);
 
 		scroll->Add(content);
 		parent->Add(scroll);
@@ -144,11 +145,13 @@ private:
 	void OnLoadState(UI::EventParams &e);
 	void OnUndoState(UI::EventParams &e);
 	void OnDeleteState(UI::EventParams &e);
+	void OnChangeState(UI::EventParams &e);
 
 	Path screenshotFilename_;
 	Path gamePath_;
 	std::string saveStatePrefix_;
 	std::string title_;
+	std::string customNameTemp_;
 	int slot_;
 };
 
@@ -203,6 +206,19 @@ void ScreenshotViewScreen::OnDeleteState(UI::EventParams &e) {
 	}));
 }
 
+void ScreenshotViewScreen::OnChangeState(UI::EventParams &e) {
+	auto di = GetI18NCategory(I18NCat::DIALOG);
+
+	customNameTemp_ = SaveState::GetSlotCustomName(saveStatePrefix_, slot_);
+
+	UI::TextEditPopupScreen *popupScreen = new UI::TextEditPopupScreen(&customNameTemp_, "", di->T("Modify the state name"), 64);
+	popupScreen->OnChange.Add([this](UI::EventParams &e) {
+		SaveState::SetSlotCustomName(saveStatePrefix_, slot_, customNameTemp_);
+		TriggerFinish(DR_YES);  // DR_YES signals that we need a refresh, but not to close the pause menu.
+	});
+	screenManager()->push(popupScreen);
+}
+
 class SaveSlotView : public UI::LinearLayout {
 public:
 	SaveSlotView(std::string_view saveStatePrefix, int slot, UI::LayoutParams *layoutParams = nullptr);
@@ -223,6 +239,10 @@ public:
 
 	std::string GetScreenshotTitle() const {
 		return SaveState::GetSlotDateAsString(saveStatePrefix_, slot_);
+	}
+
+	std::string GetCustomName() const {
+		return SaveState::GetSlotCustomName(saveStatePrefix_, slot_);
 	}
 
 	UI::Event OnStateLoaded;
@@ -276,7 +296,6 @@ SaveSlotView::SaveSlotView(std::string_view saveStatePrefix, int slot, UI::Layou
 
 	saveStateButton_ = buttons->Add(new Button(pa->T("Save State"), new LinearLayoutParams(0.0, Gravity::G_VCENTER)));
 	saveStateButton_->OnClick.Handle(this, &SaveSlotView::OnSaveState);
-
 	fv->OnClick.Add([this](UI::EventParams &e) {
 		e.v = this;
 		OnScreenshotClicked.Trigger(e);
@@ -288,6 +307,14 @@ SaveSlotView::SaveSlotView(std::string_view saveStatePrefix, int slot, UI::Layou
 			loadStateButton_->OnClick.Handle(this, &SaveSlotView::OnLoadState);
 		}
 
+		std::string nameStr = SaveState::GetSlotCustomName(saveStatePrefix_, slot_);
+
+		if (!nameStr.empty()) {
+			TextView *nameView = new TextView(nameStr, new LinearLayoutParams(0.0, Gravity::G_VCENTER));
+			nameView->SetSmall(true);
+			lines->Add(nameView)->SetShadow(true);
+		}
+		
 		std::string dateStr = SaveState::GetSlotDateAsString(saveStatePrefix_, slot_);
 
 		if (slot_ == g_Config.iAutoLoadSaveState - 3) {
@@ -427,7 +454,7 @@ void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems,
 			g_Config.iCurrentStateSlot = v->GetSlot();
 			if (SaveState::HasSaveInSlot(saveStatePrefix_, slot)) {
 				Path fn = v->GetScreenshotFilename();
-				std::string title = v->GetScreenshotTitle();
+				std::string title = v->GetCustomName();
 				Screen *screen = new ScreenshotViewScreen(fn, saveStatePrefix_, title, v->GetSlot(), gamePath_);
 				screenManager()->push(screen);
 			}


### PR DESCRIPTION
Feature requested in issue  #21598.

Now saving a state creates a .txt file with the same name in the same location. 
A new button has been added in the grid when you right click on the screenshot of the save state, allowing to type any custom name that will then be displayed in the pause menu next to the save state date.
The name is written and retrieved in that same .txt file so there is no issue with special characters.

This is my first commit, so I might have forgotten some things. 

Thank you for taking the time to review that feature.