### PR TITLE
Fix build when USE_SYSTEM_MINIUPNPC cmake option is enabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,10 @@ if(USE_SYSTEM_RAPIDJSON)
 	add_compile_definitions(SYSTEM_RAPIDJSON)
 endif()
 
+if(USE_SYSTEM_MINIUPNPC)
+	add_compile_definitions(USE_SYSTEM_MINIUPNPC)
+endif()
+
 if(WEBOS)
 	set(USING_X11_VULKAN OFF)
 	set(USING_GLES2 ON)

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 if(USE_MINIUPNPC)
 	if(USE_SYSTEM_MINIUPNPC)
 		find_package(MINIUPNPC REQUIRED)
-		add_compile_definitions(WITH_UPNP USE_SYSTEM_MINIUPNPC)
+		add_compile_definitions(WITH_UPNP)
 	else()
 		set (MINIUPNPC_VERSION 2.2) # used by miniupnpcstrings.h.cmake
 		set (MINIUPNPC_API_VERSION 18)

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -931,6 +931,8 @@ std::vector<std::string> System_GetCameraDeviceList() {
 	return __mac_getDeviceList();
 #elif PPSSPP_PLATFORM(LINUX) && !PPSSPP_PLATFORM(ANDROID)
 	return __v4l_getDeviceList();
+#else
+	return {};
 #endif
 }
 


### PR DESCRIPTION
Adding a compile definition for USE_SYSTEM_MINIUPNPC in Core/CMakeLists.txt is not enough because NativeApp.cpp pulls in Core/Util/PortManager.h as one of its includes; rather than add a duplicate compile definition in UI/CMakeLists.txt so Core/Util/PortManager.h handles the conditional location of miniupnpc headers when the USE_SYSTEM_MINIUPNPC option is enabled correctly, adding it once in the root CMakeLists.txt ensures both Core and UI handle it properly.