### PR TITLE
Don't exit games when leaving the emuthread

### DIFF
--- a/Core/EmuThread.cpp
+++ b/Core/EmuThread.cpp
@@ -118,7 +118,9 @@ bool RunMainLoop(GraphicsContext *graphicsContext, Application *application, std
 		application->Frame(graphicsContext);
 		postFrame();
 	}
-	Core_Stop();
+
+	// NOTE: Don't call stuff like Core_Stop here. On Android, we fully shut down graphics when you switch away from the app,
+	// then boot it up again when returning. That means stopping this thread and restarting it.
 
 	// Process the shutdown.  Without this, non-GL delays 800ms on shutdown.
 	Core_StateProcessed();
@@ -160,10 +162,9 @@ bool MainThreadFunc(GraphicsContext *graphicsContext, Application *application, 
 				break;
 			}
 		}
-		Core_Stop();
-		g_inLoop = false;
 
 		EmuThread_Join(graphicsContext, emuThread);
+		g_inLoop = false;
 
 		graphicsContext->ThreadEnd();
 


### PR DESCRIPTION
Discovered by @Domiiniik , the Windows mainloop which is now used across more platforms had an entirely unnecessary call to Core_Stop on exit.

Since we shut down graphics and this entire thread when taskswitching away on Android and restart it when returning, we acccidentally ended up exiting the game on taskswitch return.

This fixes that by simply removing the unnecessary calls to Core_Stop.