### PR TITLE
Use the common EmuThread implementation in multiple backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -991,7 +991,7 @@ elseif(USING_QT_UI)
 	set(CMAKE_AUTOMOC ON)
 	find_package(Qt5 COMPONENTS OpenGL Gui Core Multimedia)
 	if(NOT Qt5_FOUND)
-		message(FATAL_ERROR "Qt5 not found for USING_QT_UI=ON. On macOS with Homebrew, install qt@5 and set CMAKE_PREFIX_PATH to /opt/homebrew/opt/qt@5 (or use ./b.sh --qtbrew).")
+		message(FATAL_ERROR "Qt5 not found for USING_QT_UI=ON. On linux, sudo apt install qt5-qmake qtsystems5-dev qtmultimedia5-dev qttools5-dev-tools libqt5opengl5-dev libcurl4-openssl-dev. On macOS with Homebrew, install qt@5 and set CMAKE_PREFIX_PATH to /opt/homebrew/opt/qt@5 (or use ./b.sh --qtbrew).")
 	endif()
 	list(APPEND NativeAppSource
 		Qt/QtMain.cpp

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -163,16 +163,6 @@ bool GLRenderManager::ThreadFrame(bool waitIfEmpty) {
 	return true;
 }
 
-void GLRenderManager::StartThread() {
-	// There's not really a lot to do here anymore.
-	INFO_LOG(Log::G3D, "GLRenderManager::StartThread()");
-	if (!runCompileThread_) {
-		runCompileThread_ = true;
-	} else {
-		INFO_LOG(Log::G3D, "GL submission thread was already running.");
-	}
-}
-
 std::string GLRenderManager::GetGpuProfileString() const {
 	int curFrame = curFrame_;
 	const GLQueueProfileContext &profile = frameData_[curFrame].profile;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -823,8 +823,6 @@ public:
 		}
 	}
 
-	void StartThread();  // Currently only used on iOS, since we fully recreate the context on Android
-
 	// Only supports a common subset.
 	std::string GetGLString(int name) const {
 		return queueRunner_.GetGLString(name);

--- a/Core/EmuThread.cpp
+++ b/Core/EmuThread.cpp
@@ -71,6 +71,8 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext, Application *applica
 	// This normally calls NativeShutdownGraphics()
 	application->ShutdownGraphics(graphicsContext);
 
+	delete application;
+
 	INFO_LOG(Log::System, "Leaving separate emu thread");
 }
 

--- a/Core/EmuThread.cpp
+++ b/Core/EmuThread.cpp
@@ -22,14 +22,12 @@
 #include "Core/ConfigValues.h"
 
 enum class EmuThreadState {
-	DISABLED,
-	START_REQUESTED,
 	RUNNING,
 	QUIT_REQUESTED,
 	STOPPED,
 };
 
-static std::atomic<EmuThreadState> g_emuThreadState(EmuThreadState::DISABLED);
+static std::atomic<EmuThreadState> g_emuThreadState(EmuThreadState::STOPPED);
 static std::atomic<bool> g_inLoop;
 
 class GraphicsContext;
@@ -44,10 +42,7 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext, Application *applica
 
 	AndroidJNIThreadContext context;
 
