### PR TITLE
Savedata dialog: serialize ioThreadStatus (bump section to v3)

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1293,7 +1293,13 @@ void PSPSaveDialog::DoState(PointerWrap &p) {
 	}
 	PSPDialog::DoState(p);
 
-	auto s = p.Section("PSPSaveDialog", 1, 2);
+	// Version 3 activates the s > 2 branch below, so ioThreadStatus survives
+	// a savestate. Safe to restore: the IO thread was joined above, so the
+	// value is only ever SAVEIO_NONE or SAVEIO_DONE, and the operation's
+	// effects are already part of the serialized state. Without this, loading
+	// a state taken while a savedata operation was in flight would restart
+	// the operation instead of resuming from its recorded status.
+	auto s = p.Section("PSPSaveDialog", 1, 3);
 	if (!s) {
 		return;
 	}


### PR DESCRIPTION
## What

One-line fix (plus a comment): bump the `PSPSaveDialog` savestate section from max version 2 to 3, which activates the existing-but-dead `s > 2` branch that serializes `ioThreadStatus`.

## The bug

The `if (s > 2) { Do(p, ioThreadStatus); }` branch in `PSPSaveDialog::DoState` appears to have been dead code since it was written — the section declaration stayed at `p.Section("PSPSaveDialog", 1, 2)`, so the version can never exceed 2 and every load takes the `else` path, resetting `ioThreadStatus` to `SAVEIO_NONE`.

Consequence: loading a state that was taken while a savedata operation was in flight loses the operation's completion status. Depending on where the dialog's state machine was, it either repeats the IO or waits on a completion that has already happened, instead of resuming from the recorded status.

## Why restoring the value is safe

- `DoState` joins the IO thread (`ioThread.join()`) before serializing anything, so the value that ends up in the state is only ever `SAVEIO_NONE` or `SAVEIO_DONE` — never a mid-operation status.
- The effects of a completed operation are already part of the serialized state (emulated RAM / savedata results), so restoring `SAVEIO_DONE` is consistent with the rest of the loaded state.

## Compatibility

- Old (v2 and v1) states load exactly as before, through the reset path.
- States written by this build won't load on older builds — the usual consequence of a section version bump.
