### PR TITLE
core: using std::move strict no have copies

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -331,7 +331,7 @@ static void Core_PerformCPUStep(MIPSDebugInterface *cpu, CPUStepType stepType, i
 		u32 entry = cpu->GetPC();
 		u32 stackTop = 0;
 
-		auto threads = GetThreadsInfo();
+		auto threads = std::move(GetThreadsInfo());
 		for (size_t i = 0; i < threads.size(); i++) {
 			if (threads[i].isCurrent) {
 				entry = threads[i].entrypoint;
@@ -340,7 +340,7 @@ static void Core_PerformCPUStep(MIPSDebugInterface *cpu, CPUStepType stepType, i
 			}
 		}
 
-		auto frames = MIPSStackWalk::Walk(cpu->GetPC(), cpu->GetRegValue(0, 31), cpu->GetRegValue(0, 29), entry, stackTop);
+		auto frames = std::move(MIPSStackWalk::Walk(cpu->GetPC(), cpu->GetRegValue(0, 31), cpu->GetRegValue(0, 29), entry, stackTop));
 		if (frames.size() < 2) {
 			// Failure. PC not moving.
 			return;
@@ -454,9 +454,9 @@ void Core_Break(BreakReason reason, u32 relatedAddress) {
 		// Stop the tracer
 		mipsTracer.stop_tracing();
 
-		g_breakReason = reason;
+		g_breakReason = std::move(reason);
 		g_cpuStepCommand.type = CPUStepType::None;
-		g_cpuStepCommand.reason = reason;
+		g_cpuStepCommand.reason = std::move(reason);
 		g_cpuStepCommand.relatedAddr = relatedAddress;
 		steppingCounter++;
 		_assert_msg_(reason != BreakReason::None, "No reason specified for break");

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -342,7 +342,7 @@ static void DoMemoryVoid(PointerWrap &p, uint32_t start, uint32_t size) {
 
 	// We only handle aligned data and sizes.
 	if ((size & 0x3F) != 0 || ((uintptr_t)d & 0x3F) != 0)
-		return p.DoVoid(d, size);
+		return std::move(p).DoVoid(d, size);
 
 	switch (p.mode) {
 	case PointerWrap::MODE_READ:
@@ -367,7 +367,7 @@ static void DoMemoryVoid(PointerWrap &p, uint32_t start, uint32_t size) {
 }
 
 void DoState(PointerWrap &p) {
-	auto s = p.Section("Memory", 1, 3);
+	auto s = std::move(p).Section("Memory", 1, 3);
 	if (!s)
 		return;
 


### PR DESCRIPTION
 beneficial use of std::move only works when complex class objects are moved, not C++ simple types primitives.

Reference:
- https://stackoverflow.com/questions/40193269/does-the-use-of-stdmove-have-any-performance-benefits/40193338#40193338