-	// There's no real requirement that NativeInit happen on this thread.
-	// We just call the update/render loop here.
-	g_emuThreadState = EmuThreadState::RUNNING;
-
+	// This normally calls NativeInitGraphics()
 	if (!application->InitGraphics(graphicsContext)) {
 		_assert_msg_(false, "NativeInitGraphics failed, might as well bail");
 		// If this fails, which it normally shouldn't, let's bail.
@@ -59,6 +54,7 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext, Application *applica
 	while (g_emuThreadState != EmuThreadState::QUIT_REQUESTED) {
 		// We're here again, so the game quit.  Restart Run() which controls the UI.
 		// This way they can load a new game.
+		// This normally calls NativeFrame()
 		application->Frame(graphicsContext);
 		if (postFrame) {
 			postFrame();
@@ -72,12 +68,15 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext, Application *applica
 
 	g_emuThreadState = EmuThreadState::STOPPED;
 
+	// This normally calls NativeShutdownGraphics()
 	application->ShutdownGraphics(graphicsContext);
+
 	INFO_LOG(Log::System, "Leaving separate emu thread");
 }
 
 std::thread EmuThread_Start(GraphicsContext *graphicsContext, Application *application, std::function<void()> postFrame) {
-	g_emuThreadState = EmuThreadState::START_REQUESTED;
+	_dbg_assert_(g_emuThreadState == EmuThreadState::STOPPED);
+	g_emuThreadState = EmuThreadState::RUNNING;
 	std::thread emuThread = std::thread(&EmuThreadFunc, graphicsContext, application, postFrame);
 	return emuThread;
 }

--- a/Core/EmuThread.cpp
+++ b/Core/EmuThread.cpp
@@ -80,6 +80,7 @@ std::thread EmuThread_Start(GraphicsContext *graphicsContext, Application *appli
 	_dbg_assert_(g_emuThreadState == EmuThreadState::STOPPED);
 	g_emuThreadState = EmuThreadState::RUNNING;
 	std::thread emuThread = std::thread(&EmuThreadFunc, graphicsContext, application, postFrame);
+	graphicsContext->ThreadStart();
 	return emuThread;
 }
 
@@ -96,6 +97,7 @@ void EmuThread_Join(GraphicsContext *graphicsContext, std::thread &emuThread) {
 			return g_emuThreadState == EmuThreadState::STOPPED;
 		});
 	}
+	graphicsContext->ThreadEnd();
 	emuThread.join();
 	emuThread = std::thread();
 }

--- a/Core/EmuThread.h
+++ b/Core/EmuThread.h
@@ -30,9 +30,11 @@ class GraphicsContext;
 // Doesn't take ownership of the graphicsContext, you have to delete it.
 // This should be used by platforms that launch a separate thread and doesn't
 // need to run a polling loop in it.
+// NOTE: Does take ownership over Application (which is just a wrapper for NativeInitGraphics/NativeShutdownGraphics/NativeFrame).
 bool MainThreadFunc(GraphicsContext * graphicsContext, Application *application, WindowSystem windowSystem, void *windowData1, void *windowData2, std::function<void()> postFrame);
 
 // If you're not using MainThreadFunc, you can at least use these to manage a spinning EmuThread (that calls NativeFrame),
 // whether your graphics context requires multithreading or not.
+// NOTE: Does take ownership over Application (which is just a wrapper for NativeInitGraphics/NativeShutdownGraphics/NativeFrame).
 std::thread EmuThread_Start(GraphicsContext *graphicsContext, Application *application, std::function<void()> postFrame);
 void EmuThread_Join(GraphicsContext *graphicsContext, std::thread &emuThread);

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -915,7 +915,6 @@ void MainUI::initializeGL() {
 	} else {
 		INFO_LOG(Log::System, "Not using thread, backend=%d", (int)g_Config.iGPUBackend);
 	}
