### PR TITLE
Add TextureReplacer unit test; make replacer testable standalone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1391,6 +1391,7 @@ if(UNITTEST)
 		unittest/TestVFS.cpp
 		unittest/TestZipSlip.cpp
 		unittest/TestLzrc.cpp
+		unittest/TestTextureReplacer.cpp
 		unittest/TestRiscVEmitter.cpp
 		unittest/TestLoongArch64Emitter.cpp
 		unittest/TestSoftwareGPUJit.cpp

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -356,7 +356,7 @@ void ProcessEvents() {
 			// INFO_LOG(Log::CPU, "%s (%lld, %lld) ", first->name ? first->name : "?", (u64)GetTicks(), (u64)first->time);
 			Event *evt = first;
 			first = first->next;
-			if (evt->type >= 0 && evt->type < event_types.size()) {
+			if (evt->type >= 0 && evt->type < (int)event_types.size()) {
 				event_types[evt->type].callback(evt->userdata, (int)(GetTicks() - evt->time));
 			} else {
 				_dbg_assert_msg_(false, "Bad event type %d", evt->type);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1261,7 +1261,7 @@ bool SavedataParam::GetList(SceUtilitySavedataParam *param)
 		// Log out the listing.
 		if (GenericLogEnabled(Log::sceUtility, LogLevel::LINFO)) {
 			INFO_LOG(Log::sceUtility, "LIST (searchstring=%s): %d files (max: %d)", searchString.c_str(), param->idList->resultCount, maxFileCount);
-			for (int i = 0; i < validDir.size(); i++) {
+			for (size_t i = 0; i < validDir.size(); i++) {
 				NOTICE_LOG(Log::sceUtility, "LIST %s: mode %08x, ctime: %s, atime: %s, mtime: %s",
 					entries[i].name, entries[i].st_mode, FmtPspTime(entries[i].st_ctime).c_str(), FmtPspTime(entries[i].st_atime).c_str(), FmtPspTime(entries[i].st_mtime).c_str());
 			}
@@ -1604,7 +1604,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param) {
 				// Check if thisSaveName is in the list before processing.
 				// This is hopefully faster than doing file I/O.
 				bool found = false;
-				for (int i = 0; i < allSaves.size(); i++) {
+				for (size_t i = 0; i < allSaves.size(); i++) {
 					if (allSaves[i].name == folderName) {
 						found = true;
 					}

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -267,7 +267,7 @@ static int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 		ctx->srcBytesRead = inDataConsumed;
 		ctx->dstSamplesWritten = outSamples;
 	}
-	return hleLogDebug(Log::ME, 0, "codec %s", GetCodecName(codec));
+	return hleLogDebug(Log::ME, 0, "codec %s sampleRate: %d bytesPerFrame: %d channels: %d", GetCodecName(codec), sampleRate, bytesPerFrame, channels);
 }
 
 // This is used by sceMp3, in Beats.

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -1036,7 +1036,7 @@ void Register_ThreadManForKernel()
 const char *KernelErrorToString(u32 err) {
 	switch (err) {
 	case 0x00000000: return "ERROR_OK";
-	case SCE_KERNEL_ERROR_BAD_ARGUMENT: "BAD_ARGUMENT";
+	case SCE_KERNEL_ERROR_BAD_ARGUMENT: return "BAD_ARGUMENT";
 	case 0x80000020: return "ALREADY";
 	case 0x80000021: return "BUSY";
 	case 0x80000022: return "OUT_OF_MEMORY";

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -864,7 +864,7 @@ static int sysclib_sprintf_impl(u32 dst, int limit, u32 fmt, int paramOffset) {
 	const size_t retval = result.size();
 
 	// Implement the snprintf length check.
-	if (limit != 0 && result.length() >= limit) {
+	if (limit != 0 && (int)result.length() >= limit) {
 		result.resize(limit - 1);
 	}
 

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -268,7 +268,7 @@ int IRBlockCache::AllocateBlock(int emAddr, u32 origSize, const std::vector<IRIn
 		return -1;
 	}
 	// TODO: Use memcpy.
-	for (int i = 0; i < insts.size(); i++) {
+	for (size_t i = 0; i < insts.size(); i++) {
 		arena_.push_back(insts[i]);
 	}
 	int newBlockIndex = (int)blocks_.size();

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -562,7 +562,7 @@ std::string GameManager::GetISOGameID(FileLoader *loader) const {
 	return sfo.GetValueString("DISC_ID");
 }
 
-bool GameManager::ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes, size_t maxTotalSize) {
+bool GameManager::ExtractFile(struct zip *z, int file_index, const Path &outFilename, int64_t *bytesCopied, int64_t allBytes, int64_t maxTotalSize) {
 	struct zip_stat zstat;
 	zip_stat_index(z, file_index, 0, &zstat);
 	size_t size = zstat.size;
@@ -635,9 +635,9 @@ bool GameManager::ExtractFile(struct zip *z, int file_index, const Path &outFile
 }
 
 // Doesn't care what it is, just extracts the whole ZIP to the requested location.
-bool GameManager::ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot, size_t maxTotalSize) {
-	size_t allBytes = 0;
-	size_t bytesCopied = 0;
+bool GameManager::ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot, int64_t maxTotalSize) {
+	int64_t allBytes = 0;
+	int64_t bytesCopied = 0;
 
 	auto sy = GetI18NCategory(I18NCat::SYSTEM);
 
@@ -701,12 +701,12 @@ bool GameManager::ExtractZipContents(struct zip *z, const Path &dest, const ZipF
 			if (zip_stat_index(z, i, 0, &zstat) >= 0) {
 				// Guard against zip bombs: the total declared size must not
 				// exceed the limit. Check before adding to avoid overflow.
-				if (zstat.size > maxTotalSize || allBytes > maxTotalSize - zstat.size) {
+				if ((int64_t)zstat.size > maxTotalSize || allBytes > maxTotalSize - (int64_t)zstat.size) {
 					ERROR_LOG(Log::HLE, "Bailing: zip contents too large (%d bytes), limit %d", (int)allBytes, (int)maxTotalSize);
 					SetInstallError(sy->T("Too large"));
 					goto bail;
 				}
-				allBytes += zstat.size;
+				allBytes += (int64_t)zstat.size;
 			}
 		}
 		g_OSD.SetProgressBar("install", di->T("Installing..."), 0.0f, info.numFiles, (i + 1) * 0.1f, 0.1f);
@@ -835,7 +835,7 @@ bool GameManager::InstallZippedISO(struct zip *z, int isoFileIndex, const Path &
 	}
 	outputISOFilename = outputISOFilename / name;
 
-	size_t bytesCopied = 0;
+	int64_t bytesCopied = 0;
 	bool success = false;
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 	g_OSD.SetProgressBar("install", di->T("Installing..."), 0.0f, 0.0f, 0.0f, 0.1f);

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -90,7 +90,7 @@ public:
 
 	// Extracts the contents of an open zip archive into dest. Exposed for testing.
 	// maxTotalSize limits the total decompressed size (zip bomb protection).
-	bool ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot, size_t maxTotalSize = 0x100000000);
+	bool ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot, size_t maxTotalSize = 0x100000000ULL);
 
 private:
 	void InstallZipContents(ZipFileTask task);
@@ -100,7 +100,7 @@ private:
 
 	void InstallDone();
 
-	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes, size_t maxTotalSize = 0x100000000);
+	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes, size_t maxTotalSize = 0x100000000ULL);
 	bool DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest);
 	void SetInstallError(std::string_view err);
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -90,7 +90,7 @@ public:
 
 	// Extracts the contents of an open zip archive into dest. Exposed for testing.
 	// maxTotalSize limits the total decompressed size (zip bomb protection).
-	bool ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot, size_t maxTotalSize = 0x100000000ULL);
+	bool ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot, int64_t maxTotalSize = 0x100000000ULL);
 
 private:
 	void InstallZipContents(ZipFileTask task);
@@ -100,7 +100,7 @@ private:
 
 	void InstallDone();
 
-	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes, size_t maxTotalSize = 0x100000000ULL);
+	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, int64_t *bytesCopied, int64_t allBytes, int64_t maxTotalSize = 0x100000000ULL);
 	bool DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest);
 	void SetInstallError(std::string_view err);
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -63,10 +63,13 @@ TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
 	}
 
 	// We don't want to keep the draw object around, so extract the info we need.
-	if (draw->GetDataFormatSupport(Draw::DataFormat::BC3_UNORM_BLOCK)) formatSupport_.bc123 = true;
-	if (draw->GetDataFormatSupport(Draw::DataFormat::ASTC_4x4_UNORM_BLOCK)) formatSupport_.astc = true;
-	if (draw->GetDataFormatSupport(Draw::DataFormat::BC7_UNORM_BLOCK)) formatSupport_.bc7 = true;
-	if (draw->GetDataFormatSupport(Draw::DataFormat::ETC2_R8G8B8_UNORM_BLOCK)) formatSupport_.etc2 = true;
+	// In tests, draw may be null; formats then just default to unsupported.
+	if (draw) {
+		if (draw->GetDataFormatSupport(Draw::DataFormat::BC3_UNORM_BLOCK)) formatSupport_.bc123 = true;
+		if (draw->GetDataFormatSupport(Draw::DataFormat::ASTC_4x4_UNORM_BLOCK)) formatSupport_.astc = true;
+		if (draw->GetDataFormatSupport(Draw::DataFormat::BC7_UNORM_BLOCK)) formatSupport_.bc7 = true;
+		if (draw->GetDataFormatSupport(Draw::DataFormat::ETC2_R8G8B8_UNORM_BLOCK)) formatSupport_.etc2 = true;
+	}
 }
 
 TextureReplacer::~TextureReplacer() {
@@ -74,6 +77,15 @@ TextureReplacer::~TextureReplacer() {
 		delete iter.second;
 	}
 	delete vfs_;
+}
+
+bool TextureReplacer::LoadPackForTesting(const Path &basePath, std::string *error) {
+	basePath_ = basePath;
+	gameID_ = "";
+	replaceEnabled_ = true;
+	saveEnabled_ = false;
+	replaceEnabled_ = LoadIni(error, false);
+	return replaceEnabled_;
 }
 
 void TextureReplacer::NotifyConfigChanged() {
@@ -610,7 +622,7 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 
 ReplacedTexture *TextureReplacer::FindReplacement(ReplacementCacheKey replacementKey, int w, int h) {
 	// Only actually replace if we're replacing.  We might just be saving.
-	if (!Enabled() || !g_Config.bReplaceTextures) {
+	if (!replaceEnabled_) {
 		return nullptr;
 	}
 
@@ -952,7 +964,7 @@ static typename std::unordered_map<ReplacementCacheKey, Value>::const_iterator L
 }
 
 bool TextureReplacer::FindFiltering(ReplacementCacheKey replacementKey, TextureFiltering *forceFiltering) {
-	if (!Enabled() || !g_Config.bReplaceTextures) {
+	if (!replaceEnabled_) {
 		return false;
 	}
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -93,6 +93,10 @@ public:
 	// Returns nullptr if not found.
 	ReplacedTexture *FindReplacement(ReplacementCacheKey key, int w, int h);
 
+	// For testing: point the replacer at a texture pack directory and load its
+	// ini, without touching the global config. Returns true on success.
+	bool LoadPackForTesting(const Path &basePath, std::string *error);
+
 	// Check if a NotifyTextureDecoded for this texture is desired (used to avoid reads from write-combined memory.)
 	bool WillSave(const ReplacedTextureDecodeInfo &replacedInfo) const;
 

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -143,7 +143,6 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 
 	std::string shortFilename = zipPath_.GetFilename();
 
-	bool showDeleteCheckbox = false;
 	returnToHomebrew_ = false;
 	installChoice_ = nullptr;
 	playChoice_ = nullptr;
@@ -186,7 +185,6 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 		}
 
 		returnToHomebrew_ = true;
-		showDeleteCheckbox = true;
 		break;
 	}
 	case ZipFileContents::TEXTURE_PACK:
@@ -195,7 +193,6 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 		leftColumn->Add(new TextView(question));
 		leftColumn->Add(new TextView(shortFilename));
 
-		showDeleteCheckbox = true;
 		break;
 	}
 	case ZipFileContents::PRX_PLUGIN:
@@ -241,7 +238,6 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 		destFolders_.push_back(savestateDir);
 
 		// TODO: Use the GameInfoCache to display data about the game if available.
-		showDeleteCheckbox = true;
 		break;
 	}
 	case ZipFileContents::SAVE_DATA:
