### PR TITLE
jitLock: migrate std::mutex to atomic with memory_order_relaxed

### DIFF
--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 #include <cstring>
-#include <mutex>
+#include <atomic>
 #include "Common/Data/Encoding/Base64.h"
 #include "Common/StringUtils.h"
 #include "Core/Core.h"
@@ -77,9 +77,10 @@ static AutoDisabledReplacements LockMemoryAndCPU(uint32_t addr, bool keepReplace
 		result.saved = true;
 		// Okay, save so we can restore later.
 		result.replacements = SaveAndClearReplacements();
-		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+		MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 		if (MIPSComp::jit)
 			result.emuhacks = MIPSComp::jit->SaveAndClearEmuHackOps();
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 	}
 	return result;
 }
@@ -97,9 +98,10 @@ AutoDisabledReplacements::AutoDisabledReplacements(AutoDisabledReplacements &&ot
 
 AutoDisabledReplacements::~AutoDisabledReplacements() {
 	if (saved) {
-		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+		MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 		if (MIPSComp::jit)
 			MIPSComp::jit->RestoreSavedEmuHackOps(emuhacks);
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		RestoreSavedReplacements(replacements);
 	}
 	if (!wasStepping)

--- a/Core/MIPS/JitCommon/JitCommon.cpp
+++ b/Core/MIPS/JitCommon/JitCommon.cpp
@@ -18,7 +18,7 @@
 #include "ppsspp_config.h"
 
 #include <cstdlib>
-#include <mutex>
+#include <atomic>
 
 #include "ext/disarm.h"
 #include "ext/riscv-disas.h"
@@ -57,7 +57,7 @@
 
 namespace MIPSComp {
 	JitInterface *jit;
-	std::recursive_mutex jitLock;
+	std::atomic<u32> jitLock;
 
 	void JitAt() {
 		// TODO: We could probably check for a bad pc here, and fire an exception. Could spare us from some crashes.
@@ -185,14 +185,16 @@ std::string AddAddress(const std::string &buf, uint64_t addr) {
 #if PPSSPP_ARCH(ARM64) || defined(DISASM_ALL)
 
 static bool Arm64SymbolCallback(char *buffer, int bufsize, uint8_t *address) {
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (MIPSComp::jit) {
 		std::string name;
 		if (MIPSComp::jit->DescribeCodePtr(address, name)) {
 			truncate_cpy(buffer, bufsize, name);
+			MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 			return true;
 		}
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 	return false;
 }
 
@@ -279,12 +281,14 @@ const char *ppsspp_resolver(struct ud*,
 	static char buf[128];
 	std::string str;
 
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (MIPSComp::jit && MIPSComp::jit->DescribeCodePtr((u8 *)(uintptr_t)addr, str)) {
 		*offset = 0;
 		truncate_cpy(buf, sizeof(buf), str);
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return buf;
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 	return NULL;
 }
 

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <mutex>
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -170,7 +170,7 @@ namespace MIPSComp {
 	u32 ResolveNotTakenTarget(const BranchInfo &branchInfo);
 
 	extern JitInterface *jit;
-	extern std::recursive_mutex jitLock;
+	extern std::atomic<u32> jitLock;
 
 	void DoDummyJitState(PointerWrap &p);
 

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -17,7 +17,7 @@
 
 #include <cmath>
 #include <limits>
-#include <mutex>
+#include <atomic>
 #include <utility>
 
 
@@ -161,12 +161,13 @@ MIPSState::~MIPSState() {
 }
 
 void MIPSState::Shutdown() {
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	MIPSComp::JitInterface *oldjit = MIPSComp::jit;
 	if (oldjit) {
 		MIPSComp::jit = nullptr;
 		delete oldjit;
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void MIPSState::Reset() {
@@ -209,7 +210,7 @@ void MIPSState::Init() {
 
 	memset(vcmpResult, 0, sizeof(vcmpResult));
 
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (PSP_CoreParameter().cpuCore == CPUCore::JIT || PSP_CoreParameter().cpuCore == CPUCore::JIT_IR) {
 		MIPSComp::jit = MIPSComp::CreateNativeJit(this, PSP_CoreParameter().cpuCore == CPUCore::JIT_IR);
 	} else if (PSP_CoreParameter().cpuCore == CPUCore::IR_INTERPRETER) {
@@ -217,6 +218,7 @@ void MIPSState::Init() {
 	} else {
 		MIPSComp::jit = nullptr;
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 bool MIPSState::HasDefaultPrefix() const {
@@ -232,11 +234,12 @@ void MIPSState::UpdateCore(CPUCore desired) {
 
 	// Get rid of the old JIT first, before switching.
 	{
-		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+		MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 		if (MIPSComp::jit) {
 			delete MIPSComp::jit;
 			MIPSComp::jit = nullptr;
 		}
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 	}
 
 	PSP_CoreParameter().cpuCore = desired;
@@ -264,8 +267,9 @@ void MIPSState::UpdateCore(CPUCore desired) {
 		break;
 	}
 
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	MIPSComp::jit = newjit;
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void MIPSState::DoState(PointerWrap &p) {
@@ -356,7 +360,7 @@ int MIPSState::RunLoopUntil(u64 globalTicks) {
 static std::vector<std::pair<u32, int>> pendingClears;
 
 void MIPSState::ProcessPendingClears() {
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	for (auto &p : pendingClears) {
 		if (p.first == 0 && p.second == 0)
 			MIPSComp::jit->ClearCache();
@@ -365,19 +369,21 @@ void MIPSState::ProcessPendingClears() {
 	}
 	pendingClears.clear();
 	hasPendingClears = false;
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void MIPSState::InvalidateICache(u32 address, int length) {
 	// Only really applies to jit.
 	// Note that the backend is responsible for ensuring native code can still be returned to.
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (MIPSComp::jit && length != 0) {
 		MIPSComp::jit->InvalidateCacheAt(address, length);
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void MIPSState::ClearJitCache() {
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (MIPSComp::jit) {
 		if (coreState == CORE_RUNNING_CPU || insideJit) {
 			pendingClears.emplace_back(0, 0);
@@ -387,4 +393,5 @@ void MIPSState::ClearJitCache() {
 			MIPSComp::jit->ClearCache();
 		}
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }

--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 #include <unordered_set>
-#include <mutex>
+#include <atomic>
 #include <sstream>
 
 #include "Common/StringUtils.h"
@@ -118,7 +118,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 	SContext *context = (SContext *)ctx;
 	const uint8_t *codePtr = (uint8_t *)(context->CTX_PC);
 
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 
 	// We set this later if we think it can be resumed from.
 	g_lastCrashAddress = nullptr;
@@ -130,6 +130,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 		// Actually, we could handle crashes from the IR interpreter here, although recovering the call stack
 		// might be tricky...
 		inCrashHandler = false;
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return false;
 	}
 
@@ -146,6 +147,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 		// Host address outside - this was a different kind of crash.
 		if (!invalidHostAddress) {
 			inCrashHandler = false;
+			MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 			return false;
 		}
 	}
@@ -270,6 +272,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 			context->CTX_PC = crashHandler;
 			ERROR_LOG(Log::MemMap, "Bad execution access detected, halting: %08x (last known pc %08x, host: %p)", targetAddr, currentMIPS->pc, (void *)hostAddress);
 			inCrashHandler = false;
+			MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 			return true;
 		}
 
@@ -331,6 +334,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 	}
 
 	inCrashHandler = false;
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 	return handled;
 }
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -18,7 +18,7 @@
 #include <algorithm>
 #include <vector>
 #include <thread>
-#include <mutex>
+#include <atomic>
 #include <string>
 #include <set>
 
@@ -165,7 +165,7 @@ int g_screenshotFailures;
 		// These must be saved before copying out memory and restored after.
 		auto savedReplacements = SaveAndClearReplacements();
 		if (MIPSComp::jit && p.mode == p.MODE_WRITE) {
-			std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+			MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 			if (MIPSComp::jit) {
 				std::vector<u32> savedBlocks;
 				savedBlocks = MIPSComp::jit->SaveAndClearEmuHackOps();
@@ -174,6 +174,7 @@ int g_screenshotFailures;
 			} else {
 				Memory::DoState(p);
 			}
+			MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		} else {
 			Memory::DoState(p);
 		}

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -358,10 +358,11 @@ void CwCheatScreen::onFinish(DialogResult result) {
 	if (result != DR_BACK) // This only works for BACK here.
 		return;
 
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (MIPSComp::jit) {
 		MIPSComp::jit->ClearCache();
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void CwCheatScreen::OnDisableAll(UI::EventParams &params) {
@@ -384,10 +385,11 @@ void CwCheatScreen::OnAddCheat(UI::EventParams &params) {
 
 void CwCheatScreen::OnEditCheatFile(UI::EventParams &params) {
 	g_Config.bReloadCheats = true;
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (MIPSComp::jit) {
 		MIPSComp::jit->ClearCache();
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 	if (engine_) {
 		File::OpenFileInEditor(engine_->CheatFilename());
 	}

--- a/UI/JitCompareScreen.cpp
+++ b/UI/JitCompareScreen.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <atomic>
 
 #include "UI/JitCompareScreen.h"
 #include "Common/Data/Text/I18n.h"
@@ -336,22 +337,28 @@ void JitCompareScreen::OnBlockClick(UI::EventParams &e) {
 }
 
 void JitCompareScreen::OnAddressChange(UI::EventParams &e) {
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (!MIPSComp::jit) {
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return;
 	}
 	JitBlockCacheDebugInterface *blockCache = MIPSComp::jit->GetBlockCacheDebugInterface();
-	if (!blockCache)
+	if (!blockCache) {
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return;
+	}
 	u32 addr;
-	if (blockAddr_->GetText().size() > 8)
+	if (blockAddr_->GetText().size() > 8) {
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return;
+	}
 	if (1 == sscanf(blockAddr_->GetText().c_str(), "%08x", &addr)) {
 		if (Memory::IsValidAddress(addr)) {
 			currentBlock_ = blockCache->GetBlockNumberFromStartAddress(addr);
 			UpdateDisasm();
 		}
 	}
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 void JitCompareScreen::OnSelectBlock(UI::EventParams &e) {
@@ -363,14 +370,17 @@ void JitCompareScreen::OnSelectBlock(UI::EventParams &e) {
 }
 
 void JitCompareScreen::OnBlockAddress(UI::EventParams &e) {
-	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 	if (!MIPSComp::jit) {
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return;
 	}
 
 	JitBlockCacheDebugInterface *blockCache = MIPSComp::jit->GetBlockCacheDebugInterface();
-	if (!blockCache)
+	if (!blockCache) {
+		MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		return;
+	}
 
 	if (Memory::IsValidAddress(e.a)) {
 		currentBlock_ = blockCache->GetBlockNumberFromStartAddress(e.a);
@@ -378,6 +388,7 @@ void JitCompareScreen::OnBlockAddress(UI::EventParams &e) {
 		currentBlock_ = -1;
 	}
 	UpdateDisasm();
+	MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 }
 
 /*

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <atomic>
 
 #include "Common/Render/DrawBuffer.h"
 #include "Common/UI/Context.h"
@@ -66,9 +67,10 @@ void HandleCommonMessages(UIMessage message, const char *value, ScreenManager *m
 	if (message == UIMessage::REQUEST_CLEAR_JIT && PSP_IsInited()) {
 		// TODO: This seems to clearly be the wrong place to handle this.
 		if (MIPSComp::jit) {
-			std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+			MIPSComp::jitLock.fetch_add(1, std::memory_order_relaxed);
 			if (MIPSComp::jit)
 				MIPSComp::jit->ClearCache();
+			MIPSComp::jitLock.fetch_sub(1, std::memory_order_relaxed);
 		}
 		currentMIPS->UpdateCore((CPUCore)g_Config.iCpuCore);
 	} else if (message == UIMessage::SHOW_CONTROL_MAPPING && isActiveScreen && std::string(activeScreen->tag()) != "ControlMapping") {


### PR DESCRIPTION
- https://hyunlibro.com/en/posts/cpp/how-fast-is-atomic-compared-to-mutex/
- https://gist.github.com/MangaD/58cbe3f99e743308b719b86f44500398