-	graphicsContext->ThreadStart();
 }
 
 void MainUI::paintGL() {

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -54,6 +54,7 @@
 #include "Core/CmdLine.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
+#include "Core/EmuThread.h"
 #include "Core/HW/Camera.h"
 #include "Core/Debugger/SymbolMap.h"
 
@@ -662,40 +663,8 @@ static int mainInternal(QApplication &a) {
 	return retval;
 }
 
-void MainUI::EmuThreadFunc() {
-	SetCurrentThreadName("EmuThread");
-
-	// There's no real requirement that NativeInit happen on this thread, though it can't hurt...
-	// We just call the update/render loop here. NativeInitGraphics should be here though.
-	NativeInitGraphics(graphicsContext);
-
-	emuThreadState = (int)EmuThreadState::RUNNING;
-	while (emuThreadState != (int)EmuThreadState::QUIT_REQUESTED) {
-		updateAccelerometer();
-		NativeFrame(graphicsContext);
-	}
-	emuThreadState = (int)EmuThreadState::STOPPED;
-
-	NativeShutdownGraphics(graphicsContext);
-}
-
-void MainUI::EmuThreadStart() {
-	emuThreadState = (int)EmuThreadState::START_REQUESTED;
-	emuThread = std::thread([&]() { this->EmuThreadFunc(); } );
-}
-
-void MainUI::EmuThreadStop() {
-	emuThreadState = (int)EmuThreadState::QUIT_REQUESTED;
-}
-
-void MainUI::EmuThreadJoin() {
-	emuThread.join();
-	emuThread = std::thread();
-}
-
 MainUI::MainUI(QWidget *parent)
 	: QGLWidget(parent) {
-	emuThreadState = (int)EmuThreadState::DISABLED;
 	setAttribute(Qt::WA_AcceptTouchEvents);
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 	setAttribute(Qt::WA_LockLandscapeOrientation);
@@ -711,13 +680,8 @@ MainUI::MainUI(QWidget *parent)
 
 MainUI::~MainUI() {
 	INFO_LOG(Log::System, "MainUI::Destructor");
-	if (emuThreadState != (int)EmuThreadState::DISABLED) {
-		INFO_LOG(Log::System, "EmuThreadStop");
-		EmuThreadStop();
-		graphicsContext->ThreadFrameUntilCondition([this]() -> bool {
-			return emuThreadState == (int)EmuThreadState::STOPPED;
-		});
-		EmuThreadJoin();
+	if (graphicsContext->NeedsSeparateEmuThread()) {
+		EmuThread_Join(graphicsContext, emuThread_);
 	}
 #if defined(MOBILE_DEVICE)
 	delete acc;
@@ -911,7 +875,9 @@ void MainUI::initializeGL() {
 		graphicsContext->InitAPI(nullptr, nullptr, &errorMessage);
 		graphicsContext->InitSurface(WINDOWSYSTEM_NONE, nullptr, nullptr, &errorMessage);
 		INFO_LOG(Log::System, "Using thread, starting emu thread");
-		EmuThreadStart();
+		emuThread_ = EmuThread_Start(graphicsContext, new NativeApplication(), [this](){
+			updateAccelerometer();
+		});
 	} else {
 		INFO_LOG(Log::System, "Not using thread, backend=%d", (int)g_Config.iGPUBackend);
 	}

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -104,8 +104,7 @@ enum class EmuThreadState {
 
 
 // GUI, thread manager
-class MainUI : public QGLWidget
-{
+class MainUI : public QGLWidget {
 	Q_OBJECT
 public:
 	explicit MainUI(QWidget *parent = 0);
@@ -130,11 +129,6 @@ protected:
 
 	void updateAccelerometer();
 
-	void EmuThreadFunc();
-	void EmuThreadStart();
-	void EmuThreadStop();
-	void EmuThreadJoin();
-
 private:
 	bool HandleCustomEvent(QEvent *e);
 	QtGLGraphicsContext *graphicsContext;
@@ -144,8 +138,7 @@ private:
 	QAccelerometer* acc;
 #endif
 
-	std::thread emuThread;
-	std::atomic<int> emuThreadState;
+	std::thread emuThread_;
 };
 
 class QTCamera : public QObject {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -2200,7 +2200,7 @@ int main(int argc, char *argv[]) {
 				}
 			}
 
-			emuThread = EmuThread_Start(graphicsContext, &application, nullptr);
+			emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), nullptr);
 			graphicsContext->ThreadStart();
 		}
 	}

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -2104,10 +2104,8 @@ int main(int argc, char *argv[]) {
 	}
 	EnableFZ();
 
-	NativeApplication application;
-
 	// We use the emuthread both for OpenGL and Vulkan, but in OpenGL mode we also render from the main thread.
-	std::thread emuThread = EmuThread_Start(graphicsContext, &application, nullptr);
+	std::thread emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), nullptr);
 
 	graphicsContext->ThreadStart();
 

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -28,6 +28,10 @@ bool SDLVulkanGraphicsContext::InitAPI(void *wnd, std::string *deviceName, std::
 	init_glslang();
 	errorMessage->clear();
 
+	g_LogOptions.breakOnError = true;
+	g_LogOptions.breakOnWarning = true;
+	g_LogOptions.msgBoxOnError = false;
+
 	std::string errorStr;
 	if (!VulkanLoad(&errorStr)) {
 		*errorMessage = "Failed to load Vulkan driver library: " + errorStr;

--- a/android/jni/AndroidJavaGLContext.cpp
+++ b/android/jni/AndroidJavaGLContext.cpp
@@ -8,16 +8,10 @@
 
 AndroidJavaEGLGraphicsContext::AndroidJavaEGLGraphicsContext() {
 	SetGPUBackend(GPUBackend::OPENGL);
-}
-
-bool AndroidJavaEGLGraphicsContext::InitAPI(void *wnd, std::string *deviceName, std::string *errorMessage) {
 	// OpenGL handles rotated rendering in the driver.
 	g_display.rotation = DisplayRotation::ROTATE_0;
 	g_display.rot_matrix.setIdentity();
-	return true;
 }
-
-void AndroidJavaEGLGraphicsContext::ShutdownAPI() {}
 
 bool AndroidJavaEGLGraphicsContext::InitSurface(WindowSystem winsys, void *data1, void *data2, std::string *errorMessage) {
 	INFO_LOG(Log::G3D, "AndroidJavaEGLGraphicsContext::InitFromRenderThread");

--- a/android/jni/AndroidJavaGLContext.h
+++ b/android/jni/AndroidJavaGLContext.h
@@ -11,9 +11,6 @@ public:
 
 	bool NeedsSeparateEmuThread() const override { return true; }
 
-	bool InitAPI(void *wnd, std::string *deviceName, std::string *errorMessage) override;
-	void ShutdownAPI() override;
-
 	bool InitSurface(WindowSystem winsys, void *data1, void *data2, std::string *error_message) override;
 	void ShutdownSurface() override;
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -905,7 +905,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 		// Only used in Java EGL path.
 		EmuThread_Join(graphicsContext, g_emuThread);
 
-		INFO_LOG(Log::System, "ThreadEnd called.");
+		INFO_LOG(Log::System, "EmuThread joined.");
 		graphicsContext->ShutdownSurface();
 		INFO_LOG(Log::System, "Graphics context now shut down from NativeApp_shutdown");
 	}
@@ -953,16 +953,15 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 			System_Toast("Graphics initialization failed. Quitting.");
 			return false;
 		}
-		// This is where we start the emuthread now - after InitFromRenderThread. This eliminates a race condition.
-		g_emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), []() {
-			ProcessFrameCommands();
-		});
 
 		graphicsContext->GetDrawContext()->SetErrorCallback([](const char *shortDesc, const char *details, void *userdata) {
 			g_OSD.Show(OSDType::MESSAGE_ERROR, details, 5.0);
 		}, nullptr);
 
