### PR TITLE
Libretro: prevent Vulkan launch crashes with large swapchains

### DIFF
--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -29,14 +29,15 @@ static struct {
 } vk_init_info;
 static bool DEDICATED_ALLOCATION;
 
-#define VULKAN_MAX_SWAPCHAIN_IMAGES 8
+struct VkSwapchainImage {
+	VkImage handle;
+	VkDeviceMemory memory;
+	retro_vulkan_image retro_image;
+};
+
 struct VkSwapchainKHR_T {
 	uint32_t count;
-	struct {
-		VkImage handle;
-		VkDeviceMemory memory;
-		retro_vulkan_image retro_image;
-	} images[VULKAN_MAX_SWAPCHAIN_IMAGES];
+	std::vector<VkSwapchainImage> images;
 	std::mutex mutex;
 	std::condition_variable condVar;
 	int current_index;
@@ -204,7 +205,7 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateSwapchainKHR_libretro(VkDevice dev
 		chain.count++;
 		swapchain_mask >>= 1;
 	}
-	assert(chain.count <= VULKAN_MAX_SWAPCHAIN_IMAGES);
+	chain.images.resize(chain.count);
 
 	for (uint32_t i = 0; i < chain.count; i++) {
 		{
@@ -324,7 +325,7 @@ static VKAPI_ATTR void VKAPI_CALL vkDestroySwapchainKHR_libretro(VkDevice device
 		vkFreeMemory(device, chain.images[i].memory, pAllocator);
 	}
 
-	memset(&chain.images, 0x00, sizeof(chain.images));
+	chain.images.clear();
 	chain.count = 0;
 	chain.current_index = -1;
 	chain.ever_presented = false;


### PR DESCRIPTION
Follow-up to #21956. That fix allows PPSSPP to create its Vulkan device on strict drivers; this fixes the separate virtual-swapchain overflow reached immediately afterward when the frontend exposes more than eight images.

## Problem

The libretro Vulkan wrapper stores virtual-swapchain images in a fixed eight-element array.

RetroArch can expose more than eight swapchain images. On the RG477M’s Mali driver, nine images are returned. In release builds, the assertion is removed and the ninth image writes past the array during swapchain creation, corrupting state and crashing a Vulkan hardware-rendered core at launch.

## Fix

Replace the fixed array with dynamically sized storage:

- Size it from the frontend’s actual swapchain-image count.
- Clear it when the virtual swapchain is destroyed.

## Validation

Tested PPSSPP with Vulkan hardware rendering on:

- Android 14 / Mali-G615 (RG477M)
- Android 13 / Snapdragon 865 Adreno (Retroid Pocket Mini)

Both devices launch and run successfully.