### PR TITLE
OpenGL: Check for support for high precision float in fragment shaders, and avoid the new workarounds if not supported

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -297,6 +297,7 @@ D3D11DrawContext::D3D11DrawContext(ComPtr<ID3D11Device> device, ComPtr<ID3D11Dev
 	_assert_(featureLevel_ >= D3D_FEATURE_LEVEL_9_3);
 
 	caps_.coordConvention = CoordConvention::Direct3D11;
+	caps_.fragmentShaderFullPrecisionFloat = true;
 
 	switch (featureLevel_) {
 	case D3D_FEATURE_LEVEL_11_1:

--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -494,7 +494,7 @@ bool CheckGLExtensions() {
 			GL_LOW_FLOAT, GL_MEDIUM_FLOAT, GL_HIGH_FLOAT,
 			GL_LOW_INT, GL_MEDIUM_INT, GL_HIGH_INT
 		};
-		GLint shaderTypes[2] = {
+		const GLint shaderTypes[2] = {
 			GL_VERTEX_SHADER, GL_FRAGMENT_SHADER
 		};
 		for (int st = 0; st < 2; st++) {

--- a/Common/GPU/OpenGL/GLFeatures.h
+++ b/Common/GPU/OpenGL/GLFeatures.h
@@ -138,6 +138,15 @@ struct GLExtensions {
 	// greater-or-equal than
 	bool VersionGEThan(int major, int minor, int sub = 0);
 	int GLSLVersion();
+
+	bool FullPrecisionIntInFragment() const {
+		return range[1][5][0] >= 30 && range[1][5][1] >= 30;
+	}
+
+	// If 23, normal floats are supported.
+	int HighpFragmentFloatMantissaBits() const {
+		return precision[1][2];
+	}
 };
 
 extern GLExtensions gl_extensions;

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -561,11 +561,11 @@ OpenGLContext::OpenGLContext(bool canChangeSwapInterval) : renderManager_(frameT
 		} else {
 			caps_.preferredDepthBufferFormat = DataFormat::D16;
 		}
+		if (gl_extensions.FullPrecisionIntInFragment()) {
+			caps_.fragmentShaderInt32Supported = true;
+		}
 		if (gl_extensions.GLES3) {
-			// Mali reports 30 but works fine...
-			if (gl_extensions.range[1][5][1] >= 30) {
-				caps_.fragmentShaderInt32Supported = true;
-			}
+			// 30 is an ok value for the max since it's 2^31-1, which is the max value for a signed int. NVIDIA also reports this.
 			caps_.samplerLodControl = true;
 		}
 		caps_.texture3DSupported = gl_extensions.GLES3 || gl_extensions.OES_texture_3D;
@@ -574,10 +574,15 @@ OpenGLContext::OpenGLContext(bool canChangeSwapInterval) : renderManager_(frameT
 		if (gl_extensions.VersionGEThan(3, 3, 0)) {
 			caps_.fragmentShaderInt32Supported = true;
 		}
+		caps_.fragmentShaderFullPrecisionFloat = true;
 		caps_.preferredDepthBufferFormat = DataFormat::D24_S8;
 		caps_.texture3DSupported = true;
 		caps_.textureDepthSupported = true;
 		caps_.samplerLodControl = true;
+	}
+
+	if (gl_extensions.HighpFragmentFloatMantissaBits() >= 23 && !(gl_extensions.bugs & BUG_PVR_SHADER_PRECISION_TERRIBLE)) {
+		caps_.fragmentShaderFullPrecisionFloat = true;
 	}
 
 	caps_.maxTextureSize = gl_extensions.maxTextureSize;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -918,6 +918,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
 	// Make sure that the surface has been initialized.
 	_dbg_assert_(vulkan->GetAvailablePresentModes().size() > 0);
 
+	caps_.fragmentShaderFullPrecisionFloat = true;
 	caps_.coordConvention = CoordConvention::Vulkan;
 	caps_.setMaxFrameLatencySupported = true;
 	caps_.anisoSupported = vulkan->GetDeviceFeatures().enabled.standard.samplerAnisotropy != 0;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -612,6 +612,7 @@ struct DeviceCaps {
 	bool framebufferStencilBlitSupported;
 	bool framebufferFetchSupported;
 	bool texture3DSupported;
+	bool fragmentShaderFullPrecisionFloat;  // Without this, our clip plane workaround doesn't work
 	bool fragmentShaderInt32Supported;
 	bool fragmentShaderDepthWriteSupported;
 	bool fragmentShaderStencilWriteSupported;

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -32,6 +32,7 @@
 // NOTE: Needs to be kept in sync with the g_logTypeNames array.
 enum class Log {
 	System = 0,  // Catch-all for uncategorized things
+	Config,
 	Boot,
 	Common,
 	CPU,

--- a/Common/Log/LogManager.cpp
+++ b/Common/Log/LogManager.cpp
@@ -70,6 +70,7 @@ void GenericLog(Log type, LogLevel level, const char *file, int line, const char
 // NOTE: Needs to be kept in sync with the Log enum.
 static const char * const g_logTypeNames[] = {
 	"System",
+	"Config",
 	"Boot",
 	"Common",
 	"CPU",

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -423,7 +423,7 @@ static int DefaultInternalResolution() {
 	}
 	int longestDisplaySide = std::max(System_GetPropertyInt(SYSPROP_DISPLAY_XRES), System_GetPropertyInt(SYSPROP_DISPLAY_YRES));
 	int scale = longestDisplaySide >= 1000 ? 2 : 1;
-	INFO_LOG(Log::G3D, "Longest display side: %d pixels. Choosing scale %d", longestDisplaySide, scale);
+	INFO_LOG(Log::Config, "Longest display side: %d pixels. Choosing scale %d", longestDisplaySide, scale);
 	return scale;
 #endif
 }
@@ -545,7 +545,7 @@ int Config::NextValidBackend() {
 	}
 
 	if (failed.count((GPUBackend)iGPUBackend)) {
-		ERROR_LOG(Log::Loader, "Graphics backend failed for %d, trying another", iGPUBackend);
+		ERROR_LOG(Log::Config, "Graphics backend failed for %d, trying another", iGPUBackend);
 
 #if !PPSSPP_PLATFORM(UWP)
 		if (!failed.count(GPUBackend::VULKAN) && VulkanMayBeAvailable()) {
@@ -567,7 +567,7 @@ int Config::NextValidBackend() {
 		if (sFailedGPUBackends.find(",ALL") == std::string::npos) {
 			sFailedGPUBackends += ",ALL";
 		}
-		ERROR_LOG(Log::Loader, "All graphics backends failed");
+		ERROR_LOG(Log::Config, "All graphics backends failed");
 #if PPSSPP_PLATFORM(ANDROID)
 		return (int)GPUBackend::OPENGL;
 #else
@@ -1267,7 +1267,7 @@ void Config::UpdateIniLocation(const char *iniFileName, const char *controllerIn
 bool Config::LoadAppendedConfig() {
 	IniFile iniFile;
 	if (!iniFile.Load(appendedConfigFileName_)) {
-		ERROR_LOG(Log::Loader, "Failed to read appended config '%s'.", appendedConfigFileName_.c_str());
+		ERROR_LOG(Log::Config, "Failed to read appended config '%s'.", appendedConfigFileName_.c_str());
 		return false;
 	}
 
@@ -1281,7 +1281,7 @@ bool Config::LoadAppendedConfig() {
 		}
 	}
 
-	INFO_LOG(Log::Loader, "Loaded appended config '%s'.", appendedConfigFileName_.c_str());
+	INFO_LOG(Log::Config, "Loaded appended config '%s'.", appendedConfigFileName_.c_str());
 
 	Save("Loaded appended config"); // Let's prevent reset
 	return true;
@@ -1338,12 +1338,12 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	UpdateIniLocation(iniFileName, controllerIniFilename);
 
-	INFO_LOG(Log::Loader, "Loading config: %s", iniFilename_.c_str());
+	INFO_LOG(Log::Config, "Loading config: %s", iniFilename_.c_str());
 	bSaveSettings = true;
 
 	IniFile iniFile;
 	if (!iniFile.Load(iniFilename_)) {
-		WARN_LOG(Log::Loader, "Failed to read '%s'. Setting main config to default.", iniFilename_.c_str());
+		WARN_LOG(Log::Config, "Failed to read '%s'. Setting main config to default.", iniFilename_.c_str());
 		// Continue anyway to initialize the config.
 	}
 
@@ -1370,7 +1370,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	// Fix JIT setting if no longer available.
 	if (!System_GetPropertyBool(SYSPROP_CAN_JIT)) {
 		if (iCpuCore == (int)CPUCore::JIT || iCpuCore == (int)CPUCore::JIT_IR) {
-			WARN_LOG(Log::Loader, "Forcing JIT off due to unavailablility");
+			WARN_LOG(Log::Config, "Forcing JIT off due to unavailablility");
 			iCpuCore = (int)CPUCore::IR_INTERPRETER;
 		}
 	}
@@ -1432,7 +1432,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	CheckForUpdate();
 
-	INFO_LOG(Log::Loader, "Loading controller config: %s", controllerIniFilename_.c_str());
+	INFO_LOG(Log::Config, "Loading controller config: %s", controllerIniFilename_.c_str());
 	bSaveSettings = true;
 
 	LoadStandardControllerIni();
@@ -1444,7 +1444,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 
 	PostLoadCleanup();
 
-	INFO_LOG(Log::Loader, "Config loaded: '%s' (%0.1f ms)", iniFilename_.c_str(), (time_now_d() - startTime) * 1000.0);
+	INFO_LOG(Log::Config, "Config loaded: '%s' (%0.1f ms)", iniFilename_.c_str(), (time_now_d() - startTime) * 1000.0);
 }
 
 bool Config::ShouldSaveSetting(const void *ptr) const {
@@ -1459,7 +1459,7 @@ bool Config::Save(const char *saveReason) {
 	if (!IsFirstInstance()) {
 		// TODO: Should we allow saving config if started from a different directory?
 		// How do we tell?
-		WARN_LOG(Log::Loader, "Not saving config - secondary instances don't.");
+		WARN_LOG(Log::Config, "Not saving config - secondary instances don't.");
 		// Don't want to retry or something.
 		return true;
 	}
@@ -1475,7 +1475,7 @@ bool Config::Save(const char *saveReason) {
 		g_recentFiles.Clean();
 		IniFile iniFile;
 		if (!iniFile.Load(iniFilename_)) {
-			WARN_LOG(Log::Loader, "Likely saving config for first time - couldn't read ini '%s'", iniFilename_.c_str());
+			WARN_LOG(Log::Config, "Likely saving config for first time - couldn't read ini '%s'", iniFilename_.c_str());
 		}
 
 		// Need to do this somewhere...
@@ -1492,7 +1492,7 @@ bool Config::Save(const char *saveReason) {
 				}
 				if (!ShouldSaveSetting(meta.settings[j].GetVoidPtr(configBlock))) {
 					// Skip settings marked as "don't save".
-					INFO_LOG(Log::System, "Not saving setting '%.*s' as marked as don't save.", STR_VIEW(meta.settings[j].IniKey()));
+					INFO_LOG(Log::Config, "Not saving setting '%.*s' as marked as don't save.", STR_VIEW(meta.settings[j].IniKey()));
 					continue;
 				}
 				meta.settings[j].WriteToIniSection(configBlock, section);
@@ -1546,28 +1546,28 @@ bool Config::Save(const char *saveReason) {
 		playTimeTracker_.Save(playTime);
 
 		if (!iniFile.Save(iniFilename_)) {
-			ERROR_LOG(Log::Loader, "Error saving config (%s) - can't write ini '%s'", saveReason, iniFilename_.c_str());
+			ERROR_LOG(Log::Config, "Error saving config (%s) - can't write ini '%s'", saveReason, iniFilename_.c_str());
 			return false;
 		}
-		INFO_LOG(Log::Loader, "Config saved (%s): '%s' (%0.1f ms)", saveReason, iniFilename_.c_str(), (time_now_d() - startTime) * 1000.0);
+		INFO_LOG(Log::Config, "Config saved (%s): '%s' (%0.1f ms)", saveReason, iniFilename_.c_str(), (time_now_d() - startTime) * 1000.0);
 
 		if (!IsGameSpecific()) {
 			// These settings can be game specific, and so are handled in SaveGameConfig().
 			IniFile controllerIniFile;
 			if (!controllerIniFile.Load(controllerIniFilename_)) {
-				ERROR_LOG(Log::Loader, "Error saving controller config - can't read ini first '%s'", controllerIniFilename_.c_str());
+				ERROR_LOG(Log::Config, "Error saving controller config - can't read ini first '%s'", controllerIniFilename_.c_str());
 			}
 			KeyMap::SaveToIni(controllerIniFile);
 			if (!controllerIniFile.Save(controllerIniFilename_)) {
-				ERROR_LOG(Log::Loader, "Error saving config - can't write ini '%s'", controllerIniFilename_.c_str());
+				ERROR_LOG(Log::Config, "Error saving config - can't write ini '%s'", controllerIniFilename_.c_str());
 				return false;
 			}
-			INFO_LOG(Log::Loader, "Controller config saved: %s", controllerIniFilename_.c_str());
+			INFO_LOG(Log::Config, "Controller config saved: %s", controllerIniFilename_.c_str());
 		}
 
 		PostSaveCleanup();
 	} else {
-		INFO_LOG(Log::Loader, "Not saving config");
+		INFO_LOG(Log::Config, "Not saving config");
 	}
 
 	return true;
@@ -1699,20 +1699,20 @@ void Config::CheckForUpdate() {
 
 void Config::VersionJsonDownloadCompleted(http::Request &download) {
 	if (download.ResultCode() != 200) {
-		ERROR_LOG(Log::Loader, "Failed to download %s: %d", download.url().c_str(), download.ResultCode());
+		ERROR_LOG(Log::Config, "Failed to download %s: %d", download.url().c_str(), download.ResultCode());
 		return;
 	}
 	std::string data;
 	download.buffer().TakeAll(&data);
 	if (data.empty()) {
-		ERROR_LOG(Log::Loader, "Version check: Empty data from server!");
+		ERROR_LOG(Log::Config, "Version check: Empty data from server!");
 		return;
 	}
 
 	json::JsonReader reader(data.c_str(), data.size());
 	const json::JsonGet root = reader.root();
 	if (!root) {
-		ERROR_LOG(Log::Loader, "Failed to parse json");
+		ERROR_LOG(Log::Config, "Failed to parse json");
 		return;
 	}
 
@@ -1729,16 +1729,16 @@ void Config::VersionJsonDownloadCompleted(http::Request &download) {
 	Version dismissed(g_Config.sDismissedVersion);
 
 	if (!installed.IsValid()) {
-		ERROR_LOG(Log::Loader, "Version check: Local version string invalid. Build problems? %s", PPSSPP_GIT_VERSION);
+		ERROR_LOG(Log::Config, "Version check: Local version string invalid. Build problems? %s", PPSSPP_GIT_VERSION);
 		return;
 	}
 	if (!upgrade.IsValid()) {
-		ERROR_LOG(Log::Loader, "Version check: Invalid server version: %s", version.c_str());
+		ERROR_LOG(Log::Config, "Version check: Invalid server version: %s", version.c_str());
 		return;
 	}
 
 	if (installed >= upgrade) {
-		INFO_LOG(Log::Loader, "Version check: Already up to date, erasing any upgrade message");
+		INFO_LOG(Log::Config, "Version check: Already up to date, erasing any upgrade message");
 		g_Config.sUpgradeMessage.clear();
 		g_Config.sUpgradeVersion = upgrade.ToString();
 		g_Config.sDismissedVersion.clear();
@@ -1757,7 +1757,7 @@ bool Config::ShowUpgradeReminder() {
 }
 
 void Config::DismissUpgrade() {
-	INFO_LOG(Log::Loader, "Upgrade dismissed for version %s", sUpgradeVersion.c_str());
+	INFO_LOG(Log::Config, "Upgrade dismissed for version %s", sUpgradeVersion.c_str());
 	sDismissedVersion = sUpgradeVersion;
 	sUpgradeMessage.clear();
 }
@@ -1815,7 +1815,7 @@ bool Config::CreateGameConfig(std::string_view gameId) {
 	Path fullIniFilePath = GetGameConfigFilePath(searchPath_, gameId, &exists);
 
 	if (exists) {
-		INFO_LOG(Log::System, "Game config already exists");
+		INFO_LOG(Log::Config, "Game config already exists");
 		return false;
 	}
 
@@ -1890,7 +1890,7 @@ bool Config::SaveGameConfig(const std::string &gameId, std::string_view titleFor
 	KeyMap::SaveToIni(iniFile);
 	iniFile.Save(fullIniFilePath);
 
-	INFO_LOG(Log::Loader, "Game-specific config saved: '%s'", fullIniFilePath.c_str());
+	INFO_LOG(Log::Config, "Game-specific config saved: '%s'", fullIniFilePath.c_str());
 
 	PostSaveCleanup();
 	return true;
@@ -1901,13 +1901,13 @@ bool Config::LoadGameConfig(const std::string &gameId) {
 	Path iniFileNameFull = GetGameConfigFilePath(searchPath_, gameId, &exists);
 	if (!exists) {
 		// Bail if there's no game-specific config.
-		DEBUG_LOG(Log::Loader, "No game-specific settings found in %s. Using global defaults.", iniFileNameFull.c_str());
+		DEBUG_LOG(Log::Config, "No game-specific settings found in %s. Using global defaults.", iniFileNameFull.c_str());
 		return false;
 	}
 
 	// Switch to game specific mode, if we're not in it.
 	if (gameId_.empty()) {
-		INFO_LOG(Log::Loader, "Switching to game specific mode before load: %s", gameId.c_str());
+		INFO_LOG(Log::Config, "Switching to game specific mode before load: %s", gameId.c_str());
 		gameId_ = gameId;
 	}
 
@@ -1921,7 +1921,7 @@ bool Config::LoadGameConfig(const std::string &gameId) {
 		if (sscanf(v.c_str(), "%f", &value)) {
 			mPostShaderSetting[k] = value;
 		} else {
-			WARN_LOG(Log::Loader, "Invalid float value string for param %s: '%s'", k.c_str(), v.c_str());
+			WARN_LOG(Log::Config, "Invalid float value string for param %s: '%s'", k.c_str(), v.c_str());
 		}
 	}
 
@@ -1958,7 +1958,7 @@ bool Config::LoadGameConfig(const std::string &gameId) {
 
 	PostLoadCleanup();
 
-	DEBUG_LOG(Log::Loader, "Game-specific config loaded: %s", gameId_.c_str());
+	DEBUG_LOG(Log::Config, "Game-specific config loaded: %s", gameId_.c_str());
 	return true;
 }
 
@@ -1994,7 +1994,7 @@ void Config::UnloadGameConfig() {
 void Config::LoadStandardControllerIni() {
 	IniFile controllerIniFile;
 	if (!controllerIniFile.Load(controllerIniFilename_)) {
-		WARN_LOG(Log::Loader, "Failed to read '%s'. Setting controller config to default.", controllerIniFilename_.c_str());
+		WARN_LOG(Log::Config, "Failed to read '%s'. Setting controller config to default.", controllerIniFilename_.c_str());
 		KeyMap::RestoreDefault();
 	} else {
 		// Continue anyway to initialize the config. It will just restore the defaults.
@@ -2016,7 +2016,7 @@ void PlayTimeTracker::Start(std::string_view gameId) {
 	if (gameId.empty()) {
 		return;
 	}
-	VERBOSE_LOG(Log::System, "GameTimeTracker::Start(%.*s)", STR_VIEW(gameId));
+	VERBOSE_LOG(Log::Config, "GameTimeTracker::Start(%.*s)", STR_VIEW(gameId));
 
 	auto iter = tracker_.find(gameId);
 	if (iter != tracker_.end()) {
@@ -2039,7 +2039,7 @@ void PlayTimeTracker::Stop(std::string_view gameId) {
 		return;
 	}
 
-	VERBOSE_LOG(Log::System, "GameTimeTracker::Stop(%.*s)", STR_VIEW(gameId));
+	VERBOSE_LOG(Log::Config, "GameTimeTracker::Stop(%.*s)", STR_VIEW(gameId));
 
 	auto iter = tracker_.find(gameId);
 	if (iter != tracker_.end()) {
@@ -2052,7 +2052,7 @@ void PlayTimeTracker::Stop(std::string_view gameId) {
 	}
 
 	// Can happen if boot gets cancelled. Not worth warn-logging.
-	DEBUG_LOG(Log::System, "GameTimeTracker::Stop called without corresponding GameTimeTracker::Start");
+	DEBUG_LOG(Log::Config, "GameTimeTracker::Stop called without corresponding GameTimeTracker::Start");
 }
 
 void PlayTimeTracker::Reset(std::string_view gameId) {

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -138,11 +138,15 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform,
 		id.SetBit(VS_BIT_NORM_REVERSE, gstate.areNormalsReversed());
 	}
 
-	if (clipInfoFlags & ClipInfoFlags::DepthClampFragment) {
-		id.SetBit(VS_BIT_FS_DEPTH_CLAMP);
-	}
-	if (clipInfoFlags & ClipInfoFlags::MinMaxZDiscard) {
-		id.SetBit(VS_BIT_FS_MINMAX_DISCARD);
+	if (gstate_c.Use(GPU_USE_FULL_PRECISION_IN_FRAGMENT)) {
+		if (clipInfoFlags & ClipInfoFlags::DepthClampFragment) {
+			id.SetBit(VS_BIT_FS_DEPTH_CLAMP);
+		}
+		if (clipInfoFlags & ClipInfoFlags::MinMaxZDiscard) {
+			id.SetBit(VS_BIT_FS_MINMAX_DISCARD);
+		}
+	} else {
+		// TODO: We're gonna need to soft-clip... Ugh.
 	}
 
 	id.SetBit(VS_BIT_FLATSHADE, doFlatShading);
@@ -286,11 +290,15 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 
 	// NOTE: This check MUST be identical to the one in ComputeVertexShaderID, otherwise we might get mismatches between VS and FS and end up with no shader at all.
 	if (!isModeThrough) {
-		if (clipInfoFlags & ClipInfoFlags::DepthClampFragment) {
-			id.SetBit(FS_BIT_DEPTH_CLAMP);
-		}
-		if (clipInfoFlags & ClipInfoFlags::MinMaxZDiscard) {
-			id.SetBit(FS_BIT_MINMAX_DISCARD);
+		if (gstate_c.Use(GPU_USE_FULL_PRECISION_IN_FRAGMENT)) {
+			if (clipInfoFlags & ClipInfoFlags::DepthClampFragment) {
+				id.SetBit(FS_BIT_DEPTH_CLAMP);
+			}
+			if (clipInfoFlags & ClipInfoFlags::MinMaxZDiscard) {
+				id.SetBit(FS_BIT_MINMAX_DISCARD);
+			}
+		} else {
+			// TODO: We're gonna need to soft-clip... Ugh.
 		}
 	} else {
 		_dbg_assert_(0 == (clipInfoFlags & (ClipInfoFlags::DepthClampFragment | ClipInfoFlags::MinMaxZDiscard)));

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -578,6 +578,10 @@ u32 GPUCommonHW::CheckGPUFeatures() const {
 		features |= GPU_USE_CULL_DISTANCE;
 	}
 
+	if (draw_->GetDeviceCaps().fragmentShaderFullPrecisionFloat) {
+		features |= GPU_USE_FULL_PRECISION_IN_FRAGMENT;
+	}
+
 	if (draw_->GetDeviceCaps().depthClampSupported) {
 		features |= GPU_USE_DEPTH_CLAMP;
 	}

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -483,7 +483,7 @@ enum : u32 {
 	// Free bit: 18
 	GPU_USE_FRAMEBUFFER_ARRAYS = FLAG_BIT(19),
 	GPU_USE_FRAMEBUFFER_FETCH = FLAG_BIT(20),
-	// Free bit: 21
+	GPU_USE_FULL_PRECISION_IN_FRAGMENT = FLAG_BIT(21),  // Required for the min-max/depthclamp in fragment shader stuff
 	GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT = FLAG_BIT(22),
 	GPU_ROUND_DEPTH_TO_16BIT = FLAG_BIT(23),  // Can be disabled either per game or if we use a real 16-bit depth buffer
 	GPU_USE_CLIP_DISTANCE = FLAG_BIT(24),

--- a/UI/SystemInfoScreen.cpp
+++ b/UI/SystemInfoScreen.cpp
@@ -184,6 +184,8 @@ void SystemInfoScreen::CreateDeviceInfoTab(UI::LinearLayout *deviceSpecs) {
 		const int highp_int_max = gl_extensions.range[1][5][1];
 		const int highp_float_min = gl_extensions.range[1][2][0];
 		const int highp_float_max = gl_extensions.range[1][2][1];
+		const int highp_int_precision = gl_extensions.precision[1][5];
+		const int highp_float_precision = gl_extensions.precision[1][2];
 		if (highp_int_max != 0) {
 			char temp[128];
 			snprintf(temp, sizeof(temp), "%d-%d", highp_int_min, highp_int_max);
@@ -191,7 +193,8 @@ void SystemInfoScreen::CreateDeviceInfoTab(UI::LinearLayout *deviceSpecs) {
 		}
 		if (highp_float_max != 0) {
 			char temp[128];
-			snprintf(temp, sizeof(temp), "%d-%d", highp_float_min, highp_float_max);
+			// if highp_float_precision is 23, full floats are available which is good.
+			snprintf(temp, sizeof(temp), "%d-%d (%d bits)", highp_float_min, highp_float_max, highp_float_precision);
 			gpuInfo->Add(new InfoItem(si->T("High precision float range"), temp));
 		}
 	}


### PR DESCRIPTION
Should fix #22001  (although some other games migh have minor glitches due to the lack of these workarounds, from #21715 ).