-		graphicsContext->ThreadStart();
+		// This is where we start the emuthread now - after InitFromRenderThread. This eliminates a race condition.
+		g_emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), []() {
+			ProcessFrameCommands();
+		});
 		renderer_inited = true;
 	} else {
 		// Would be really nice if we could get something on the GL thread immediately when shutting down,
@@ -972,7 +971,6 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 		INFO_LOG(Log::G3D, "NativeApp.displayInit() restoring");
 		EmuThread_Join(graphicsContext, g_emuThread);
 
-		graphicsContext->ThreadEnd();
 		graphicsContext->ShutdownSurface();
 
 		INFO_LOG(Log::G3D, "Shut down both threads. Now let's bring it up again!");
@@ -989,8 +987,6 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 		g_emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), []() {
 			ProcessFrameCommands();
 		});
-
-		graphicsContext->ThreadStart();
 
 		INFO_LOG(Log::G3D, "Restored.");
 	}
@@ -1607,24 +1603,27 @@ static void ProcessFrameCommands() {
 			ERROR_LOG(Log::System, "No activity, clearing commands");
 		} else {
 			frameCommands = std::move(g_frameCommands);
-			INFO_LOG(Log::System, "Processing %zu frame commands", g_frameCommands.size());
 		}
 		g_frameCommands.clear();
 	}
-	for (const FrameCommand &frameCmd : frameCommands) {
-		DEBUG_LOG(Log::System, "frameCommand '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
 
-		jstring cmd = env->NewStringUTF(frameCmd.command.c_str());
-		jstring param = env->NewStringUTF(frameCmd.params.c_str());
-		env->CallVoidMethod(ppssppActivity, postCommand, cmd, param);
-		env->DeleteLocalRef(cmd);
-		env->DeleteLocalRef(param);
+	if (!frameCommands.empty()) {
+		INFO_LOG(Log::System, "Processing %zu frame commands", g_frameCommands.size());
+		for (const FrameCommand &frameCmd : frameCommands) {
+			DEBUG_LOG(Log::System, "frameCommand '%s' '%s'", frameCmd.command.c_str(), frameCmd.params.c_str());
+
+			jstring cmd = env->NewStringUTF(frameCmd.command.c_str());
+			jstring param = env->NewStringUTF(frameCmd.params.c_str());
+			env->CallVoidMethod(ppssppActivity, postCommand, cmd, param);
+			env->DeleteLocalRef(cmd);
+			env->DeleteLocalRef(param);
+		}
 	}
 }
 
 std::thread g_renderLoopThread;
 
-static void VulkanEmuThread(ANativeWindow *wnd, AndroidVulkanContext *graphicsContext);
+static void VulkanEmuThread(ANativeWindow *wnd, GraphicsContext *graphicsContext);
 
 // This runs in Vulkan mode only.
 // This handles the entire lifecycle of the Vulkan context, init and exit.
@@ -1652,7 +1651,7 @@ extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_PpssppActivity_runVulkanRende
 		return false;
 	}
 
