### PR TITLE
Use new/delete properly for SceNetAdhocMatchingContext, fixing multiplayer crash

### DIFF
--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -1624,20 +1624,20 @@ int NetAdhocMatching_Delete(int matchingId) {
 	SceNetAdhocMatchingContext* prev = NULL;
 
 	// Context Pointer
-	SceNetAdhocMatchingContext* item = contexts;
+	SceNetAdhocMatchingContext* context = contexts;
 
 	// Iterate contexts
-	for (; item != NULL; item = item->next) {
+	for (; context != NULL; context = context->next) {
 		// Found matching ID
-		if (item->id == matchingId) {
+		if (context->id == matchingId) {
 			// Unlink Left (Beginning)
-			if (prev == NULL) contexts = item->next;
+			if (prev == NULL) contexts = context->next;
 
 			// Unlink Left (Other)
-			else prev->next = item->next;
+			else prev->next = context->next;
 
 			// Stop it first if it's still running
-			if (item->running) {
+			if (context->running) {
 				NetAdhocMatching_Stop(matchingId);
 			}
 			// Delete the Fake PSP Thread
@@ -1645,24 +1645,24 @@ int NetAdhocMatching_Delete(int matchingId) {
 			//delete item->matchingThread;
 
 			// Free allocated memories
-			free(item->hello);
-			free(item->rxbuf);
-			clearPeerList(item); //deleteAllMembers(item);
-			(*item->peerPort).clear();
-			delete item->peerPort;
+			free(context->hello);
+			free(context->rxbuf);
+			clearPeerList(context); //deleteAllMembers(item);
+			(*context->peerPort).clear();
+			delete context->peerPort;
 			// Destroy locks
-			item->eventlock->lock(); // Make sure it's not locked when being deleted
-			item->eventlock->unlock();
-			delete item->eventlock;
-			item->inputlock->lock(); // Make sure it's not locked when being deleted
-			item->inputlock->unlock();
-			delete item->inputlock;
-			item->socketlock->lock(); // Make sure it's not locked when being deleted
-			item->socketlock->unlock();
-			delete item->socketlock;
+			context->eventlock->lock(); // Make sure it's not locked when being deleted
+			context->eventlock->unlock();
+			delete context->eventlock;
+			context->inputlock->lock(); // Make sure it's not locked when being deleted
+			context->inputlock->unlock();
+			delete context->inputlock;
+			context->socketlock->lock(); // Make sure it's not locked when being deleted
+			context->socketlock->unlock();
+			delete context->socketlock;
 			// Free item context memory
-			free(item);
-			item = NULL;
+			delete context;
+			context = nullptr;
 
 			// Making sure there are no leftover matching events from this session which could cause a crash on the next session
 			deleteMatchingEvents(matchingId);
@@ -1672,7 +1672,7 @@ int NetAdhocMatching_Delete(int matchingId) {
 		}
 
 		// Set Previous Reference
-		prev = item;
+		prev = context;
 	}
 
 	return 0;
@@ -1775,10 +1775,10 @@ static int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbufle
 	}
 
 	// Allocate Context Memory
-	SceNetAdhocMatchingContext * context = (SceNetAdhocMatchingContext *)malloc(sizeof(SceNetAdhocMatchingContext));
+	SceNetAdhocMatchingContext *context = new SceNetAdhocMatchingContext();
 
 	// Allocated Memory
-	if (context != NULL) {
+	if (context) {  // This can't be null but let's not reformat all this code..
 		// Create PDP Socket
 		SceNetEtherAddr localmac;
 		getLocalMac(&localmac);
@@ -1842,7 +1842,7 @@ static int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbufle
 		}
 
 		// Free Memory
-		free(context);
+		delete context;
 	}
 
 	// Out of Memory

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2122,7 +2122,6 @@ ULUS01826 = 0.5
 ULUS11826 = 0.5
 
 # Tales of Destiny 2
-# Unfortunately, this affects game backgrounds negatively, although fixes lines in the menus.
 ULJS00097 = -0.25
 
 # Outrun 2006: Coast to Coast
@@ -2161,12 +2160,25 @@ ULUS10154 = -0.5
 # Metal Slug XX combat school
 ULUS10495 = -0.5
 
-# Tokiden (issue #19422)
-# This works in the provided dump, but needs more testing.
+# Toukiden: Kiwami (issue #19422)
 NPJH50878 = -0.4
+ULJM06376 = -0.4
+KTGSP0266 = -0.4
 
 # Naruto Shippuden: Ultimate Ninja Heroes 3
 ULES01407 = -0.5
+ULJS00236 = -0.5
+ULAS42208 = -0.5
+ULAS42317 = -0.5
+ULUS10518 = -0.5
+ULJS19066 = -0.5
+
+# Dragon Ball Z: Shin Budokai Another road
+ULES00789 = 0.5
+ULUS10234 = 0.5
+ULAS42103 = 0.5
+ULJS00107 = 0.5
+ULKS46184 = 0.5
 
 [TextureCLUTInShader]
 # Fushigi no Dungeon 4. See #15251. This drastically reduces the amount of textures decoded by the game,


### PR DESCRIPTION
The struct contains C++ object instances that are non-POD, so it was always wrong to use malloc/free here.

Trying to clear it the C++ way caused occasional crashes due to uninitialized data sometimes.

Also adds some more sprite fixes.