### PR TITLE
feat(shaders): add Scanline Modern 4x2 post-processing shader

### DIFF
--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -98,6 +98,22 @@ SettingDefaultValue2=0.5
 SettingMaxValue2=1.0
 SettingMinValue2=0.0
 SettingStep2=0.05
+[ScanlineModern]
+Name=Scanline Modern
+Author=crashGG
+Fragment=scanline-modern-4x2.fsh
+Vertex=fxaa.vsh
+OutputResolution=True
+SettingName1=Aperture Grille Intensity (Horizontal)
+SettingDefaultValue1=0.02
+SettingMaxValue1=0.10
+SettingMinValue1=0.0
+SettingStep1=0.005
+SettingName2=Scanline Intensity (Vertical)
+SettingDefaultValue2=0.075
+SettingMaxValue2=0.40
+SettingMinValue2=0.0
+SettingStep2=0.005
 [Cartoon]
 Name=Cartoon
 Fragment=cartoon.fsh

--- a/assets/shaders/scanline-modern-4x2.fsh
+++ b/assets/shaders/scanline-modern-4x2.fsh
@@ -1,0 +1,93 @@
+/*
+================================================================================
+Scanline Modern 4x2
+
+This shader is not designed to simply simulate the scanline + aperture grille 
+effect of old CRT monitors. Instead, it aims to combine the advantages of sharp 
+clarity on modern displays with retro games, enabling better pixel-level scaling.
+
+The generation intensity of scanlines is dynamically quantized and adjusted based 
+on the human eye's perceptual curve for chromatic brightness, rather than using 
+rigid stripe overlay.
+
+Core Features:
+- Lossless RGB Chromaticity and Luminance: Implements a symmetric brightness 
+  compensation loop where the quantization attenuation applied to dark sectors 
+  is dynamically counterbalanced and redistributed within the bright cycles. 
+  This fundamentally resolves the inherent chromaticity degradation and exposure 
+  loss typical of traditional scanline shaders caused by naive stripe overlaying.
+- Fixed vertical scanline period to 4 pixels and horizontal mask to 2 pixels 
+  to establish a native physical grid on modern 2K/4K displays. This efficiently 
+  masks and embellishes the glaring grid unevenness caused by non-integer scaling 
+  when rendering high-res PSX low-poly/pixel titles.
+- Leverages sub-pixel edge detection to smoothly transition and camouflage 
+  misalignment artifacts where the virtual game pixels fail to align 
+  pixel-to-pixel with the modern LCD hardware.
+- Optimized scanline performance based on human eye brightness sensitivity curve: 
+  scanlines are prominent in medium brightness areas and weakened in extreme 
+  brightness areas.
+
+(C) 2025-2026 by crashGG.
+================================================================================
+*/
+
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+
+uniform sampler2D u_tex0;
+uniform vec2 u_texelDelta;
+uniform vec4 u_setting;
+
+varying vec2 v_texcoord0;
+
+void main() {
+
+	// --- UI Parameters ---
+	float compY = u_setting.y;
+	float compX = u_setting.x;
+
+    // 5-tap sampling: center plus down, up, left, right neighboring pixels
+    vec3 texel = texture2D(u_tex0, v_texcoord0).rgb;
+    vec3 tex_D = texture2D(u_tex0, v_texcoord0 + vec2(0.0, u_texelDelta.y)).rgb;
+    vec3 tex_U = texture2D(u_tex0, v_texcoord0 + vec2(0.0, -u_texelDelta.y)).rgb;
+    vec3 tex_L = texture2D(u_tex0, v_texcoord0 + vec2(-u_texelDelta.x, 0.0)).rgb;
+    vec3 tex_R = texture2D(u_tex0, v_texcoord0 + vec2(u_texelDelta.x, 0.0)).rgb;
+
+    // Calculate luminance (r+g+b) and normalize to 1.0
+    float lumaC = dot(texel, vec3(0.3333333));
+    float lumaD = dot(tex_D, vec3(0.3333333));
+    float lumaU = dot(tex_U, vec3(0.3333333));
+    float lumaL = dot(tex_L, vec3(0.3333333));
+    float lumaR = dot(tex_R, vec3(0.3333333));
+
+    // Square wave generator: 1-pixel phase shift on Y-axis to form a -1, +1, +1, -1 pattern
+    vec2 freq = vec2(0.5, 0.25);
+    vec2 phase = fract((gl_FragCoord.xy + vec2(0.0, 1.0)) * freq + 0.01); // +0.01 to avoid precision drift at boundaries
+    vec2 wave = step(0.5, phase) * 2.0 - 1.0;
+
+	//	Scanline edge detection
+    float diffU = (lumaC - lumaU) * sign(wave.y);
+    float diffD = (lumaC - lumaD) * sign(wave.y);
+    float diffL = (lumaC - lumaL) * sign(wave.x);
+    float diffR = (lumaC - lumaR) * sign(wave.x);
+
+    // Modulate square wave amplitude via component-wise multiplication
+	// During the dark cycle, the center pixel cannot be darker than its sides (by compXY threshold); 
+	// during the light cycle, the center pixel cannot be brighter than its sides (by compXY threshold). 
+	// Otherwise, fallback to the original pixel.
+    float modY = compY * wave.y * float(diffU < compY && diffD < compY);
+    float modX = compX * wave.x * float(diffL < compX && diffR < compX);
+
+
+    // Dynamic quantization core logic: distance from each of the RGB channels to the median value 0.5 (vec3 [0.0 - 1.0])
+    // The wave perturbation peaks around mid-tones (0.5) where dist approaches 0, and dampens at extreme brightness levels.
+    vec3 dist = abs(texel - 0.5) * 2.0;
+	// Combined scanline lighting pass synthesis:
+	// Overlay scanline oscillation onto the baseline brightness (1.0), then multiply back by the source texture.
+    vec3 final_brightness = 1.0 + (modX + modY) * (1.0 - dist);
+
+    // final out 
+    gl_FragColor = vec4(texel * final_brightness, 1.0);
+}