@@ -282,7 +278,6 @@ void InstallZipScreen::CreateContentViews(UI::ViewGroup *parent) {
 			}
 		}
 
-		showDeleteCheckbox = true;
 		break;
 	}
 	case ZipFileContents::FRAME_DUMP:

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -578,9 +578,7 @@ void NativeInit(int argc, const char *argv[], const CommandLineOptions &cmdLineO
 	// Apply parsed command line options to config.
 	cmdLineOptions.ApplyToConfig();
 
-	bool gotBootFilename = false;
 	boot_filename.clear();
-
 	if (boot_filename.empty() && cmdLineOptions.bootVSH.has_value() && cmdLineOptions.bootVSH.value()) {
 		boot_filename = g_Config.flash0Directory / "vsh/module/vshmain.prx";
 	}
@@ -629,7 +627,6 @@ void NativeInit(int argc, const char *argv[], const CommandLineOptions &cmdLineO
 	// don't already have one.
 	if (!cmdLineOptions.bootFilenames.empty()) {
 		std::string bootFilename = cmdLineOptions.bootFilenames[0];
-		gotBootFilename = true;
 		INFO_LOG(Log::System, "Boot filename found in args: '%s'", bootFilename.c_str());
 
 		bool okToLoad = true;

--- a/android/ab.sh
+++ b/android/ab.sh
@@ -8,7 +8,6 @@ cp -r ../assets/upload assets/
 cp -r ../assets/ui_images assets/
 cp ../assets/*.ini assets/
 cp ../assets/*.ttf assets/
-cp ../assets/*.png assets/
 cp ../assets/*.zim assets/
 cp ../assets/*.meta assets/
 cp ../assets/*.wav assets/

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -90,6 +90,8 @@ LOCAL_CFLAGS += -DSTACK_LINE_READER_BUFFER_SIZE=1024 -DHAVE_DLFCN_H -DRC_DISABLE
 
 # http://software.intel.com/en-us/articles/getting-started-on-optimizing-ndk-project-for-multiple-cpu-architectures
 
+# On x86_64, we test all emitters in the unit test so we need them included here.
+
 ifeq ($(TARGET_ARCH_ABI),x86)
 ARCH_FILES := \
   $(SRC)/Common/ABI.cpp \
@@ -101,6 +103,12 @@ ARCH_FILES := \
   $(SRC)/Common/ABI.cpp \
   $(SRC)/Common/x64Emitter.cpp \
   $(SRC)/Common/x64Analyzer.cpp \
+  $(SRC)/TestX64Emitter.cpp \
+  $(SRC)/Common/ArmEmitter.cpp \
+  $(SRC)/Common/Arm64Emitter.cpp \
+  $(SRC)/Common/RiscVEmitter.cpp \
+  $(SRC)/Common/LoongArch64Emitter.cpp \
+  $(SRC)/ext/disarm.cpp \
   $(SRC)/Common/Thunk.cpp
 else ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
 ARCH_FILES := \
@@ -1011,40 +1019,26 @@ ifeq ($(UNITTEST),1)
   LOCAL_CFLAGS += -fPIE
   LOCAL_LDFLAGS += -fPIE -pie
 
-  ifeq ($(findstring arm64-v8a,$(TARGET_ARCH_ABI)),arm64-v8a)
-    TESTARMEMITTER_FILE = $(SRC)/unittest/TestArm64Emitter.cpp
-  else ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
-    TESTARMEMITTER_FILE = $(SRC)/unittest/TestArmEmitter.cpp
-  else
-    TESTARMEMITTER_FILE = \
-      $(SRC)/Common/ArmEmitter.cpp \
-      $(SRC)/Common/Arm64Emitter.cpp \
-      $(SRC)/Common/RiscVEmitter.cpp \
-      $(SRC)/Common/LoongArch64Emitter.cpp \
-      $(SRC)/Core/MIPS/ARM/ArmRegCacheFPU.cpp \
-      $(SRC)/Core/Util/DisArm64.cpp \
-      $(SRC)/ext/disarm.cpp \
-      $(SRC)/ext/riscv-disas.cpp \
-      $(SRC)/ext/loongarch-disasm.cpp \
-      $(SRC)/unittest/TestArmEmitter.cpp \
-      $(SRC)/unittest/TestArm64Emitter.cpp \
-      $(SRC)/unittest/TestRiscVEmitter.cpp \
-      $(SRC)/unittest/TestLoongArch64Emitter.cpp \
-      $(SRC)/unittest/TestX64Emitter.cpp
-  endif
-
   LOCAL_MODULE := ppsspp_unittest
   LOCAL_SRC_FILES := \
     $(SRC)/unittest/JitHarness.cpp \
+    $(SRC)/Core/MIPS/ARM/ArmRegCacheFPU.cpp \
+    $(SRC)/Core/Util/DisArm64.cpp \
+    $(SRC)/ext/riscv-disas.cpp \
+    $(SRC)/ext/loongarch-disasm.cpp \
+    $(SRC)/unittest/TestArmEmitter.cpp \
+    $(SRC)/unittest/TestArm64Emitter.cpp \
+    $(SRC)/unittest/TestRiscVEmitter.cpp \
+    $(SRC)/unittest/TestLoongArch64Emitter.cpp \
     $(SRC)/unittest/TestIRPassSimplify.cpp \
     $(SRC)/unittest/TestShaderGenerators.cpp \
     $(SRC)/unittest/TestSoftwareGPUJit.cpp \
     $(SRC)/unittest/TestThreadManager.cpp \
     $(SRC)/unittest/TestVertexJit.cpp \
+    $(SRC)/unittest/TestTextureReplacer.cpp \
     $(SRC)/unittest/TestVFS.cpp \
-		$(SRC)/unittest/TestLzrc.cpp \
+    $(SRC)/unittest/TestLzrc.cpp \
     $(SRC)/unittest/TestZipSlip.cpp \
-    $(TESTARMEMITTER_FILE) \
     $(SRC)/unittest/UnitTest.cpp
 
   include $(BUILD_EXECUTABLE)

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -103,7 +103,6 @@ ARCH_FILES := \
   $(SRC)/Common/ABI.cpp \
   $(SRC)/Common/x64Emitter.cpp \
   $(SRC)/Common/x64Analyzer.cpp \
-  $(SRC)/TestX64Emitter.cpp \
   $(SRC)/Common/ArmEmitter.cpp \
   $(SRC)/Common/Arm64Emitter.cpp \
   $(SRC)/Common/RiscVEmitter.cpp \
@@ -1028,6 +1027,7 @@ ifeq ($(UNITTEST),1)
     $(SRC)/ext/loongarch-disasm.cpp \
     $(SRC)/unittest/TestArmEmitter.cpp \
     $(SRC)/unittest/TestArm64Emitter.cpp \
+	$(SRC)/unittest/TestX64Emitter.cpp \
     $(SRC)/unittest/TestRiscVEmitter.cpp \
     $(SRC)/unittest/TestLoongArch64Emitter.cpp \
     $(SRC)/unittest/TestIRPassSimplify.cpp \

--- a/unittest/TestTextureReplacer.cpp
+++ b/unittest/TestTextureReplacer.cpp
@@ -1,0 +1,165 @@
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "Common/Data/Format/PNGLoad.h"
+#include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
+#include "Common/Thread/ThreadManager.h"
+#include "GPU/Common/TextureReplacer.h"
+
+#include "UnitTest.h"
+
+// The fake hashes in textures.ini are designed to be readable: the address
+// part starts with A, the CLUT hash with C, and the contents hash with 1.
+static const u64 KEY_A = 0xA0000001C0000001ULL;  // addr 0xA0000001, clut 0xC0000001
+static const u32 HASH_A = 0x10000001;
+static const u64 KEY_B = 0xA0000002C0000002ULL;  // two mip levels
+static const u32 HASH_B = 0x10000002;
+static const u64 KEY_C = 0xA0000003C0000003ULL;  // hashrange
+static const u32 HASH_C = 0x10000003;
+static const u64 KEY_D = 0xA0000004C0000004ULL;  // ignored (empty filename)
+static const u32 HASH_D = 0x10000004;
+static const u64 KEY_E = 0xA0000005C0000005ULL;  // file missing
+static const u32 HASH_E = 0x10000005;
+
+static bool CreateTestPNG(const Path &filename, int w, int h, u32 color) {
+	std::vector<u8> buf((size_t)w * h * 4);
+	for (int i = 0; i < w * h; i++) {
+		buf[i * 4] = (color >> 24) & 0xFF;
+		buf[i * 4 + 1] = (color >> 16) & 0xFF;
+		buf[i * 4 + 2] = (color >> 8) & 0xFF;
+		buf[i * 4 + 3] = color & 0xFF;
+	}
+	return pngSave(filename, buf.data(), w, h, 4);
+}
+
+static bool CreateTestPack(const Path &packDir) {
+	File::DeleteDirRecursively(packDir);
+	if (!File::CreateDir(packDir)) {
+		return false;
+	}
+
+	static const char *iniContent =
+		"[options]\n"
+		"hash = quick\n"
+		"version = 1\n"
+		"\n"
+		"[hashes]\n"
+		"A0000001C000000110000001 = tex_a.png\n"
+		"A0000002C000000210000002 = tex_b0.png\n"
+		"A0000002C000000210000002_1 = tex_b1.png\n"
+		"A0000003C000000310000003 = tex_c.png\n"
+		"A0000004C000000410000004 =\n"
+		"A0000005C000000510000005 = missing.png\n"
+		"\n"
+		"[hashranges]\n"
+		"A0000003,512,512 = 256,256\n"
+		"\n"
+		"[filtering]\n"
+		"A0000001C000000110000001 = nearest\n";
+
+	FILE *f = File::OpenCFile(packDir / "textures.ini", "w");
+	if (!f) {
+		return false;
+	}
+	fwrite(iniContent, 1, strlen(iniContent), f);
+	fclose(f);
+
+	if (!CreateTestPNG(packDir / "tex_a.png", 64, 64, 0xFF0000FF)) return false;
+	if (!CreateTestPNG(packDir / "tex_b0.png", 64, 64, 0x00FF00FF)) return false;
+	if (!CreateTestPNG(packDir / "tex_b1.png", 32, 32, 0x00FF00FF)) return false;
+	if (!CreateTestPNG(packDir / "tex_c.png", 256, 256, 0x0000FFFF)) return false;
+
+	return true;
+}
+
+static bool TestLookups(TextureReplacer *replacer) {
+	// Key A: single mip, found.
+	ReplacedTexture *texA = replacer->FindReplacement(ReplacementCacheKey(KEY_A, HASH_A), 64, 64);
+	EXPECT_TRUE(texA != nullptr);
+
+	// Key B: two mip levels, found.
+	ReplacedTexture *texB = replacer->FindReplacement(ReplacementCacheKey(KEY_B, HASH_B), 64, 64);
+	EXPECT_TRUE(texB != nullptr);
+
+	// Key C: found via hashrange.
+	ReplacedTexture *texC = replacer->FindReplacement(ReplacementCacheKey(KEY_C, HASH_C), 512, 512);
+	EXPECT_TRUE(texC != nullptr);
+
+	// Key D: explicitly ignored (empty filename).
+	EXPECT_TRUE(replacer->FindReplacement(ReplacementCacheKey(KEY_D, HASH_D), 16, 16) == nullptr);
+
+	// Key E: file missing, still creates a texture object (loads as NOT_FOUND).
+	ReplacedTexture *texE = replacer->FindReplacement(ReplacementCacheKey(KEY_E, HASH_E), 16, 16);
+	EXPECT_TRUE(texE != nullptr);
+
+	// Unknown key: not in the ini at all.
+	ReplacementCacheKey unknownKey(0x2000000020000000ULL, 0x20000000);
+	EXPECT_TRUE(replacer->FindReplacement(unknownKey, 16, 16) == nullptr);
+
+	if (!texA || !texB || !texC || !texE) {
+		return false;
+	}
+
+	// Load the actual textures using the thread manager.
+	g_threadManager.Init(1, 1);
+
+	// Key A: 64x64 single level, nearest filtering.
+	EXPECT_TRUE(texA->Poll(1.0));
+	EXPECT_EQ_INT(texA->NumLevels(), 1);
+	int w = 0, h = 0;
+	texA->GetSize(0, &w, &h);
+	EXPECT_EQ_INT(w, 64);
+	EXPECT_EQ_INT(h, 64);
+	TextureFiltering filtering = TEX_FILTER_AUTO;
+	EXPECT_TRUE(texA->ForceFiltering(&filtering));
+	EXPECT_TRUE(filtering == TEX_FILTER_FORCE_NEAREST);
+
+	// Key B: two mip levels, 64x64 and 32x32.
+	EXPECT_TRUE(texB->Poll(1.0));
+	EXPECT_EQ_INT(texB->NumLevels(), 2);
+	texB->GetSize(0, &w, &h);
+	EXPECT_EQ_INT(w, 64);
+	EXPECT_EQ_INT(h, 64);
+	texB->GetSize(1, &w, &h);
+	EXPECT_EQ_INT(w, 32);
+	EXPECT_EQ_INT(h, 32);
+
+	// Key C: hashrange maps 512x512 -> 256x256, upscaled back to 512x512.
+	EXPECT_TRUE(texC->Poll(1.0));
+	EXPECT_EQ_INT(texC->NumLevels(), 1);
+	texC->GetSize(0, &w, &h);
+	EXPECT_EQ_INT(w, 512);
+	EXPECT_EQ_INT(h, 512);
+
+	// Key E: missing file should end up NOT_FOUND.
+	EXPECT_TRUE(texE->Poll(1.0));
+	EXPECT_TRUE(texE->State() == ReplacementState::NOT_FOUND);
+
+	g_threadManager.Teardown();
+	return true;
+}
+
+bool TestTextureReplacer() {
+	Path packDir = Path("unittest_texture_pack");
+	if (!CreateTestPack(packDir)) {
+		return false;
+	}
+
+	TextureReplacer replacer(nullptr);
+	std::string error;
+	if (!replacer.LoadPackForTesting(packDir, &error)) {
+		ERROR_LOG(Log::G3D, "Failed to load test texture pack: %s", error.c_str());
+		File::DeleteDirRecursively(packDir);
+		return false;
+	}
+
+	if (!TestLookups(&replacer)) {
+		File::DeleteDirRecursively(packDir);
+		return false;
+	}
+
+	File::DeleteDirRecursively(packDir);
+	return true;
+}

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -1392,6 +1392,7 @@ bool TestThreadManager();
 bool TestVFS();
 bool TestZipSlip();
 bool TestLzrc();
+bool TestTextureReplacer();
 
 TestItem availableTests[] = {
 #if PPSSPP_ARCH(ARM64) || PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
@@ -1449,6 +1450,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(CmdLine),
 	TEST_ITEM(ZipSlip),
 	TEST_ITEM(Lzrc),
+	TEST_ITEM(TextureReplacer),
 };
 
 int main(int argc, const char *argv[]) {

--- a/unittest/UnitTests.vcxproj
+++ b/unittest/UnitTests.vcxproj
@@ -294,6 +294,7 @@
     <ClCompile Include="TestSoftwareGPUJit.cpp" />
     <ClCompile Include="TestLzrc.cpp" />
     <ClCompile Include="TestThreadManager.cpp" />
+    <ClCompile Include="TestTextureReplacer.cpp" />
     <ClCompile Include="TestVertexJit.cpp" />
     <ClCompile Include="TestVFS.cpp" />
     <ClCompile Include="TestZipSlip.cpp" />

--- a/unittest/UnitTests.vcxproj
+++ b/unittest/UnitTests.vcxproj
@@ -142,7 +142,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>winhttp.lib;mfuuid.lib;shlwapi.lib;Ws2_32.lib;winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;comctl32.lib;dxguid.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d2d1.lib;dwrite.lib;d3d11.lib;winhttp.lib;mfuuid.lib;shlwapi.lib;Ws2_32.lib;winmm.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;comctl32.lib;dxguid.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4049 /ignore:4217 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalLibraryDirectories>../ffmpeg/Windows/x86/lib</AdditionalLibraryDirectories>
     </Link>

--- a/unittest/UnitTests.vcxproj.filters
+++ b/unittest/UnitTests.vcxproj.filters
@@ -16,6 +16,7 @@
     <ClCompile Include="TestSoftwareGPUJit.cpp" />
     <ClCompile Include="TestIRPassSimplify.cpp" />
     <ClCompile Include="TestLzrc.cpp" />
+    <ClCompile Include="TestTextureReplacer.cpp" />
     <ClCompile Include="TestRiscVEmitter.cpp" />
     <ClCompile Include="TestVFS.cpp" />
     <ClCompile Include="TestZipSlip.cpp" />


### PR DESCRIPTION
Add unittest/TestTextureReplacer which creates a fictive texture pack (textures.ini with readable invented hashes plus real PNG files), loads it via the replacer, and verifies lookups, filtering, hashranges, mip levels, and missing/ignored entries.

To make the replacer runnable outside the emulator:
- The constructor now accepts a null DrawContext (formats just default to unsupported).
- FindReplacement/FindFiltering use the replaceEnabled_ member instead of the global config.
- Added TextureReplacer::LoadPackForTesting() to load an ini from a path directly.

Created by DeepSeek under guidance