### PR TITLE
Fix Android CMakeLists.txt build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2757,12 +2757,9 @@ add_dependencies(core GitVersion)
 
 if(ANDROID AND NOT LIBRETRO)
 	add_library(ppsspp_jni SHARED ${AndroidJniSource})
-	target_link_libraries(ppsspp_jni core)
+	target_link_libraries(ppsspp_jni core log EGL OpenSLES)
 	if(TARGET ppsspp_ui)
 		target_link_libraries(ppsspp_jni ppsspp_ui)
-	endif()
-	if(TARGET native)
-		target_link_libraries(ppsspp_jni native)
 	endif()
 	if(ARM64)
 		# Support 16kb page size on Android

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -274,12 +274,6 @@ void NativeGetAppInfo(std::string *app_dir_name, std::string *app_nice_name, boo
 	*app_dir_name = "ppsspp";
 	*landscape = true;
 	*version = PPSSPP_GIT_VERSION;
-
-#if PPSSPP_ARCH(ARM) && defined(__ANDROID__)
-	ArmEmitterTest();
-#elif PPSSPP_ARCH(ARM64) && defined(__ANDROID__)
-	Arm64EmitterTest();
-#endif
 }
 
 #if defined(USING_WIN_UI) && !PPSSPP_PLATFORM(UWP)


### PR DESCRIPTION
CI doesn't test our Cmake build on Android currently, just the old NDK build. So it failed on the buildbot.