### PR TITLE
bring back VulkanContext::SetCbGetDrawSize for linux wayland

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1400,6 +1400,20 @@ bool VulkanContext::InitSwapchain(VkPresentModeKHR desiredPresentMode) {
 
 	INFO_LOG(Log::G3D, "surfCapabilities_.current: %dx%d", currentExtent.width, currentExtent.height);
 
+	// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSurfaceCapabilitiesKHR.html
+	// currentExtent is the current width and height of the surface, or the special value (0xFFFFFFFF, 0xFFFFFFFF) indicating that the surface size will be determined by the extent of a swapchain targeting the surface.
+	if (currentExtent.width == 0xFFFFFFFFu || currentExtent.height == 0xFFFFFFFFu
+		#if PPSSPP_PLATFORM(IOS)
+		|| currentExtent.width == 0 || currentExtent.height == 0
+		#endif
+	) {
+		ERROR_LOG(Log::G3D, "using cbGetDrawSize_ to resolve surface size");
+		_dbg_assert_((bool)cbGetDrawSize_);
+		if (cbGetDrawSize_) {
+			currentExtent = cbGetDrawSize_();
+		}
+	}
+
 	swapChainExtent_.width = clamp(currentExtent.width, surfCapabilities_.minImageExtent.width, surfCapabilities_.maxImageExtent.width);
 	swapChainExtent_.height = clamp(currentExtent.height, surfCapabilities_.minImageExtent.height, surfCapabilities_.maxImageExtent.height);
 
@@ -1571,6 +1585,10 @@ bool VulkanContext::InitSwapchain(VkPresentModeKHR desiredPresentMode) {
 		INFO_LOG(Log::G3D, "Destroyed old swapchain.");
 	}
 	return true;
+}
+
+void VulkanContext::SetCbGetDrawSize(std::function<VkExtent2D()> cb) {
+	cbGetDrawSize_ = cb;
 }
 
 VkFence VulkanContext::CreateFence(bool presignalled) {

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -196,6 +196,7 @@ public:
 
 	// If the present mode is not available, will fall back to the first available (which is almost always FIFO).
 	bool InitSwapchain(VkPresentModeKHR desiredPresentMode);
+	void SetCbGetDrawSize(std::function<VkExtent2D()>);
 
 	void DestroySwapchain();
 	void DestroySurface();

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -52,6 +52,7 @@ SDLJoystick *joystick = NULL;
 
 #include "Common/GPU/GraphicsContext.h"
 #include "Common/GPU/Vulkan/VulkanLoader.h"
+#include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/GPU/Vulkan/VulkanGraphicsContext.h"
 #include "Common/TimeUtil.h"
 #include "Common/Input/InputState.h"
@@ -2047,6 +2048,17 @@ int main(int argc, char *argv[]) {
 		if (!ctx->InitAPI(nullptr, &g_Config.sVulkanDevice, errorMessage)) {
 			fprintf(stderr, "Graphics initialization failed: %s\n", errorMessage->c_str());
 			return false;
+		}
+
+		if (backend == GPUBackend::VULKAN) {
+			// linux wayland can give -1x-1 during vkGetPhysicalDeviceSurfaceCapabilitiesKHR
+			VulkanGraphicsContext *vkgfxctx = (VulkanGraphicsContext *)ctx;
+			VulkanContext *vkctx = (VulkanContext *)vkgfxctx->GetAPIContext();
+			vkctx->SetCbGetDrawSize([window]() {
+				int w=1,h=1;
+				SDL_GetWindowSizeInPixels(window, &w, &h);
+				return VkExtent2D {(uint32_t)w, (uint32_t)h};
+			});
 		}
 
 		if (!ctx->InitSurface(windowSystem, data1, data2, errorMessage)) {


### PR DESCRIPTION
It was removed during https://github.com/hrydgard/ppsspp/pull/21982

On Linux Wayland however this can be observed without: 

```
34:25:550 Vulkan/VulkanContext.cpp:1401 I[G3D]: surfCapabilities_.current: -1x-1
34:25:550 Vulkan/VulkanContext.cpp:1406 I[G3D]: surfCapabilities_.current after clamp: -1x-1 min: 1x1 max: 32768x32768 computed: 1x1 cbdraw
```