### PR TITLE
Fix upload filename traversal

### DIFF
--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -548,6 +548,11 @@ enum class MultiPartResult {
 	Done,
 };
 
+static bool IsSafeUploadFilename(std::string_view filename) {
+	return !filename.empty() && filename != "." && filename != ".." &&
+		filename.find_first_of("/\\") == std::string_view::npos;
+}
+
 static MultiPartResult HandleMultipartPart(const http::ServerRequest &request, std::string boundary, const Path &uploadPath, ProgressTracker &progress) {
 	std::string firstBoundary = request.In()->ReadLine();
 	if (firstBoundary != "--" + boundary) {
@@ -588,8 +593,8 @@ static MultiPartResult HandleMultipartPart(const http::ServerRequest &request, s
 		}
 	}
 
-	if (filename.empty()) {
-		ERROR_LOG(Log::HTTP, "Didn't receive a filename");
+	if (!IsSafeUploadFilename(filename)) {
+		ERROR_LOG(Log::HTTP, "Invalid upload filename");
 		return MultiPartResult::RequestError;
 	}
 


### PR DESCRIPTION
Multipart upload filenames were joined directly to the selected upload path. A reachable LAN client could use `../` path components to create new files outside that directory.

Reject filenames containing path separators or dot-path components before constructing the destination path. This keeps uploads confined to the directory selected by the user.