### PR TITLE
Texture replacer code cleanup and performance fix

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -264,7 +264,7 @@ void ReplacedTexture::Prepare(VFSBackend *vfs) {
 
 	if (levels_.empty()) {
 		// No replacement found.
-		std::string name = TextureReplacer::HashName(desc_.cachekey, desc_.hash, 0);
+		std::string name = TextureReplacer::HashName(desc_.cacheKey, 0);
 		if (result == LoadLevelResult::LOAD_ERROR) {
 			WARN_LOG(Log::TexReplacement, "Failed to load replacement texture '%s'", name.c_str());
 		}
@@ -273,7 +273,7 @@ void ReplacedTexture::Prepare(VFSBackend *vfs) {
 	}
 
 	// Update the level dimensions.
-	for (auto &level : levels_) {
+	for (ReplacedTextureLevel &level : levels_) {
 		level.fullW = (level.w * desc_.w) / desc_.newW;
 		level.fullH = (level.h * desc_.h) / desc_.newH;
 

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -224,7 +224,7 @@ private:
 	double lastUsed_ = 0.0;
 	LimitedWaitable *threadWaitable_ = nullptr;
 	std::mutex lock_;
-	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;  // NOTE: Right now, the only supported format is Draw::DataFormat::R8G8B8A8_UNORM.
+	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;
 	TextureAlpha alphaStatus_ = TextureAlpha::Any;
 	double lastUsed = 0.0;
 

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -64,11 +64,45 @@ struct GPUFormatSupport {
 	bool etc2;
 };
 
+struct ReplacementCacheKey {
+	u64 cachekey;  // Split into two u32?
+	u32 hash;
+
+	ReplacementCacheKey() : cachekey(0), hash(0) {}
+	ReplacementCacheKey(u64 ckey, u32 h) : cachekey(ckey), hash(h) {}
+
+	bool operator ==(const ReplacementCacheKey &k) const {
+		return k.cachekey == cachekey && k.hash == hash;
+	}
+
+	bool operator <(const ReplacementCacheKey &k) const {
+		if (k.cachekey == cachekey) {
+			return k.hash < hash;
+		}
+		return k.cachekey < cachekey;
+	}
+
+	// Access the parts.
+	u64 CacheKey() const { return cachekey; }
+	u32 ClutHash() const { return (u32)(cachekey & 0xFFFFFFFFULL); }
+	u32 Address() const { return (u32)(cachekey >> 32); }
+	u32 ContentsHash() const { return hash; }
+
+	void ZeroAddress() {
+		cachekey &= 0xFFFFFFFFULL;
+	}
+	void ZeroClutHash() {
+		cachekey &= 0xFFFFFFFF00000000ULL;
+	}
+	void ZeroContentsHash() {
+		hash = 0;
+	}
+};
+
 struct ReplacementDesc {
 	int newW;
 	int newH;
-	uint64_t cachekey;
-	uint32_t hash;
+	ReplacementCacheKey cacheKey;
 	int w;
 	int h;
 	TextureFiltering forceFiltering;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1759,8 +1759,8 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int *
 	}
 
 	double replaceStart = time_now_d();
-	u64 cachekey = entry->CacheKey();
-	ReplacedTexture *replaced = replacer_.FindReplacement(cachekey, entry->fullhash, *w, *h);
+	ReplacementCacheKey cacheKey(entry->CacheKey(), entry->fullhash);
+	ReplacedTexture *replaced = replacer_.FindReplacement(cacheKey, *w, *h);
 	replacementTimeThisFrame_ += time_now_d() - replaceStart;
 	if (!replaced) {
 		// TODO: Remove the flag here?

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -47,13 +47,19 @@ static const std::string ZIP_FILENAME = "textures.zip";
 static const std::string NEW_TEXTURE_DIR = "new/";
 static const int VERSION = 1;
 static const double MAX_CACHE_SIZE = 4.0;
+
+// basisu only needs to be initialized once, to build some tables. This global is enough to track that.
+// Doesn't need to be deinited.
 static bool basisu_initialized = false;
+
+static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
 
 TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
 	if (!basisu_initialized) {
 		basist::basisu_transcoder_init();
 		basisu_initialized = true;
 	}
+
 	// We don't want to keep the draw object around, so extract the info we need.
 	if (draw->GetDataFormatSupport(Draw::DataFormat::BC3_UNORM_BLOCK)) formatSupport_.bc123 = true;
 	if (draw->GetDataFormatSupport(Draw::DataFormat::ASTC_4x4_UNORM_BLOCK)) formatSupport_.astc = true;
@@ -62,7 +68,7 @@ TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
 }
 
 TextureReplacer::~TextureReplacer() {
-	for (auto iter : levelCache_) {
+	for (const auto &iter : levelCache_) {
 		delete iter.second;
 	}
 	delete vfs_;
@@ -113,7 +119,7 @@ void TextureReplacer::NotifyConfigChanged() {
 }
 
 bool TextureReplacer::LoadIni(std::string *error, bool notify) {
-	hash_ = ReplacedTextureHash::QUICK;
+	textureHash_ = ReplacedTextureHash::QUICK;
 	aliases_.clear();
 	hashranges_.clear();
 	filtering_.clear();
@@ -227,7 +233,7 @@ bool TextureReplacer::LoadIni(std::string *error, bool notify) {
 	return true;
 }
 
-void TextureReplacer::ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap) {
+static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap) {
 	// Scan the root of the texture folder/zip and preinitialize the hash map.
 	// TODO: Could put VFSFileReference into the map...
 	std::vector<File::FileInfo> filesInRoot;
@@ -292,11 +298,11 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 		return false;
 	}
 	if (strcasecmp(hash.c_str(), "quick") == 0) {
-		hash_ = ReplacedTextureHash::QUICK;
+		textureHash_ = ReplacedTextureHash::QUICK;
 	} else if (strcasecmp(hash.c_str(), "xxh32") == 0) {
-		hash_ = ReplacedTextureHash::XXH32;
+		textureHash_ = ReplacedTextureHash::XXH32;
 	} else if (strcasecmp(hash.c_str(), "xxh64") == 0) {
-		hash_ = ReplacedTextureHash::XXH64;
+		textureHash_ = ReplacedTextureHash::XXH64;
 	} else if (!isOverride || !hash.empty()) {
 		*error = "textures.ini: Unsupported hash type: " + hash;
 		return false;
@@ -309,12 +315,12 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	options->Get("ignoreMipmap", &ignoreMipmap_);
 	options->Get("skipLastDXT1Blocks128x64", &skipLastDXT1Blocks128x64_);
 	options->Get("skipLastDXT1Blocks128x128", &skipLastDXT1Blocks128x128_);
-	if (reduceHash_ && hash_ == ReplacedTextureHash::QUICK) {
+	if (reduceHash_ && textureHash_ == ReplacedTextureHash::QUICK) {
 		reduceHash_ = false;
 		ERROR_LOG(Log::TexReplacement, "Texture Replacement: reduceHash option requires safer hash, use xxh32 or xxh64 instead.");
 	}
 
-	if (ignoreAddress_ && hash_ == ReplacedTextureHash::QUICK) {
+	if (ignoreAddress_ && textureHash_ == ReplacedTextureHash::QUICK) {
 		ignoreAddress_ = false;
 		ERROR_LOG(Log::TexReplacement, "Texture Replacement: ignoreAddress option requires safer hash, use xxh32 or xxh64 instead.");
 	}
@@ -545,7 +551,7 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 			sizeInRAM -= 8 * skipLastDXT1Blocks128x128_;
 		}
 
-		switch (hash_) {
+		switch (textureHash_) {
 		case ReplacedTextureHash::QUICK:
 			return StableQuickTexHash(checkp, sizeInRAM);
 		case ReplacedTextureHash::XXH32:
@@ -561,7 +567,7 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 		const u32 stride = (textureBitsPerPixel[fmt] * bufw) / 8;
 
 		u32 result = 0;
-		switch (hash_) {
+		switch (textureHash_) {
 		case ReplacedTextureHash::QUICK:
 			for (int y = 0; y < h; ++y) {
 				u32 rowHash = StableQuickTexHash(checkp, bytesPerLine);
@@ -594,13 +600,12 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 	}
 }
 
-ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w, int h) {
+ReplacedTexture *TextureReplacer::FindReplacement(ReplacementCacheKey replacementKey, int w, int h) {
 	// Only actually replace if we're replacing.  We might just be saving.
 	if (!Enabled() || !g_Config.bReplaceTextures) {
 		return nullptr;
 	}
 
-	ReplacementCacheKey replacementKey(cachekey, hash);
 	auto it = cache_.find(replacementKey);
 	if (it != cache_.end()) {
 		return it->second.texture;
@@ -611,17 +616,16 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 	desc.newH = h;
 	desc.w = w;
 	desc.h = h;
-	desc.cachekey = cachekey;
-	desc.hash = hash;
-	LookupHashRange(cachekey >> 32, w, h, &desc.newW, &desc.newH);
+	desc.cacheKey = replacementKey;
+	LookupHashRange(replacementKey.Address(), w, h, &desc.newW, &desc.newH);
 
 	if (ignoreAddress_) {
-		cachekey = cachekey & 0xFFFFFFFFULL;
+		replacementKey.ZeroAddress();
 	}
 
 	bool foundAlias = false;
 	bool ignored = false;
-	std::string hashfiles = LookupHashFile(cachekey, hash, &foundAlias, &ignored);
+	std::string hashfiles = LookupHashFile(replacementKey, &foundAlias, &ignored);
 
 	// Early-out for ignored textures, let's not bother even starting a thread task.
 	if (ignored) {
@@ -633,7 +637,7 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 	}
 
 	desc.forceFiltering = (TextureFiltering)0;  // invalid value
-	FindFiltering(cachekey, hash, &desc.forceFiltering);
+	FindFiltering(replacementKey, &desc.forceFiltering);
 
 	if (!foundAlias) {
 		// We'll just need to generate the names for each level.
@@ -641,7 +645,7 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 		// For other file formats, use the ini to create aliases.
 		desc.filenames.resize(MAX_REPLACEMENT_MIP_LEVELS);
 		for (int level = 0; level < desc.filenames.size(); level++) {
-			desc.filenames[level] = TextureReplacer::HashName(cachekey, hash, level) + ".png";
+			desc.filenames[level] = TextureReplacer::HashName(replacementKey, level) + ".png";
 		}
 		desc.logId = desc.filenames[0];
 		desc.hashfiles = desc.filenames[0];  // The generated filename of the top level is used as the key in the data cache.
@@ -776,9 +780,11 @@ void TextureReplacer::NotifyTextureDecoded(ReplacedTexture *texture, const Repla
 		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
 
+	ReplacementCacheKey replacementKey(cachekey, replacedInfo.hash);
+
 	bool foundAlias = false;
 	bool ignored = false;
-	std::string replacedLevelNames = LookupHashFile(cachekey, replacedInfo.hash, &foundAlias, &ignored);
+	std::string replacedLevelNames = LookupHashFile(replacementKey, &foundAlias, &ignored);
 	if (ignored) {
 		// The ini file entry was set to empty string. We can early-out.
 		return;
@@ -793,10 +799,9 @@ void TextureReplacer::NotifyTextureDecoded(ReplacedTexture *texture, const Repla
 		hashfile = names[std::min(level, (int)(names.size() - 1))];
 	} else {
 		// Generate a new PNG filename, complete with level.
-		hashfile = HashName(cachekey, replacedInfo.hash, level) + ".png";
+		hashfile = HashName(replacementKey, level) + ".png";
 	}
 
-	ReplacementCacheKey replacementKey(cachekey, replacedInfo.hash);
 	auto it = savedCache_.find(replacementKey);
 	if (it != savedCache_.end()) {
 		// We've already saved this texture. Ignore it.
@@ -888,8 +893,10 @@ void TextureReplacer::Decimate(ReplacerDecimateMode mode) {
 }
 
 template <typename Value>
-static typename std::unordered_map<ReplacementCacheKey, Value>::const_iterator LookupWildcard(const std::unordered_map<ReplacementCacheKey, Value> &map, u64 cachekey, u32 hash, bool ignoreAddress) {
-	ReplacementCacheKey key(cachekey, hash);
+static typename std::unordered_map<ReplacementCacheKey, Value>::const_iterator LookupWildcard(const std::unordered_map<ReplacementCacheKey, Value> &map, ReplacementCacheKey key, bool ignoreAddress) {
+	u64 cachekey = key.CacheKey();
+	u32 hash = key.ContentsHash();
+
 	auto alias = map.find(key);
 	if (alias != map.end())
 		return alias;
@@ -933,13 +940,12 @@ static typename std::unordered_map<ReplacementCacheKey, Value>::const_iterator L
 	return map.find(key);
 }
 
-bool TextureReplacer::FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering) {
+bool TextureReplacer::FindFiltering(ReplacementCacheKey replacementKey, TextureFiltering *forceFiltering) {
 	if (!Enabled() || !g_Config.bReplaceTextures) {
 		return false;
 	}
 
-	ReplacementCacheKey replacementKey(cachekey, hash);
-	auto filter = LookupWildcard(filtering_, cachekey, hash, ignoreAddress_);
+	auto filter = LookupWildcard(filtering_, replacementKey, ignoreAddress_);
 	if (filter == filtering_.end()) {
 		// Allow a global wildcard.
 		replacementKey.cachekey = 0;
@@ -953,9 +959,8 @@ bool TextureReplacer::FindFiltering(u64 cachekey, u32 hash, TextureFiltering *fo
 	return false;
 }
 
-std::string TextureReplacer::LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored) {
-	ReplacementCacheKey key(cachekey, hash);
-	auto alias = LookupWildcard(aliases_, cachekey, hash, ignoreAddress_);
+std::string TextureReplacer::LookupHashFile(ReplacementCacheKey key, bool *foundAlias, bool *ignored) {
+	auto alias = LookupWildcard(aliases_, key, ignoreAddress_);
 	if (alias != aliases_.end()) {
 		// Note: this will be blank if explicitly ignored.
 		*foundAlias = true;
@@ -967,12 +972,12 @@ std::string TextureReplacer::LookupHashFile(u64 cachekey, u32 hash, bool *foundA
 	return "";
 }
 
-std::string TextureReplacer::HashName(u64 cachekey, u32 hash, int level) {
+std::string TextureReplacer::HashName(ReplacementCacheKey key, int level) {
 	char hashname[16 + 8 + 1 + 11 + 1] = {};
 	if (level > 0) {
-		snprintf(hashname, sizeof(hashname), "%016llx%08x_%d", cachekey, hash, level);
+		snprintf(hashname, sizeof(hashname), "%016llx%08x_%d", key.cachekey, key.hash, level);
 	} else {
-		snprintf(hashname, sizeof(hashname), "%016llx%08x", cachekey, hash);
+		snprintf(hashname, sizeof(hashname), "%016llx%08x", key.cachekey, key.hash);
 	}
 
 	return hashname;

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -641,26 +641,19 @@ ReplacedTexture *TextureReplacer::FindReplacement(ReplacementCacheKey replacemen
 
 	FindFiltering(replacementKey, &desc.forceFiltering);
 
-	if (!foundAlias) {
-		// We'll just need to generate the names for each level.
-		// By default, we look for png since that's also what's dumped.
-		// For other file formats, use the ini to create aliases.
-		desc.filenames.resize(MAX_REPLACEMENT_MIP_LEVELS);
-		for (int level = 0; level < desc.filenames.size(); level++) {
-			desc.filenames[level] = TextureReplacer::HashName(replacementKey, level) + ".png";
-		}
-		desc.logId = desc.filenames[0];
-		desc.hashfiles = desc.filenames[0];  // The generated filename of the top level is used as the key in the data cache.
-		hashfiles.clear();
-		hashfiles.reserve(desc.filenames[0].size() * (desc.filenames.size() + 1));
-		for (int level = 0; level < desc.filenames.size(); level++) {
-			hashfiles += desc.filenames[level];
-			hashfiles.push_back('|');
-		}
-	} else {
+	if (foundAlias) {
 		desc.logId = hashfiles;
 		SplitString(hashfiles, '|', desc.filenames);
 		desc.hashfiles = hashfiles;
+	} else {
+		DEBUG_LOG(Log::TexReplacement, "Replacement not found in alias list - skipping!");
+		// Not found in the alias map.
+		//
+		// Since we've added aliases generated from the file listing, if we didn't found an alias, that means that
+		// we shouldn't replace this texture. Add a marker to cache_.
+		ReplacedTextureRef ref{};
+		cache_.emplace(std::make_pair(replacementKey, ref));
+		return nullptr;
 	}
 
 	_dbg_assert_(!hashfiles.empty());

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -52,7 +52,8 @@ static const double MAX_CACHE_SIZE = 4.0;
 // Doesn't need to be deinited.
 static bool basisu_initialized = false;
 
-static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
+static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> *filenameMap);
+static void ComputeAliasMap(std::unordered_map<ReplacementCacheKey, std::string> *aliases, const std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
 
 TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
 	if (!basisu_initialized) {
@@ -197,14 +198,14 @@ bool TextureReplacer::LoadIni(std::string *error, bool notify) {
 			}
 			// Do what we can do anyway: Scan for textures and build the map.
 			std::map<ReplacementCacheKey, std::map<int, std::string>> filenameMap;
-			ScanForHashNamedFiles(dir, filenameMap);
+			ScanForHashNamedFiles(dir, &filenameMap);
 
 			if (filenameMap.empty()) {
 				WARN_LOG(Log::TexReplacement, "No replacement textures found.");
 				return false;
 			}
 
-			ComputeAliasMap(filenameMap);
+			ComputeAliasMap(&aliases_, filenameMap);
 		}
 	}
 
@@ -233,7 +234,7 @@ bool TextureReplacer::LoadIni(std::string *error, bool notify) {
 	return true;
 }
 
-static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap) {
+static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> *filenameMap) {
 	// Scan the root of the texture folder/zip and preinitialize the hash map.
 	// TODO: Could put VFSFileReference into the map...
 	std::vector<File::FileInfo> filesInRoot;
@@ -256,13 +257,13 @@ static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey,
 			int level = 0;  // sscanf might fail to pluck the level, but that's ok, we default to 0. sscanf doesn't write to non-matched outputs.
 			if (sscanf(hash.c_str(), "%16llx%8x_%d", &key.cachekey, &key.hash, &level) >= 1) {
 				// INFO_LOG(Log::TexReplacement, "hash-like file in root, adding: %s", file.name.c_str());
-				filenameMap[key][level] = file.name;
+				(*filenameMap)[key][level] = file.name;
 			}
 		}
 	}
 }
 
-void TextureReplacer::ComputeAliasMap(const std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap) {
+static void ComputeAliasMap(std::unordered_map<ReplacementCacheKey, std::string> *aliases, const std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap) {
 	for (auto &pair : filenameMap) {
 		std::string alias;
 		int mipIndex = 0;
@@ -284,7 +285,7 @@ void TextureReplacer::ComputeAliasMap(const std::map<ReplacementCacheKey, std::m
 				c = '/';
 			}
 		}
-		aliases_[pair.first] = alias;
+		(*aliases)[pair.first] = alias;
 	}
 }
 
@@ -335,7 +336,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	std::map<ReplacementCacheKey, std::map<int, std::string>> filenameMap;
 
 	if (dir) {
-		ScanForHashNamedFiles(dir, filenameMap);
+		ScanForHashNamedFiles(dir, &filenameMap);
 	}
 
 	std::string badFilenames;
@@ -385,7 +386,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	}
 
 	// Now, translate the filenameMap to the final aliasMap.
-	ComputeAliasMap(filenameMap);
+	ComputeAliasMap(&aliases_, filenameMap);
 
 	if (badFileNameCount > 0) {
 		auto err = GetI18NCategory(I18NCat::ERRORS);
@@ -617,10 +618,12 @@ ReplacedTexture *TextureReplacer::FindReplacement(ReplacementCacheKey replacemen
 	desc.w = w;
 	desc.h = h;
 	desc.cacheKey = replacementKey;
-	LookupHashRange(replacementKey.Address(), w, h, &desc.newW, &desc.newH);
+	desc.forceFiltering = (TextureFiltering)0;  // invalid value
 
 	if (ignoreAddress_) {
 		replacementKey.ZeroAddress();
+	} else {
+		LookupHashRange(replacementKey.Address(), w, h, &desc.newW, &desc.newH);
 	}
 
 	bool foundAlias = false;
@@ -636,7 +639,6 @@ ReplacedTexture *TextureReplacer::FindReplacement(ReplacementCacheKey replacemen
 		return nullptr;
 	}
 
-	desc.forceFiltering = (TextureFiltering)0;  // invalid value
 	FindFiltering(replacementKey, &desc.forceFiltering);
 
 	if (!foundAlias) {
@@ -818,7 +820,7 @@ void TextureReplacer::NotifyTextureDecoded(ReplacedTexture *texture, const Repla
 		return;
 	}
 
-	// Only save the hashed portion of the PNG.
+	// Only save the hashed portion of the PNG, in case we have specified it in the ini file.
 	int lookupW;
 	int lookupH;
 	if (LookupHashRange(replacedInfo.addr, origW, origH, &lookupW, &lookupH)) {
@@ -826,8 +828,8 @@ void TextureReplacer::NotifyTextureDecoded(ReplacedTexture *texture, const Repla
 		h = lookupH * (scaledH / origH);
 	}
 
-
-	size_t saveBufSize = w * h * 4;
+	constexpr int bpp = 4;
+	size_t saveBufSize = w * h * bpp;
 	u8 *saveBuf = (u8 *)malloc(saveBufSize);
 	if (!saveBuf) {
 		ERROR_LOG(Log::TexReplacement, "Failed to allocated %d bytes of memory for saving a texture", (int)saveBufSize);
@@ -837,7 +839,7 @@ void TextureReplacer::NotifyTextureDecoded(ReplacedTexture *texture, const Repla
 	// Copy data to a buffer so we can send it to the thread. Might as well compact-away the pitch
 	// while we're at it.
 	for (int y = 0; y < h; y++) {
-		memcpy(saveBuf + y * w * 4, (const u8 *)data + y * srcPitch, w * 4);
+		memcpy(saveBuf + y * w * bpp, (const u8 *)data + y * srcPitch, w * bpp);
 	}
 
 	SaveTextureTask *task = new SaveTextureTask(std::move(saveBuf));

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -887,8 +887,9 @@ void TextureReplacer::Decimate(ReplacerDecimateMode mode) {
 	lastTextureCacheSizeGB_ = totalSizeGB;
 }
 
-template <typename Key, typename Value>
-static typename std::unordered_map<Key, Value>::const_iterator LookupWildcard(const std::unordered_map<Key, Value> &map, Key &key, u64 cachekey, u32 hash, bool ignoreAddress) {
+template <typename Value>
+static typename std::unordered_map<ReplacementCacheKey, Value>::const_iterator LookupWildcard(const std::unordered_map<ReplacementCacheKey, Value> &map, u64 cachekey, u32 hash, bool ignoreAddress) {
+	ReplacementCacheKey key(cachekey, hash);
 	auto alias = map.find(key);
 	if (alias != map.end())
 		return alias;
@@ -938,7 +939,7 @@ bool TextureReplacer::FindFiltering(u64 cachekey, u32 hash, TextureFiltering *fo
 	}
 
 	ReplacementCacheKey replacementKey(cachekey, hash);
-	auto filter = LookupWildcard(filtering_, replacementKey, cachekey, hash, ignoreAddress_);
+	auto filter = LookupWildcard(filtering_, cachekey, hash, ignoreAddress_);
 	if (filter == filtering_.end()) {
 		// Allow a global wildcard.
 		replacementKey.cachekey = 0;
@@ -954,7 +955,7 @@ bool TextureReplacer::FindFiltering(u64 cachekey, u32 hash, TextureFiltering *fo
 
 std::string TextureReplacer::LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored) {
 	ReplacementCacheKey key(cachekey, hash);
-	auto alias = LookupWildcard(aliases_, key, cachekey, hash, ignoreAddress_);
+	auto alias = LookupWildcard(aliases_, cachekey, hash, ignoreAddress_);
 	if (alias != aliases_.end()) {
 		// Note: this will be blank if explicitly ignored.
 		*foundAlias = true;

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -122,8 +122,6 @@ protected:
 	float LookupReduceHashRange(int w, int h);
 	std::string LookupHashFile(ReplacementCacheKey key, bool *foundAlias, bool *ignored);
 
-	void ComputeAliasMap(const std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
-
 	bool replaceEnabled_ = false;
 	bool saveEnabled_ = false;
 	bool allowVideo_ = false;

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -50,24 +50,6 @@ struct SavedTextureCacheData {
 	double lastTimeSaved = 0.0;
 };
 
-struct ReplacementCacheKey {
-	u64 cachekey;
-	u32 hash;
-
-	ReplacementCacheKey(u64 c, u32 h) : cachekey(c), hash(h) { }
-
-	bool operator ==(const ReplacementCacheKey &k) const {
-		return k.cachekey == cachekey && k.hash == hash;
-	}
-
-	bool operator <(const ReplacementCacheKey &k) const {
-		if (k.cachekey == cachekey) {
-			return k.hash < hash;
-		}
-		return k.cachekey < cachekey;
-	}
-};
-
 namespace std {
 	template <>
 	struct hash<ReplacementCacheKey> {
@@ -109,7 +91,7 @@ public:
 	u32 ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled, GETextureFormat fmt, u16 maxSeenV);
 
 	// Returns nullptr if not found.
-	ReplacedTexture *FindReplacement(u64 cachekey, u32 hash, int w, int h);
+	ReplacedTexture *FindReplacement(ReplacementCacheKey key, int w, int h);
 
 	// Check if a NotifyTextureDecoded for this texture is desired (used to avoid reads from write-combined memory.)
 	bool WillSave(const ReplacedTextureDecodeInfo &replacedInfo) const;
@@ -126,10 +108,10 @@ public:
 	int GetNumTrackedTextures() const { return (int)cache_.size(); }
 	int GetNumCachedReplacedTextures() const { return (int)levelCache_.size(); }
 
-	static std::string HashName(u64 cachekey, u32 hash, int level);
+	static std::string HashName(ReplacementCacheKey key, int level);
 
 protected:
-	bool FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering);
+	bool FindFiltering(ReplacementCacheKey key, TextureFiltering *forceFiltering);
 
 	bool LoadIni(std::string *error, bool notify = true);
 	bool LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverride, std::string *error);
@@ -138,9 +120,8 @@ protected:
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
 	bool LookupHashRange(u32 addr, int w, int h, int *newW, int *newH);
 	float LookupReduceHashRange(int w, int h);
-	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
+	std::string LookupHashFile(ReplacementCacheKey key, bool *foundAlias, bool *ignored);
 
-	static void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
 	void ComputeAliasMap(const std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
 
 	bool replaceEnabled_ = false;
@@ -158,7 +139,7 @@ protected:
 	std::string gameID_;
 	Path basePath_;
 	Path newTextureDir_;
-	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;
+	ReplacedTextureHash textureHash_ = ReplacedTextureHash::QUICK;
 
 	VFSBackend *vfs_ = nullptr;
 	bool vfsIsZip_ = false;

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -208,7 +208,7 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 							ImGui::Text("Replaced: %dx%d, %d mip levels", w, h, numLevels);
 							ImGui::Text("Level 0 size: %d bytes, format: %s", entry->replacedTexture->GetLevelDataSizeAfterCopy(0), Draw::DataFormatToString(entry->replacedTexture->Format()));
 						}
-						ImGui::Text("Key: %08x_%08x", (u32)(desc.cachekey >> 32), (u32)desc.cachekey);
+						ImGui::Text("Key: %08x_%08x_%08x", desc.cacheKey.Address(), desc.cacheKey.ClutHash(), desc.cacheKey.ContentsHash());
 						ImGui::Text("Hashfiles: %s", desc.hashfiles.c_str());
 						ImGui::Text("Base: %s", desc.basePath.c_str());
 						ImGui::Text("Alpha status: %d", (int)entry->replacedTexture->AlphaStatus());


### PR DESCRIPTION
We already get the file listing of the texture replacement directory - no need to go try to load files that we know aren't there.

This may improve the performance problem in Tactics Ogre reported by Coffee Potato on Discord.
