### PR TITLE
Libretro: fix Vulkan launch crash on Mali devices

### DIFF
--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -110,27 +110,32 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDevice_libretro(VkPhysicalDevice p
    newInfo.enabledExtensionCount = (uint32_t)enabledExtensionNames.size();
    newInfo.ppEnabledExtensionNames = newInfo.enabledExtensionCount ? enabledExtensionNames.data() : nullptr;
 
-   // Then check for VkPhysicalDeviceFeatures2 chaining or pEnabledFeatures to enable required features. Note that when both
-   // structs are present Features2 takes precedence. vkCreateDevice parameters don't give us a simple way to detect
-   // VK_KHR_get_physical_device_properties2 usage so we'll always try both paths.
+   // Add required features through VkPhysicalDeviceFeatures2 when it is present.
+   // Vulkan requires pEnabledFeatures to be NULL in that case.
    std::unordered_map<VkPhysicalDeviceFeatures *, VkPhysicalDeviceFeatures> originalFeaturePointers;
    VkPhysicalDeviceFeatures placeholderEnabledFeatures{};
+   bool has_features2 = false;
 
    for (const VkBaseOutStructure *next = (const VkBaseOutStructure *)pCreateInfo->pNext; next != nullptr;) {
       if (next->sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2) {
          VkPhysicalDeviceFeatures *enabledFeatures = &((VkPhysicalDeviceFeatures2 *)next)->features;
          originalFeaturePointers.try_emplace(enabledFeatures, *enabledFeatures);
+         has_features2 = true;
       }
 
       next = (const VkBaseOutStructure *)next->pNext;
    }
 
-   if (newInfo.pEnabledFeatures) {
-      placeholderEnabledFeatures = *newInfo.pEnabledFeatures;
-   }
+   if (!has_features2) {
+      if (newInfo.pEnabledFeatures) {
+         placeholderEnabledFeatures = *newInfo.pEnabledFeatures;
+      }
 
-   newInfo.pEnabledFeatures = &placeholderEnabledFeatures;
-   originalFeaturePointers.try_emplace((VkPhysicalDeviceFeatures *)newInfo.pEnabledFeatures, *newInfo.pEnabledFeatures);
+      newInfo.pEnabledFeatures = &placeholderEnabledFeatures;
+      originalFeaturePointers.try_emplace((VkPhysicalDeviceFeatures *)newInfo.pEnabledFeatures, *newInfo.pEnabledFeatures);
+   } else {
+      newInfo.pEnabledFeatures = nullptr;
+   }
 
    for (const auto& pair : originalFeaturePointers) {
       for (uint32_t i = 0; i < sizeof(VkPhysicalDeviceFeatures) / sizeof(VkBool32); i++) {


### PR DESCRIPTION
## Problem

The libretro Vulkan wrapper populated the legacy `pEnabledFeatures` field even when a core supplied `VkPhysicalDeviceFeatures2` in `VkDeviceCreateInfo::pNext`. Vulkan requires `pEnabledFeatures` to be null in that case.

Some drivers tolerate the invalid create-info, but Mali rejects it with `VK_ERROR_INITIALIZATION_FAILED`, preventing Vulkan hardware-rendered cores such as PPSSPP from launching and instead crashes RetroArch.

## Fix

Detect `VkPhysicalDeviceFeatures2` in the create-info chain and merge frontend-required features into that structure only. Preserve the legacy `pEnabledFeatures` path when `VkPhysicalDeviceFeatures2` is absent.

## Validation

Tested PPSSPP with Vulkan hardware rendering on:

- Android 14 / Mali-G615 (RG477M)
- Android 13 / Snapdragon 865 Adreno (Retroid Pocket Mini)

Both devices launch and run successfully.

## Follow-up

On the RG477M, this fix allows PPSSPP to reach virtual-swapchain creation, where the frontend exposes nine images. [#21959](https://github.com/hrydgard/ppsspp/pull/21959) fixes PPSSPP's separate fixed eight-image storage limit. The fixes are independent and were validated together on Mali and Adreno.