-	g_renderLoopThread = std::thread(VulkanEmuThread, wnd, (AndroidVulkanContext *)graphicsContext);
+	g_renderLoopThread = std::thread(VulkanEmuThread, wnd, graphicsContext);
 	return true;
 }
 
@@ -1668,8 +1667,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_PpssppActivity_requestExitVulkanR
 }
 
 // TODO: Merge with the Win32 EmuThread and so on, and the Java EmuThread?
-// This function must release the window reference.
-static void VulkanEmuThread(ANativeWindow *wnd, AndroidVulkanContext *graphicsContext) {
+// This function must release the wnd reference.
+static void VulkanEmuThread(ANativeWindow *wnd, GraphicsContext *graphicsContext) {
 	SetCurrentThreadName("EmuThread");
 
 	AndroidJNIThreadContext ctx;
@@ -1708,7 +1707,6 @@ static void VulkanEmuThread(ANativeWindow *wnd, AndroidVulkanContext *graphicsCo
 			ERROR_LOG(Log::G3D, "Failed to initialize graphics.");
 			// Gonna be in a weird state here..
 		}
-		graphicsContext->ThreadStart();
 		renderer_inited = true;
 
 		// The main loop.
@@ -1725,7 +1723,6 @@ static void VulkanEmuThread(ANativeWindow *wnd, AndroidVulkanContext *graphicsCo
 	NativeShutdownGraphics(graphicsContext);
 
 	renderer_inited = false;
-	graphicsContext->ThreadEnd();
 
 	// Shut the graphics context down to the same state it was in when we entered the render thread.
 	INFO_LOG(Log::G3D, "Shutting down graphics context...");

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -100,6 +100,7 @@ struct JNIEnv {};
 #include "Core/Loaders.h"
 #include "Core/KeyMap.h"
 #include "Core/System.h"
+#include "Core/EmuThread.h"
 #include "Core/HLE/sceUsbCam.h"
 #include "Core/HLE/sceUsbGps.h"
 #include "Common/CPUDetect.h"
@@ -116,8 +117,7 @@ enum class EmuThreadState {
 };
 
 // OpenGL emu thread
-static std::thread emuThread;
-static std::atomic<int> emuThreadState((int)EmuThreadState::DISABLED);
+static std::thread g_emuThread;
 
 AndroidAudioState *g_audioState;
 
@@ -260,59 +260,6 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *pjvm, void *reserved) {
 
 	TimeInit();
 	return JNI_VERSION_1_6;
-}
-
-// Only used in OpenGL mode.
-static void EmuThreadFunc() {
-	SetCurrentThreadName("Entering EmuThread");
-
-	AndroidJNIThreadContext jniContext;
-
-	INFO_LOG(Log::System, "Entering emu thread");
-
-	_assert_(graphicsContext);
-	if (!NativeInitGraphics(graphicsContext)) {
-		_assert_msg_(false, "NativeInitGraphics failed, might as well bail");
-		emuThreadState = (int)EmuThreadState::QUIT_REQUESTED;
-		return;
-	}
-
-	INFO_LOG(Log::System, "Graphics initialized. Entering loop.");
-
-	// There's no real requirement that NativeInit happen on this thread.
-	// We just call the update/render loop here.
-	emuThreadState = (int)EmuThreadState::RUNNING;
-	while (emuThreadState != (int)EmuThreadState::QUIT_REQUESTED) {
-		NativeFrame(graphicsContext);
-		ProcessFrameCommands();
-	}
-
-	INFO_LOG(Log::System, "emuThreadState was set to QUIT_REQUESTED, left EmuThreadFunc loop. Setting state to STOPPED.");
-	emuThreadState = (int)EmuThreadState::STOPPED;
-
-	NativeShutdownGraphics(graphicsContext);
-
-	INFO_LOG(Log::System, "Leaving EmuThread");
-}
-
-static void EmuThreadStart() {
-	INFO_LOG(Log::System, "EmuThreadStart");
-	emuThreadState = (int)EmuThreadState::START_REQUESTED;
-	emuThread = std::thread(&EmuThreadFunc);
-}
-
-// Call EmuThreadStop first, then keep running the GPU (or eat commands)
-// as long as emuThreadState isn't STOPPED and/or there are still things queued up.
-// Only after that, call EmuThreadJoin.
-static void EmuThreadStop(const char *caller) {
-	INFO_LOG(Log::System, "EmuThreadStop - stopping (%s)...", caller);
-	emuThreadState = (int)EmuThreadState::QUIT_REQUESTED;
-}
-
-static void EmuThreadJoin() {
-	emuThread.join();
-	emuThread = std::thread();
-	INFO_LOG(Log::System, "EmuThreadJoin - joined");
 }
 
 static void PushCommand(std::string_view cmd, std::string_view param) {
@@ -956,23 +903,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 
 	if (renderer_inited && graphicsContext && graphicsContext->NeedsSeparateEmuThread()) {
 		// Only used in Java EGL path.
-		EmuThreadStop("shutdown");
-		// NOTE: We know that the GLSurfaceView render thread is stopped here, since we now
-		// correctly call GLSurfaceView.onPause/onResume. However, there may still be queued frames.
-		// We can't join until we've cleared the queue by calling ThreadFrame.
-
-		// Now we know that more frames won't be coming in.
-
-		INFO_LOG(Log::System, "BeginShutdown");
-
-		// Now, it could be that we had some frames queued up. Get through them.
-		// We're on the render thread, so this is synchronous.
-		graphicsContext->ThreadFrameUntilCondition([]() -> bool {
-			return emuThreadState == (int)EmuThreadState::STOPPED;
-		});
-		graphicsContext->ThreadEnd();
-
-		EmuThreadJoin();
+		EmuThread_Join(graphicsContext, g_emuThread);
 
 		INFO_LOG(Log::System, "ThreadEnd called.");
 		graphicsContext->ShutdownSurface();
@@ -1023,7 +954,9 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 			return false;
 		}
 		// This is where we start the emuthread now - after InitFromRenderThread. This eliminates a race condition.
-		EmuThreadStart();
+		g_emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), []() {
+			ProcessFrameCommands();
+		});
 
 		graphicsContext->GetDrawContext()->SetErrorCallback([](const char *shortDesc, const char *details, void *userdata) {
 			g_OSD.Show(OSDType::MESSAGE_ERROR, details, 5.0);
@@ -1037,15 +970,7 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 		// which ends up calling displayInit.
 
 		INFO_LOG(Log::G3D, "NativeApp.displayInit() restoring");
-		EmuThreadStop("displayInit");
-		// Skipping GL calls here because the old context is lost.
-		INFO_LOG(Log::G3D, "Looping until emu thread done...");
-		// TODO: Why can't we just join the EmuThread first?
-		graphicsContext->ThreadFrameUntilCondition([]() -> bool {
-			return emuThreadState == (int)EmuThreadState::STOPPED;
-		});
-		INFO_LOG(Log::G3D, "Joining emu thread");
-		EmuThreadJoin();
+		EmuThread_Join(graphicsContext, g_emuThread);
 
 		graphicsContext->ThreadEnd();
 		graphicsContext->ShutdownSurface();
@@ -1061,7 +986,9 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 			g_OSD.Show(OSDType::MESSAGE_ERROR, details, 5.0);
 		}, nullptr);
 
-		EmuThreadStart();
+		g_emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), []() {
+			ProcessFrameCommands();
+		});
 
 		graphicsContext->ThreadStart();
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -34,6 +34,7 @@
 
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
+#include "Core/EmuThread.h"
 #include "Core/KeyMap.h"
 #include "Core/System.h"
 
