### PR TITLE
Graphics context shutdown refactor

### DIFF
--- a/Common/GPU/GraphicsContext.h
+++ b/Common/GPU/GraphicsContext.h
@@ -37,8 +37,12 @@ public:
 
 	// Called from the render thread from threaded backends.
 	virtual void ThreadStart() {}
-	virtual bool ThreadFrame(bool waitIfEmpty) { return true; }   // waitIfEmpty should normally be true, except in exit scenarios.
+	virtual bool ThreadFrame() { return true; }   // Returns false when it's time to exit the loop.
 	virtual void ThreadEnd() {}
+
+	// When this is called, the emulation thread has stopped producing frames completely.
+	// Called from the emu thread, so be ready for that.
+	virtual void NotifyEmuThreadExit() {}
 
 	// Useful for checks that need to be performed every frame.
 	// Should strive to get rid of these.
@@ -46,31 +50,4 @@ public:
 
 	// TODO: Store in a protected variable?
 	virtual Draw::DrawContext *GetDrawContext() = 0;
-
-	void ThreadFrameUntilCondition(std::function<bool()> conditionStopped) {
-		_dbg_assert_(NeedsSeparateEmuThread());
-		BeginShutdownSurface();
-		bool exitOnEmpty = false;
-
-		INFO_LOG(Log::System, "Executing graphicsContext->ThreadFrame to clear buffers");
-		while (true) {
-			// When EmuThread is done, we know there are no more frames coming. When that happens,
-			// we'll bail.
-			if (!exitOnEmpty && conditionStopped()) {
-				INFO_LOG(Log::System, "Found out that the thread is done.");
-				exitOnEmpty = true;
-			}
-
-			const bool retval = ThreadFrame(false);
-			if (!retval && exitOnEmpty) {
-				INFO_LOG(Log::System, "ThreadFrame returned false and emu thread is done, breaking.");
-				break;
-			} else {
-				sleep_ms(5, "exit poll");
-			}
-		}
-	}
-
-protected:
-	virtual void BeginShutdownSurface() {}  // This is currently only used on Android.
 };

--- a/Common/GPU/OpenGL/GLMemory.cpp
+++ b/Common/GPU/OpenGL/GLMemory.cpp
@@ -4,13 +4,6 @@
 #include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/Data/Text/Parsers.h"
 
