### PR TITLE
libretro: remove CmdLine as not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2137,13 +2137,21 @@ if((MACOSX OR IOS) AND NOT LIBRETRO)
 		Core/Util/DarwinFileSystemServices.h)
 endif()
 
+set(CmdLine)
+
+if(NOT LIBRETRO)
+    list(APPEND CmdLine
+        Core/CmdLine.cpp
+        Core/CmdLine.h
+    )
+endif()
+
 # 'ppsspp_jni' on ANDROID, 'Core' everywhere else
 # SHARED on ANDROID, STATIC everywhere else
 add_library(${CoreLibName} ${CoreLinkType}
 	${CoreExtra}
 	${CommonJIT}
-	Core/CmdLine.cpp
-	Core/CmdLine.h
+	${CmdLine}
 	Core/Config.cpp
 	Core/Config.h
 	Core/ConfigSettings.cpp


### PR DESCRIPTION
CmdLine does not build on mac os runner on libretro buildbot. It's not required for the libretro core.

Fixes: https://github.com/hrydgard/ppsspp/issues/21957
