### PR TITLE
Remove OpenGL support on iOS

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -368,6 +368,5 @@ const char *Android_ErrorToString(StorageError error) {
 // Very hacky.
 std::string g_extFilesDir = "(IF YOU SEE THIS THERE'S A BUG)";
 std::string g_externalDir = "(IF YOU SEE THIS THERE'S A BUG (2))";
-std::string g_nativeLibDir = "(IF YOU SEE THIS THERE'S A BUG (3))";
 
 #endif

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -33,7 +33,6 @@ inline StorageError StorageErrorFromInt(int ival) {
 
 extern std::string g_extFilesDir;
 extern std::string g_externalDir;
-extern std::string g_nativeLibDir;
 
 // Note that we don't use string_view much here because NewStringUTF doesn't have a size parameter.
 

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -265,6 +265,7 @@ static VulkanLibraryHandle vulkanLibrary;
 
 bool g_vulkanAvailabilityChecked = false;
 bool g_vulkanMayBeAvailable = false;
+static std::string g_nativeLibDir;
 
 static PFN_vkVoidFunction LoadInstanceFunc(VkInstance instance, const char *name) {
 	PFN_vkVoidFunction funcPtr = vkGetInstanceProcAddr(instance, name);
@@ -430,6 +431,10 @@ void VulkanSetAvailable(bool available) {
 	INFO_LOG(Log::G3D, "Setting Vulkan availability to true");
 	g_vulkanAvailabilityChecked = true;
 	g_vulkanMayBeAvailable = available;
+}
+
+void VulkanSetNativeLibDir(std::string_view nativeLibDir) {
+	g_nativeLibDir = nativeLibDir;
 }
 
 bool VulkanMayBeAvailable() {

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -281,6 +281,7 @@ struct VulkanExtensions {
 };
 
 // Way to do a quick check before even attempting to load.
+void VulkanSetNativeLibDir(std::string_view nativeLibDir);
 bool VulkanMayBeAvailable();
 void VulkanSetAvailable(bool available);
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -563,7 +563,6 @@ int Config::NextValidBackend() {
 			return (int)GPUBackend::OPENGL;
 		}
 #endif
-
 		// They've all failed.  Let them try the default - or on Android, OpenGL.
 		if (sFailedGPUBackends.find(",ALL") == std::string::npos) {
 			sFailedGPUBackends += ",ALL";

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1579,7 +1579,7 @@ void Config::PostLoadCleanup() {
 	// Override ppsspp.ini JIT value to prevent crashing
 	jitForcedOff = DefaultCpuCore() != (int)CPUCore::JIT && (g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR);
 	if (jitForcedOff) {
-		g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
+		iCpuCore = (int)CPUCore::IR_INTERPRETER;
 	}
 
 	// This caps the aniso level exponent to 4 (so 16x.). No hardware supports more anyway.
@@ -1596,18 +1596,23 @@ void Config::PostLoadCleanup() {
 	iGPUBackend = (int)GPUBackend::DIRECT3D11;
 #endif
 
+	if (!IsBackendEnabled((GPUBackend)iGPUBackend)) {
+		ERROR_LOG(Log::G3D, "Backend %d not enabled - switching to platform default");
+		iGPUBackend = (int)DefaultGPUBackend();
+	}
+
 	// Set a default MAC, and correct if it's an old format.
 	if (sMACAddress.length() != 17)
 		sMACAddress = CreateRandMAC();
 
-	if (g_Config.bAutoFrameSkip && g_Config.bSkipBufferEffects) {
-		g_Config.bSkipBufferEffects = false;
+	if (bAutoFrameSkip && bSkipBufferEffects) {
+		bSkipBufferEffects = false;
 	}
 
 	// Automatically silence secondary instances. Could be an option I guess, but meh.
 	if (PPSSPP_ID > 1) {
 		NOTICE_LOG(Log::Audio, "Secondary instance %d - silencing audio", (int)PPSSPP_ID);
-		g_Config.iGameVolume = 0;
+		iGameVolume = 0;
 	}
 
 	// Automatically switch away from deprecated setting value.
@@ -1616,17 +1621,17 @@ void Config::PostLoadCleanup() {
 	}
 
 	// Remove a legacy value.
-	if (g_Config.sCustomDriver == "Default") {
-		g_Config.sCustomDriver.clear();
+	if (sCustomDriver == "Default") {
+		sCustomDriver.clear();
 	}
 
 	// Squash unsupported screen rotations.
-	if (g_Config.iScreenRotation == ROTATION_LOCKED_VERTICAL180) {
-		g_Config.iScreenRotation = ROTATION_LOCKED_VERTICAL;
+	if (iScreenRotation == ROTATION_LOCKED_VERTICAL180) {
+		iScreenRotation = ROTATION_LOCKED_VERTICAL;
 	}
 
 	// Clamp save state slot count to somewhat sane limits.
-	g_Config.iSaveStateSlotCount = std::clamp(g_Config.iSaveStateSlotCount, 1, 100);
+	iSaveStateSlotCount = std::clamp(iSaveStateSlotCount, 1, 100);
 }
 
 void Config::PreSaveCleanup() {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -136,7 +136,6 @@ static std::string boardName;
 
 std::string g_externalDir;  // Original external dir (root of Android storage).
 std::string g_extFilesDir;  // App private external dir.
-std::string g_nativeLibDir;  // App native library dir
 
 static std::vector<std::string> g_additionalStorageDirs;
 
@@ -695,7 +694,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 
 	g_externalDir = externalStorageDir;
 	g_extFilesDir = externalFilesDir;
-	g_nativeLibDir = nativeLibDir;
+	VulkanSetNativeLibDir(nativeLibDir);
 
 	if (!additionalStorageDirsString.empty()) {
 		SplitString(additionalStorageDirsString, ':', g_additionalStorageDirs);

--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -127,7 +127,16 @@
 #endif
 
 // Windows ARM/ARM64, and Windows UWP (all), are the only platform that don't do GL at all (until Apple finally removes it)
-#if !PPSSPP_PLATFORM(WINDOWS) || ((!PPSSPP_ARCH(ARM) && !PPSSPP_ARCH(ARM64)) && !PPSSPP_PLATFORM(UWP))
+#if PPSSPP_PLATFORM(WINDOWS)
+#if PPSSPP_ARCH(ARM64) || PPSSPP_ARCH(ARM) || PPSSPP_PLATFORM(UWP)
+// No GL
+#else
+#define PPSSPP_API_ANY_GL 1
+#endif
+#elif PPSSPP_PLATFORM(IOS_APP_STORE)
+// No GL
+#else
+// All other platforms support GL.
 #define PPSSPP_API_ANY_GL 1
 #endif
 


### PR DESCRIPTION
OpenGL has long been deprecated on iOS, and the driver is not of great quality.

Supporting it is extra work, and the Vulkan backend works fine through MoltenVK and now doesn't really have any known deficiencies on iOS vs the OpenGL backend.

So let's just move on from it. The code will remain for now (it's not a lot), so non-app-store builds for legacy iOS, if people are still messing with that, will still be able to use it.