-extern std::thread::id renderThreadId;
-#if MAX_LOGLEVEL >= DEBUG_LEVEL
-static bool OnRenderThread() {
-	return std::this_thread::get_id() == renderThreadId;
-}
-#endif
-
 void *GLRBuffer::Map(GLBufferStrategy strategy) {
 	_assert_(buffer_ != 0);
 
@@ -102,7 +95,6 @@ void GLPushBuffer::Unmap() {
 
 void GLPushBuffer::Flush() {
 	// Must be called from the render thread.
-	_dbg_assert_(OnRenderThread());
 	if (buf_ >= buffers_.size()) {
 		_dbg_assert_msg_(false, "buf_ somehow got out of sync: %d vs %d", (int)buf_, (int)buffers_.size());
 		return;
@@ -184,8 +176,6 @@ void GLPushBuffer::NextBuffer(size_t minSize) {
 }
 
 void GLPushBuffer::Defragment() {
-	_dbg_assert_msg_(!OnRenderThread(), "Defragment must not run on the render thread");
-
 	if (buffers_.size() <= 1) {
 		// Let's take this opportunity to jettison any localMemory we don't need.
 		for (auto &info : buffers_) {
@@ -227,8 +217,6 @@ size_t GLPushBuffer::GetTotalSize() const {
 }
 
 void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
-	_dbg_assert_msg_(OnRenderThread(), "MapDevice must run on render thread");
-
 	strategy_ = strategy;
 	if (strategy_ == GLBufferStrategy::SUBDATA) {
 		return;
@@ -261,8 +249,6 @@ void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
 }
 
 void GLPushBuffer::UnmapDevice() {
-	_dbg_assert_msg_(OnRenderThread(), "UnmapDevice must run on render thread");
-
 	for (auto &info : buffers_) {
 		if (info.deviceMemory) {
 			// TODO: Technically this can return false?

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -17,8 +17,6 @@
 #define VLOG(...)
 #endif
 
-std::thread::id renderThreadId;
-
 GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips) {
 	w = width;
 	h = height;
@@ -38,8 +36,6 @@ GLRenderManager::GLRenderManager(HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY
 }
 
 GLRenderManager::~GLRenderManager() {
-	_dbg_assert_(!runCompileThread_);
-
 	for (int i = 0; i < MAX_INFLIGHT_FRAMES; i++) {
 		_assert_(frameData_[i].deleter.IsEmpty());
 		_assert_(frameData_[i].deleter_prev.IsEmpty());
@@ -50,8 +46,13 @@ GLRenderManager::~GLRenderManager() {
 }
 
 void GLRenderManager::ThreadStart(Draw::DrawContext *draw) {
+	INFO_LOG(Log::G3D, "GLRenderManager::ThreadStart begin");
+
 	queueRunner_.CreateDeviceObjects();
-	renderThreadId = std::this_thread::get_id();
+
+	exitNotified_ = false;
+	hitExit_ = false;
+	skipGLCalls_ = false;
 
 	if (newInflightFrames_ != -1) {
 		INFO_LOG(Log::G3D, "OpenGL: Updating inflight frames to %d", newInflightFrames_);
@@ -91,12 +92,12 @@ void GLRenderManager::ThreadStart(Draw::DrawContext *draw) {
 	} else {
 		bufferStrategy_ = GLBufferStrategy::SUBDATA;
 	}
+
+	INFO_LOG(Log::G3D, "GLRenderManager::ThreadStart end");
 }
 
 void GLRenderManager::ThreadEnd() {
 	INFO_LOG(Log::G3D, "GLRenderManager::ThreadEnd begin");
-
-	runCompileThread_ = false;
 
 	queueRunner_.DestroyDeviceObjects();
 
@@ -117,14 +118,28 @@ void GLRenderManager::ThreadEnd() {
 	INFO_LOG(Log::G3D, "GLRenderManager::ThreadEnd end");
 }
 
+void GLRenderManager::NotifyEmuThreadExit() {
+	_dbg_assert_(!exitNotified_);
+	_dbg_assert_(!hitExit_);
+	exitNotified_ = true;
+	// We need to make sure that the render thread isn't waiting for more work, since the emu thread is gone.
+	// This is a bit of a hack, but it works.
+	GLRRenderThreadTask *task = new GLRRenderThreadTask(GLRRunType::EXIT);
+	{
+		std::unique_lock<std::mutex> lock(pushMutex_);
+		renderThreadQueue_.push(task);
+	}
+	pushCondVar_.notify_one();
+}
+
 // Unlike in Vulkan, this isn't a full independent function, instead it gets called every frame.
 //
 // This means that we have to block and run the render queue until we've presented one frame,
 // at which point we can leave.
-//
-// NOTE: If run_ is true, we WILL run a task!
-bool GLRenderManager::ThreadFrame(bool waitIfEmpty) {
-	_assert_(runCompileThread_);
+bool GLRenderManager::ThreadFrame() {
+	if (hitExit_) {
+		return false;
+	}
 
 	GLRRenderThreadTask *task = nullptr;
 
@@ -134,20 +149,16 @@ bool GLRenderManager::ThreadFrame(bool waitIfEmpty) {
 		// to keep things uniform.
 		{
 			std::unique_lock<std::mutex> lock(pushMutex_);
-
-			if (!waitIfEmpty && renderThreadQueue_.empty()) {
-				lock.unlock();
-				// Oh, host wanted out. Let's leave, and also let's notify the host.
-				// This is unlike Vulkan too which can just block on the thread existing.
-				std::unique_lock<std::mutex> lock(syncMutex_);
-				syncCondVar_.notify_one();
-				syncDone_ = true;
-				return false;
-			}
-
 			pushCondVar_.wait(lock, [this] { return !renderThreadQueue_.empty(); });
 			task = renderThreadQueue_.front();
 			renderThreadQueue_.pop();
+		}
+
+		if (task->runType == GLRRunType::EXIT) {
+			VLOG("  PULL: Frame %d EXIT (%0.3f)", task->frame, time_now_d());
+			delete task;
+			hitExit_ = true;
+			return false;
 		}
 
 		// Render the scene.
@@ -159,7 +170,6 @@ bool GLRenderManager::ThreadFrame(bool waitIfEmpty) {
 		}
 		delete task;
 	};
-
 	return true;
 }
 
@@ -325,12 +335,12 @@ void GLRenderManager::CopyImageToMemorySync(GLRTexture *texture, int mipLevel, i
 }
 
 void GLRenderManager::BeginFrame(bool enableProfiling) {
+	_dbg_assert_(!exitNotified_);
+	_dbg_assert_(!hitExit_);
+
 #ifdef _DEBUG
 	curProgram_ = nullptr;
 #endif
-
-	// Shouldn't call BeginFrame unless we're in a run state.
-	_dbg_assert_(runCompileThread_);
 
 	int curFrame = GetCurFrame();
 

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -200,6 +200,7 @@ enum class GLRRunType {
 	SUBMIT,
 	PRESENT,
 	SYNC,
+	EXIT,
 };
 
 class GLRenderManager;
@@ -237,7 +238,9 @@ public:
 
 	void ThreadStart(Draw::DrawContext *draw);
 	void ThreadEnd();
-	bool ThreadFrame(bool waitIfEmpty);  // Returns true if it did anything. False means the queue was empty.
+	bool ThreadFrame();  // False means it's time to exit.
+
+	void NotifyEmuThreadExit();
 
 	void SetErrorCallback(ErrorCallbackFn callback, void *userdata) {
 		queueRunner_.SetErrorCallback(callback, userdata);
@@ -860,8 +863,6 @@ private:
 	FastVec<GLRInitStep> initSteps_;
 
 	// Execution time state
-	// TODO: Rename this, as we don't actually use a compile thread on OpenGL.
-	bool runCompileThread_ = true;
 
 	// Thread is managed elsewhere, and should call ThreadFrame.
 	GLQueueRunner queueRunner_;
@@ -895,6 +896,9 @@ private:
 
 	int targetWidth_ = 0;
 	int targetHeight_ = 0;
+
+	bool exitNotified_ = false;
+	bool hitExit_ = false;
 
 #ifdef _DEBUG
 	GLRProgram *curProgram_ = nullptr;

--- a/Common/GPU/OpenGL/OpenGLGraphicsContext.h
+++ b/Common/GPU/OpenGL/OpenGLGraphicsContext.h
@@ -22,21 +22,23 @@ public:
 		return draw_;
 	}
 
+	// Called from render thread
 	void ThreadStart() override {
 		renderManager_->ThreadStart(draw_);
 	}
-
-	bool ThreadFrame(bool waitIfEmpty) override {
-		return renderManager_->ThreadFrame(waitIfEmpty);
+	bool ThreadFrame() override {
+		return renderManager_->ThreadFrame();
 	}
-
 	void ThreadEnd() override {
 		renderManager_->ThreadEnd();
 	}
-protected:
-	void BeginShutdownSurface() override {
+
+	// Call from emu thread
+	void NotifyEmuThreadExit() override {
 		renderManager_->SetSkipGLCalls();
+		renderManager_->NotifyEmuThreadExit();
 	}
+
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	GLRenderManager *renderManager_ = nullptr;

--- a/Core/EmuThread.cpp
+++ b/Core/EmuThread.cpp
@@ -40,6 +40,8 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext, Application *applica
 	INFO_LOG(Log::G3D, "Entering separate emu thread");
 	SetCurrentThreadName("EmuThread");
 
+	g_emuThreadState = EmuThreadState::RUNNING;
+
 	AndroidJNIThreadContext context;
 
 	// This normally calls NativeInitGraphics()
@@ -66,39 +68,34 @@ static void EmuThreadFunc(GraphicsContext *graphicsContext, Application *applica
 
 	INFO_LOG(Log::System, "emuThreadState was set to QUIT_REQUESTED, left EmuThreadFunc loop. Setting state to STOPPED.");
 
-	g_emuThreadState = EmuThreadState::STOPPED;
-
 	// This normally calls NativeShutdownGraphics()
 	application->ShutdownGraphics(graphicsContext);
 	delete application;
 
 	INFO_LOG(Log::System, "Leaving separate emu thread");
+
+	g_emuThreadState = EmuThreadState::STOPPED;
 }
 
 std::thread EmuThread_Start(GraphicsContext *graphicsContext, Application *application, std::function<void()> postFrame) {
+	INFO_LOG(Log::System, "EmuTread_Start");
 	_dbg_assert_(g_emuThreadState == EmuThreadState::STOPPED);
-	g_emuThreadState = EmuThreadState::RUNNING;
 	std::thread emuThread = std::thread(&EmuThreadFunc, graphicsContext, application, postFrame);
 	graphicsContext->ThreadStart();
 	return emuThread;
 }
 
+// This is useful when the render thread is in control.
+void EmuThread_RequestExit() {
+	INFO_LOG(Log::System, "EmuTread_RequestExit");
+	g_emuThreadState = EmuThreadState::QUIT_REQUESTED;
+}
+
 void EmuThread_Join(GraphicsContext *graphicsContext, std::thread &emuThread) {
-	const EmuThreadState state = g_emuThreadState;
-	if (state != EmuThreadState::QUIT_REQUESTED &&
-		state != EmuThreadState::STOPPED) {
-		g_emuThreadState = EmuThreadState::QUIT_REQUESTED;
-	}
-	_dbg_assert_(emuThread.joinable());
-	if (graphicsContext->NeedsSeparateEmuThread()) {
-		graphicsContext->ThreadFrameUntilCondition([] {
-			// Need to keep eating frames to allow the EmuThread to exit correctly.
-			return g_emuThreadState == EmuThreadState::STOPPED;
-		});
-	}
-	graphicsContext->ThreadEnd();
+	INFO_LOG(Log::System, "EmuTread_Join");
 	emuThread.join();
 	emuThread = std::thread();
+	graphicsContext->ThreadEnd();
 }
 
 bool RunMainLoop(GraphicsContext *graphicsContext, Application *application, std::function<bool()> runCondition, std::function<void()> postFrame) {
@@ -150,19 +147,9 @@ bool MainThreadFunc(GraphicsContext *graphicsContext, Application *application, 
 
 		g_inLoop = true;
 		std::thread emuThread = EmuThread_Start(graphicsContext, application, postFrame);
-
 		graphicsContext->ThreadStart();
-		// This thread becomes the render thread.
-		while (true) {
-			if (equals_any(g_emuThreadState, EmuThreadState::QUIT_REQUESTED, EmuThreadState::STOPPED)) {
-				break;
-			}
-			graphicsContext->ThreadFrame(true);
-			if (GetUIState() == UISTATE_EXIT) {
-				break;
-			}
-		}
-
+		// This thread becomes the render thread. EmuThread will tell it when to quit by sending a message.
+		while (graphicsContext->ThreadFrame()) {}
 		EmuThread_Join(graphicsContext, emuThread);
 		g_inLoop = false;
 

--- a/Core/EmuThread.h
+++ b/Core/EmuThread.h
@@ -38,6 +38,7 @@ bool MainThreadFunc(GraphicsContext * graphicsContext, Application *application,
 // the case where a separate EmuThread is not needed.
 // NOTE: Does take ownership over Application (which is just a wrapper for NativeInitGraphics/NativeShutdownGraphics/NativeFrame).
 std::thread EmuThread_Start(GraphicsContext *graphicsContext, Application *application, std::function<void()> postFrame);
+void EmuThread_RequestExit();  // Useful when the render thread is in control like on Android.
 void EmuThread_Join(GraphicsContext *graphicsContext, std::thread &emuThread);
 
 // Call from the main thread.

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -681,6 +681,10 @@ MainUI::MainUI(QWidget *parent)
 MainUI::~MainUI() {
 	INFO_LOG(Log::System, "MainUI::Destructor");
 	if (graphicsContext->NeedsSeparateEmuThread()) {
+		EmuThread_RequestExit();
+		while (graphicsContext->ThreadFrame()) {
+			// Wait for the emu thread to finish.
+		}
 		EmuThread_Join(graphicsContext, emuThread_);
 	}
 #if defined(MOBILE_DEVICE)
@@ -889,7 +893,7 @@ void MainUI::paintGL() {
 #endif
 	updateAccelerometer();
 	if (graphicsContext->NeedsSeparateEmuThread()) {
-		graphicsContext->ThreadFrame(true);
+		graphicsContext->ThreadFrame();
 		// Do the rest in EmuThreadFunc
 	} else {
 		NativeFrame(graphicsContext);

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -81,12 +81,16 @@ public:
 		renderManager_->ThreadStart(draw_);
 	}
 
-	bool ThreadFrame(bool waitIfEmpty) override {
-		return renderManager_->ThreadFrame(waitIfEmpty);
+	bool ThreadFrame() override {
+		return renderManager_->ThreadFrame();
 	}
 
 	void ThreadEnd() override {
 		renderManager_->ThreadEnd();
+	}
+
+	void NotifyEmuThreadExit() override {
+		renderManager_->NotifyEmuThreadExit();
 	}
 
 private:

--- a/SDL/SDLGLGraphicsContext.h
+++ b/SDL/SDLGLGraphicsContext.h
@@ -31,12 +31,16 @@ public:
 		renderManager_->ThreadStart(draw_);
 	}
 
-	bool ThreadFrame(bool waitIfEmpty) override {
-		return renderManager_->ThreadFrame(waitIfEmpty);
+	bool ThreadFrame() override {
+		return renderManager_->ThreadFrame();
 	}
 
 	void ThreadEnd() override {
 		renderManager_->ThreadEnd();
+	}
+
+	void NotifyEmuThreadExit() override {
+		renderManager_->NotifyEmuThreadExit();
 	}
 
 private:

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -2192,7 +2192,6 @@ int main(int argc, char *argv[]) {
 
 	// We use the emuthread both for OpenGL and Vulkan, but in OpenGL mode we also render from the main thread.
 	_dbg_assert_(graphicsContext);
-	std::thread emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), nullptr);
 
 	InputStateTracker inputTracker{};
 
@@ -2211,6 +2210,8 @@ int main(int argc, char *argv[]) {
 
 	const bool mainThreadIsRender = graphicsContext->NeedsSeparateEmuThread();
 	if (!mainThreadIsRender) {
+		// TODO: This shouldn't be the EmuThread, but rather RunMainLoop?
+		std::thread emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), nullptr);
 		// Vulkan mode uses this.
 		// We should only be a message pump. This allows for lower latency
 		// input events, and so on. The spawned EmuThread runs emulation and rendering.
@@ -2240,37 +2241,46 @@ int main(int argc, char *argv[]) {
 				}
 			}
 		}
-	} else while (true) {
-		// OpenGL mode uses this.
-		{
-			SDL_Event event;
-			while (SDL_PollEvent(&event)) {
-				ProcessSDLEvent(window, event, &inputTracker);
+		EmuThread_Join(graphicsContext, emuThread);
+	} else {
+		std::thread emuThread = EmuThread_Start(graphicsContext, new NativeApplication(), nullptr);
+		while (true) {
+			// OpenGL mode uses this.
+			{
+				SDL_Event event;
+				while (SDL_PollEvent(&event)) {
+					ProcessSDLEvent(window, event, &inputTracker);
+				}
 			}
-		}
-		if (g_QuitRequested || g_RestartRequested)
-			break;
-
-		UpdateTextFocus(window);
-		UpdateSDLCursor();
-
-		inputTracker.MouseCaptureControl(window);
-
-		bool renderThreadPaused = Native_IsWindowHidden() && g_Config.bPauseWhenMinimized;
-		if (graphicsContext->NeedsSeparateEmuThread() && !renderThreadPaused) {
-			if (!graphicsContext->ThreadFrame(true))
+			if (g_QuitRequested || g_RestartRequested)
 				break;
-		}
 
-		{
-			std::lock_guard<std::mutex> guard(g_mutexWindow);
-			if (g_windowState.update) {
-				UpdateWindowState(window);
+			UpdateTextFocus(window);
+			UpdateSDLCursor();
+
+			inputTracker.MouseCaptureControl(window);
+
+			bool renderThreadPaused = Native_IsWindowHidden() && g_Config.bPauseWhenMinimized;
+			if (graphicsContext->NeedsSeparateEmuThread() && !renderThreadPaused) {
+				if (!graphicsContext->ThreadFrame()) {
+					// The render thread was instructed to exit by the emu thread,
+					// and has now reached the end of the submitted frames.
+					// EmuThread will be in the process of exiting, so below
+					// we can just EmuThread_Join().
+					break;
+				}
+			}
+
+			{
+				std::lock_guard<std::mutex> guard(g_mutexWindow);
+				if (g_windowState.update) {
+					UpdateWindowState(window);
+				}
 			}
 		}
+		EmuThread_Join(graphicsContext, emuThread);
 	}
 
-	EmuThread_Join(graphicsContext, emuThread);
 
 	delete joystick;
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -944,17 +944,19 @@ bool CreateGlobalPipelines() {
 	return true;
 }
 
-void NativeShutdownGraphics(GraphicsContext *graphicContext) {
+void NativeShutdownGraphics(GraphicsContext *graphicsContext) {
 	INFO_LOG(Log::System, "NativeShutdownGraphics begin");
+
+	graphicsContext->NotifyEmuThreadExit();
 
 	if (g_screenManager) {
 		g_screenManager->deviceLost();
 	}
 	g_iconCache.ClearTextures();
 
-	// TODO: This is not really necessary with Vulkan on Android - could keep shaders etc in memory
-	if (gpu)
+	if (gpu) {
 		gpu->DeviceLost();
+	}
 
 #if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
 	if (winCamera) {

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -485,10 +485,15 @@ void WindowsGLContext::ThreadStart() {
 	renderManager_->ThreadStart(draw_);
 }
 
-bool WindowsGLContext::ThreadFrame(bool waitIfEmpty) {
-	return renderManager_->ThreadFrame(waitIfEmpty);
+bool WindowsGLContext::ThreadFrame() {
+	return renderManager_->ThreadFrame();
 }
 
 void WindowsGLContext::ThreadEnd() {
 	renderManager_->ThreadEnd();
+}
+
+void WindowsGLContext::NotifyEmuThreadExit() {
+	// renderManager_->SetSkipGLCalls();   // not necessary on desktop, maybe unadvisable?
+	renderManager_->NotifyEmuThreadExit();
 }

--- a/Windows/GPU/WindowsGLContext.h
+++ b/Windows/GPU/WindowsGLContext.h
@@ -33,7 +33,11 @@ public:
 	// If these are used, they are called from the render thread. If NeedsRenderThread is false, they are not called.
 	void ThreadStart() override;
 	void ThreadEnd() override;
-	bool ThreadFrame(bool waitIfEmpty) override;
+
+	// If this returns false, the render thread has been instructed to exit.
+	bool ThreadFrame() override;
+
+	void NotifyEmuThreadExit() override;
 
 	Draw::DrawContext *GetDrawContext() override { return draw_; }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -966,8 +966,10 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 		// Would be really nice if we could get something on the GL thread immediately when shutting down,
 		// but the only mechanism for handling lost devices seems to be that onSurfaceCreated is called again,
 		// which ends up calling displayInit.
-
-		INFO_LOG(Log::G3D, "NativeApp.displayInit() restoring");
+		INFO_LOG(Log::G3D, "NativeApp.displayInit(): Second time, joining the emuthread and starting it up again.");
+		EmuThread_RequestExit();
+		// Eat up any remaining frames.
+		while (graphicsContext->ThreadFrame()) {}
 		EmuThread_Join(graphicsContext, g_emuThread);
 
 		graphicsContext->ShutdownSurface();
@@ -1157,8 +1159,9 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env,
 	}
 	_assert_(graphicsContext->NeedsSeparateEmuThread());
 
-	if (!graphicsContext->ThreadFrame(true)) {
+	if (!graphicsContext->ThreadFrame()) {
 		INFO_LOG(Log::G3D, "ThreadFrame returned false");
+		// TODO: We should stop calling ThreadFrame here.
 		return;
 	}
 

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -996,6 +996,8 @@ public class PpssppActivity extends AppCompatActivity implements SensorEventList
 			}
 		} else if (mSurface != null) {
 			// JavaGL path.
+			// TODO: This might not be the best place to do this. Seems to cause a surface recreation
+			// unnecessarily.
 			Log.i(TAG, "notifySurface: Applying framerate.");
 			applyFrameRate(mSurface, 60.0f);
 		}

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -77,8 +77,8 @@ public:
 		renderManager_->ThreadStart(draw_);
 	}
 
-	bool ThreadFrame(bool waitIfEmpty) override {
-		return renderManager_->ThreadFrame(waitIfEmpty);
+	bool ThreadFrame() override {
+		return renderManager_->ThreadFrame();
 	}
 
 	void ThreadEnd() override {

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -185,7 +185,7 @@ bool SDLHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext *
 		gfx_->ThreadStart();
 		threadState_ = RenderThreadState::STARTED;
 
-		gfx_->ThreadFrameUntilCondition([this] { return threadState_ == RenderThreadState::STOP_REQUESTED; });
+		while (gfx_->ThreadFrame()) {}
 
 		threadState_ = RenderThreadState::STOPPING;
 		gfx_->ThreadEnd();
@@ -202,9 +202,7 @@ bool SDLHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext *
 }
 
 void SDLHeadlessHost::ShutdownGraphics() {
-	threadState_ = RenderThreadState::STOP_REQUESTED;
-	while (threadState_ != RenderThreadState::STOPPED && threadState_ != RenderThreadState::START_FAILED)
-		sleep_ms(1, "sdl-stop-poll");
+	gfx_->NotifyEmuThreadExit();
 
 	gfx_->ShutdownAPI();
 	delete gfx_;

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -121,7 +121,7 @@ bool WindowsHeadlessHost::InitGraphics(std::string *error_message, GraphicsConte
 			gfx_->ThreadStart();
 			threadState_ = RenderThreadState::STARTED;
 
-			gfx_->ThreadFrameUntilCondition([this] { return threadState_ == RenderThreadState::STOP_REQUESTED; });
+			while (gfx_->ThreadFrame()) {};
 
 			threadState_ = RenderThreadState::STOPPING;
 			gfx_->ThreadEnd();
@@ -153,9 +153,7 @@ bool WindowsHeadlessHost::InitGraphics(std::string *error_message, GraphicsConte
 
 void WindowsHeadlessHost::ShutdownGraphics() {
 	if (renderThread_.joinable()) {
-		threadState_ = RenderThreadState::STOP_REQUESTED;
-		while (threadState_ != RenderThreadState::STOPPED && threadState_ != RenderThreadState::IDLE)
-			sleep_ms(1, "render-thread-stop-poll");
+		gfx_->NotifyEmuThreadExit();
 		renderThread_.join();
 	} else {
 		gfx_->ShutdownSurface();

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -42,7 +42,6 @@
 #error Must be built with ARC, please revise the flags for ViewController.mm to include -fobjc-arc.
 #endif
 
-static std::atomic<bool> renderLoopRunning;
 static std::thread g_emuThread;
 
 PPSSPPBaseViewController *sharedViewController;
@@ -90,6 +89,9 @@ PPSSPPBaseViewController *sharedViewController;
 
 - (void)requestExitGLRenderLoop {
 	_assert_(g_emuThread.joinable());
+	EmuThread_RequestExit();
+	// Eat up any remaining frames.
+	while (graphicsContext->ThreadFrame()) {}
 	EmuThread_Join(graphicsContext, g_emuThread);
 	_assert_(!g_emuThread.joinable());
 }
@@ -226,7 +228,9 @@ PPSSPPBaseViewController *sharedViewController;
 		return;
 	}
 	if (sharedViewController) {
-		graphicsContext->ThreadFrame(true);
+		if (!graphicsContext->ThreadFrame()) {
+			INFO_LOG(Log::G3D, "ThreadFrame returned false");
+		}
 	}
 }
 

--- a/libretro/LibretroGLContext.cpp
+++ b/libretro/LibretroGLContext.cpp
@@ -42,3 +42,7 @@ void LibretroGLContext::DestroyDrawContext() {
 	LibretroHWRenderContext::DestroyDrawContext();
 	renderManager_ = nullptr;
 }
+
+void LibretroGLContext::NotifyEmuThreadExit() {
+   renderManager_->NotifyEmuThreadExit();
+}

--- a/libretro/LibretroGLContext.h
+++ b/libretro/LibretroGLContext.h
@@ -27,11 +27,14 @@ public:
 	}
 
 	void ThreadStart() override { renderManager_->ThreadStart(draw_); }
-	bool ThreadFrame(bool waitIfEmpty) override { return renderManager_->ThreadFrame(waitIfEmpty); }
+	bool ThreadFrame() override { return renderManager_->ThreadFrame(); }
 	void ThreadEnd() override { renderManager_->ThreadEnd(); }
 
 	GPUCore GetGPUCore() override { return GPUCORE_GLES; }
 	const char *Ident() override { return "OpenGL"; }
+
+   // Call from emu thread
+   void NotifyEmuThreadExit() override;
 
 private:
 	GLRenderManager *renderManager_ = nullptr;

--- a/libretro/LibretroGLCoreContext.cpp
+++ b/libretro/LibretroGLCoreContext.cpp
@@ -44,3 +44,7 @@ void LibretroGLCoreContext::DestroyDrawContext() {
 	LibretroHWRenderContext::DestroyDrawContext();
 	renderManager_ = nullptr;
 }
+
+void LibretroGLCoreContext::NotifyEmuThreadExit() {
+   renderManager_->NotifyEmuThreadExit();
+}

--- a/libretro/LibretroGLCoreContext.h
+++ b/libretro/LibretroGLCoreContext.h
@@ -21,8 +21,11 @@ public:
 	}
 
 	void ThreadStart() override { renderManager_->ThreadStart(draw_); }
-	bool ThreadFrame(bool waitIfEmpty) override { return renderManager_->ThreadFrame(waitIfEmpty); }
+	bool ThreadFrame() override { return renderManager_->ThreadFrame(); }
 	void ThreadEnd() override { renderManager_->ThreadEnd(); }
+
+   // Call from emu thread
+   void NotifyEmuThreadExit() override;
 
 	GPUCore GetGPUCore() override { return GPUCORE_GLES; }
 	const char *Ident() override { return "OpenGL Core"; }

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -96,9 +96,7 @@ extern retro_hw_context_type backend;
 
 enum class EmuThreadState {
 	DISABLED,
-	START_REQUESTED,
 	RUNNING,
-	PAUSE_REQUESTED,
 	PAUSED,
 	QUIT_REQUESTED,
 	STOPPED,

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1426,11 +1426,6 @@ namespace Libretro {
 
       emuThreadState = EmuThreadState::QUIT_REQUESTED;
 
-      // Need to keep eating frames to allow the EmuThread to exit correctly.
-      ctx->ThreadFrameUntilCondition([]() -> bool {
-         return emuThreadState == EmuThreadState::STOPPED;
-      });
-
       emuThread.join();
       emuThread = std::thread();
       ctx->ThreadEnd();
@@ -1443,7 +1438,7 @@ namespace Libretro {
       emuThreadState = EmuThreadState::PAUSE_REQUESTED;
 
       // Is this safe?
-      ctx->ThreadFrame(true); // Eat 1 frame
+      ctx->ThreadFrame(); // Eat 1 frame
 
       while (emuThreadState != EmuThreadState::PAUSED)
          sleep_ms(1, "libretro-pause-poll");
@@ -1656,6 +1651,7 @@ static void retro_input(void) {
    __CtrlSetAnalogXY(CTRL_STICK_RIGHT, x_right, y_right);
 }
 
+// Called every frame by retroarch.
 void retro_run(void) {
    if (g_pendingBoot) {
       BootState state = PSP_InitUpdate(&g_bootErrorString);
@@ -1701,30 +1697,31 @@ void retro_run(void) {
       retro_reset();
    }
 
+   // Update setting if any have changed.
    bool updated;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated)
-      && updated)
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
       check_variables(PSP_CoreParameter());
    else
       check_dynamic_variables(PSP_CoreParameter());
 
+   // Process input.
    retro_input();
 
-   if (useEmuThread)
-   {
-      if (  emuThreadState == EmuThreadState::PAUSED ||
-            emuThreadState == EmuThreadState::PAUSE_REQUESTED)
-      {
+   // Handle thread pumping.
+   if (useEmuThread) {
+      if (emuThreadState == EmuThreadState::PAUSED ||
+          emuThreadState == EmuThreadState::PAUSE_REQUESTED) {
          VsyncSwapIntervalDetect();
          ctx->SwapBuffers();
          return;
       }
 
-      if (emuThreadState != EmuThreadState::RUNNING)
+      if (emuThreadState != EmuThreadState::RUNNING) {
          EmuThreadStart();
+      }
 
-      if (!ctx->ThreadFrame(true))
-      {
+      if (!ctx->ThreadFrame()) {
+         // We're done processing the last frame from the emu thread.
          VsyncSwapIntervalDetect();
          return;
       }
@@ -1763,22 +1760,21 @@ size_t retro_serialize_size(void)
    // We don't unpause intentionally
 }
 
-bool retro_serialize(void *data, size_t size)
-{
+bool retro_serialize(void *data, size_t size) {
    if (!gpu) // The HW renderer isn't ready on first pass.
       return false;
 
    // TODO: Libretro API extension to use the savestate queue
-   if (useEmuThread)
+   if (useEmuThread) {
       EmuThreadPause(); // Does nothing if already paused
+   }
 
    size_t measuredSize;
    SaveState::SaveStart state;
    auto err = CChunkFileReader::MeasureAndSavePtr(state, (u8 **)&data, &measuredSize);
    bool retVal = err == CChunkFileReader::ERROR_NONE;
 
-   if (useEmuThread)
-   {
+   if (useEmuThread) {
       EmuThreadStart();
       sleep_ms(4, "libretro-serialize");
    }
@@ -1786,8 +1782,7 @@ bool retro_serialize(void *data, size_t size)
    return retVal;
 }
 
-bool retro_unserialize(const void *data, size_t size)
-{
+bool retro_unserialize(const void *data, size_t size) {
    // The HW renderer isn't ready on first pass.
    // So we save the data until we are ready to use it.
    if (!gpu) {
@@ -1805,8 +1800,7 @@ bool retro_unserialize(const void *data, size_t size)
    bool retVal = CChunkFileReader::LoadPtr((u8 *)data, size, state, &errorString)
       == CChunkFileReader::ERROR_NONE;
 
-   if (useEmuThread)
-   {
+   if (useEmuThread) {
       EmuThreadStart();
       sleep_ms(4, "libretro-unserialize");
    }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1384,34 +1384,32 @@ namespace Libretro {
       for (;;) {
          switch ((EmuThreadState)emuThreadState)
          {
-            case EmuThreadState::START_REQUESTED:
-               emuThreadState = EmuThreadState::RUNNING;
-               [[fallthrough]];
             case EmuThreadState::RUNNING:
                EmuFrame();
                break;
-            case EmuThreadState::PAUSE_REQUESTED:
-               emuThreadState = EmuThreadState::PAUSED;
-               [[fallthrough]];
             case EmuThreadState::PAUSED:
                sleep_ms(1, "libretro-paused");
                break;
-            default:
             case EmuThreadState::QUIT_REQUESTED:
+               ctx->NotifyEmuThreadExit();
                emuThreadState = EmuThreadState::STOPPED;
+               return;
+            default:
+               _dbg_assert_(false);
                return;
          }
       }
+      // Unreachable
    }
 
    void EmuThreadStart() {
       EmuThreadState state = emuThreadState;
       bool wasPaused = state == EmuThreadState::PAUSED;
 
-      if (state == EmuThreadState::RUNNING || state == EmuThreadState::START_REQUESTED || (emuThread.joinable() && !wasPaused))
+      if (state == EmuThreadState::RUNNING || (emuThread.joinable() && !wasPaused))
          return;
 
-      emuThreadState = EmuThreadState::START_REQUESTED;
+      emuThreadState = EmuThreadState::RUNNING;
 
       if (!wasPaused)
       {
@@ -1426,6 +1424,9 @@ namespace Libretro {
 
       emuThreadState = EmuThreadState::QUIT_REQUESTED;
 
+      // Eat remaining frames.
+      while (ctx->ThreadFrame()) {}
+
       emuThread.join();
       emuThread = std::thread();
       ctx->ThreadEnd();
@@ -1435,7 +1436,7 @@ namespace Libretro {
       if (emuThreadState != EmuThreadState::RUNNING)
          return;
 
-      emuThreadState = EmuThreadState::PAUSE_REQUESTED;
+      emuThreadState = EmuThreadState::PAUSED;
 
       // Is this safe?
       ctx->ThreadFrame(); // Eat 1 frame
@@ -1709,8 +1710,7 @@ void retro_run(void) {
 
    // Handle thread pumping.
    if (useEmuThread) {
-      if (emuThreadState == EmuThreadState::PAUSED ||
-          emuThreadState == EmuThreadState::PAUSE_REQUESTED) {
+      if (emuThreadState == EmuThreadState::PAUSED) {
          VsyncSwapIntervalDetect();
          ctx->SwapBuffers();
          return;


### PR DESCRIPTION
Eliminates an old race condition in the GL backend where there was a small chance that we could hang on exit.

Prerequisite for the upcoming rework of "headless", which will be used for a new suite of rendering regressions tests.