### PR DESCRIPTION
Scanline Modern 4x2

Originally designed for [DuckStation](https://github.com/stenzek/duckstation/blob/master/data/resources/shaders/reshade/Shaders/scanline-modern-4x2.fx) by crashGG; officially ported to PPSSPP.

This shader is not designed to simply simulate the scanline + aperture grille 
effect of old CRT monitors. Instead, it aims to combine the advantages of sharp 
clarity on modern displays with retro games, enabling better pixel-level scaling.

The generation intensity of scanlines is dynamically quantized and adjusted based 
on the human eye's perceptual curve for chromatic brightness, rather than using 
rigid stripe overlay.

Core Features:
- Lossless RGB Chromaticity and Luminance: Implements a symmetric brightness 
  compensation loop where the quantization attenuation applied to dark sectors 
  is dynamically counterbalanced and redistributed within the bright cycles. 
  This fundamentally resolves the inherent chromaticity degradation and exposure 
  loss typical of traditional scanline shaders caused by naive stripe overlaying.
- Fixed vertical scanline period to 4 pixels and horizontal mask to 2 pixels 
  to establish a native physical grid on modern 2K/4K displays. This efficiently 
  masks and embellishes the glaring grid unevenness caused by non-integer scaling 
  when rendering high-res PSX low-poly/pixel titles.
- Leverages sub-pixel edge detection to smoothly transition and camouflage 
  misalignment artifacts where the virtual game pixels fail to align 
  pixel-to-pixel with the modern LCD hardware.
- Optimized scanline performance based on human eye brightness sensitivity curve: 
  scanlines are prominent in medium brightness areas and weakened in extreme 
  brightness areas.

applied to arcade games:
<img width="3840" height="2160" alt="ULUS10062_00000" src="https://github.com/user-attachments/assets/6ca07689-217d-48b1-8f61-857ead0ecfa3" />

applied to HD-2D games:
<img width="3840" height="2160" alt="NPJH50414_00000" src="https://github.com/user-attachments/assets/1d95da80-8725-4891-afe1-58c4e9458b7c" />

applied to PS1-ported low-poly games:
<img width="3840" height="2160" alt="ULJM05029_00000" src="https://github.com/user-attachments/assets/22d14d1c-e8d2-42e0-ab00-cfa987b475e9" />

applied to PSP-exclusive high-res 3D games:
<img width="3840" height="2160" alt="UCUS98620_00000" src="https://github.com/user-attachments/assets/ac4f624e-5db8-48b4-8c3f-d9365c4bf840" />
Even for PSP-exclusive high-res 3D titles, it introduces a fine, tactile grain across the entire screen without compromising or obscuring the detail-rich, high-fidelity 3D rendering.