@@ -95,10 +96,6 @@ public:
 		renderManager_->ThreadEnd();
 	}
 
-	void StartThread() {
-		renderManager_->StartThread();
-	}
-
 protected:
 	void BeginShutdown() {
 		renderManager_->SetSkipGLCalls();
@@ -109,9 +106,8 @@ private:
 	GLRenderManager *renderManager_;
 };
 
-static std::atomic<bool> exitRenderLoop;
 static std::atomic<bool> renderLoopRunning;
-static std::thread g_renderLoopThread;
+static std::thread g_emuThread;
 
 PPSSPPBaseViewController *sharedViewController;
 
@@ -141,61 +137,25 @@ PPSSPPBaseViewController *sharedViewController;
 	return self;
 }
 
-// The actual rendering is NOT on this thread, this is the emu thread
-// that runs game logic.
-void GLRenderLoop(IOSGLESContext *graphicsContext) {
-	SetCurrentThreadName("EmuThreadGL");
-	renderLoopRunning = true;
-
-	NativeInitGraphics(graphicsContext);
-
-	INFO_LOG(Log::System, "Emulation thread starting\n");
-	while (!exitRenderLoop) {
-		NativeFrame(graphicsContext);
-	}
-
-	INFO_LOG(Log::System, "Emulation thread shutting down\n");
-	NativeShutdownGraphics(graphicsContext);
-
-	// Also ask the main thread to stop, so it doesn't hang waiting for a new frame.
-	INFO_LOG(Log::System, "Emulation thread stopping\n");
-
-	exitRenderLoop = false;
-	renderLoopRunning = false;
-}
-
 - (bool)runGLRenderLoop {
 	if (!graphicsContext) {
-		ERROR_LOG(Log::G3D, "runVulkanRenderLoop: Tried to enter without a created graphics context.");
+		ERROR_LOG(Log::G3D, "runGLRenderLoop: Tried to enter without a created graphics context.");
 		return false;
 	}
 
-	if (g_renderLoopThread.joinable()) {
-		ERROR_LOG(Log::G3D, "runVulkanRenderLoop: Already running");
+	if (g_emuThread.joinable()) {
+		ERROR_LOG(Log::G3D, "runGLRenderLoop: Already running");
 		return false;
 	}
 
-	_dbg_assert_(!renderLoopRunning);
-	_dbg_assert_(!exitRenderLoop);
-
-	graphicsContext->StartThread();
-
-	g_renderLoopThread = std::thread(GLRenderLoop, graphicsContext);
+	g_emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), [](){});
 	return true;
 }
 
 - (void)requestExitGLRenderLoop {
-	if (!renderLoopRunning) {
-		ERROR_LOG(Log::System, "Render loop already exited");
-		return;
-	}
-	_assert_(g_renderLoopThread.joinable());
-	exitRenderLoop = true;
-	graphicsContext->ThreadFrameUntilCondition([]() -> bool {
-		return !renderLoopRunning.load();
-	});
-	g_renderLoopThread.join();
-	_assert_(!g_renderLoopThread.joinable());
+	_assert_(g_emuThread.joinable());
+	EmuThread_Join(graphicsContext, g_emuThread);
+	_assert_(!g_emuThread.joinable());
 }
 
 - (void)viewDidLoad {
@@ -325,7 +285,7 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 }
 
 - (void)glkView:(GLKView *)view drawInRect:(CGRect)rect {
-	if (!renderLoopRunning) {
+	if (!g_emuThread.joinable()) {
 		INFO_LOG(Log::G3D, "Ignoring drawInRect");
 		return;
 	}
@@ -374,10 +334,6 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 
-	// Skipping GL calls here because the old context is lost.
-	graphicsContext->ThreadFrameUntilCondition([]() -> bool {
-		return !renderLoopRunning;
-	});
 	graphicsContext->ShutdownSurface();
 	graphicsContext->ShutdownAPI();
 	delete graphicsContext;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -253,8 +253,6 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 		ERROR_LOG(Log::G3D, "InitAPI failed: %s", errorMessage.c_str());
 	}
 
-	graphicsContext->ThreadStart();
-
 	/*self.iCadeView = [[iCadeReaderView alloc] init];
 	[self.view addSubview:self.iCadeView];
 	self.iCadeView.delegate = self;
@@ -380,7 +378,6 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	graphicsContext->ThreadFrameUntilCondition([]() -> bool {
 		return !renderLoopRunning;
 	});
-	graphicsContext->ThreadEnd();
 	graphicsContext->ShutdownSurface();
 	graphicsContext->ShutdownAPI();
 	delete graphicsContext;


### PR DESCRIPTION
Just reducing duplication, preparing for changes.