### PR TITLE
Savestate: store only live audio queue data (AudioChannel section v3)

### DIFF
--- a/Common/Data/Collections/FixedSizeQueue.h
+++ b/Common/Data/Collections/FixedSizeQueue.h
@@ -161,6 +161,43 @@ public:
 		p.DoMarker("FixedSizeQueue");
 	}
 
+	// Compact serialization: stores only the live [head_, head_+count_) region
+	// instead of the whole fixed storage. NOT format-compatible with DoState();
+	// callers must gate on their own section version.
+	void DoStateCompact(PointerWrap &p) {
+		int size = N;
+		Do(p, size);
+		if (size != N) {
+			ERROR_LOG(Log::Common, "Savestate failure: Incompatible queue size.");
+			p.SetError(p.ERROR_FAILURE);
+			return;
+		}
+		Do(p, count_);
+		if (count_ < 0 || count_ > N) {
+			ERROR_LOG(Log::Common, "Savestate failure: Bad compact queue count.");
+			p.SetError(p.ERROR_FAILURE);
+			return;
+		}
+		if (p.mode == PointerWrap::MODE_READ) {
+			// Restore linearized: live data starts at the front of storage.
+			head_ = 0;
+			tail_ = count_ == N ? 0 : count_;
+			DoArray<T>(p, storage_, count_);
+		} else {
+			if (head_ + count_ <= N) {
+				DoArray<T>(p, storage_ + head_, count_);
+			} else {
+				// Live region wraps; write the two pieces in pop order. Raw
+				// bytes only (POD DoArray has no per-call header), so the
+				// single linear read above consumes them identically.
+				const int firstPart = N - head_;
+				DoArray<T>(p, storage_ + head_, firstPart);
+				DoArray<T>(p, storage_, count_ - firstPart);
+			}
+		}
+		p.DoMarker("FixedSizeQueue");
+	}
+
 private:
 	T *storage_;
 	int head_;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -44,7 +44,7 @@ AudioChannel g_audioChans[PSP_AUDIO_CHANNEL_MAX + 1];
 
 void AudioChannel::DoState(PointerWrap &p)
 {
-	auto s = p.Section("AudioChannel", 1, 2);
+	auto s = p.Section("AudioChannel", 1, 3);
 	if (!s)
 		return;
 
@@ -59,7 +59,15 @@ void AudioChannel::DoState(PointerWrap &p)
 		Do(p, defaultRoutingMode);
 		Do(p, defaultRoutingVolMode);
 	}
-	chanSampleQueues[index].DoState(p);
+	if (s >= 3) {
+		// v3: compact queue form — only the live samples, not the whole 512KB
+		// fixed storage per channel. Cuts ~4.6MB of dead bytes from every
+		// savestate. Old savestates (s < 3) still load through the
+		// full-storage path below.
+		chanSampleQueues[index].DoStateCompact(p);
+	} else {
+		chanSampleQueues[index].DoState(p);
+	}
 }
 
 void AudioChannel::reset()


### PR DESCRIPTION
## What

Adds `FixedSizeQueue::DoStateCompact()` and bumps the `AudioChannel` section to v3 to use it. This addresses the existing TODO in `FixedSizeQueue::DoState`:

> `// TODO: This is quite wasteful, could just store the actual data. Would be slightly more complex though.`

## Why

`DoState` serializes the entire fixed backing store. Each `sceAudio` channel queue is `FixedSizeQueue<s16, 32768 * 8>` = 512KB, and there are nine of them — **~4.6MB of almost entirely dead bytes in every savestate**, while the live sample count at any moment is typically a few KB. That's wasted memcpy, wasted compression input, and wasted size in every save — manual saves, save slots, and the rewind feature's periodic in-memory states alike.

## How

`DoStateCompact()` stores only the live `[head, head+count)` region:

- **Save**: if the live region wraps around the end of storage, it is written as its two pieces in pop order. The POD `DoArray` path writes raw bytes with no per-element or per-call header, so the concatenation is byte-identical to a single linear write of the logical queue contents.
- **Load**: the data is restored linearized at the front of storage (`head = 0`, `tail = count % N`), which is an equivalent queue state.
- The count is validated on load; a bad value fails the load cleanly via `p.SetError()` instead of desyncing the stream.

The old full-storage `DoState()` is untouched; the two formats are not interchangeable, so callers opt in via their own section version — which `AudioChannel` (the only caller changed here) does with v3.

## Compatibility

- Old states (v2/v1 `AudioChannel` sections) load exactly as before through the full-storage path.
- States written by this build won't load on older builds — standard section-bump consequence.
