### PR TITLE
libretro: add GLEW_EGL=1 to build GLEW's EGL backend

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -71,6 +71,9 @@ ifneq (,$(findstring unix,$(platform)))
 		GL_LIB := -lGLESv2
 	else
 		GL_LIB := -lGL
+		ifeq ($(GLEW_EGL),1)
+			GL_LIB += -lEGL
+		endif
 	endif
 	PLATFORM_EXT = unix
 	LDFLAGS += -lrt -ldl
@@ -451,6 +454,15 @@ else
 endif
 
 ### Finalize ###
+# GLEW resolves its entry points through GLX by default, and glxewInit() returns
+# GLEW_ERROR_NO_GLX_DISPLAY on a display stack that provides no GLX, so
+# glewInit() fails and the GL backend never comes up. Wayland and GBM are both
+# affected. Building GLEW's EGL backend instead resolves them through
+# eglGetProcAddress. Opt-in, so GLX builds keep the behaviour they have today.
+ifeq ($(GLEW_EGL),1)
+	COREFLAGS += -DGLEW_EGL
+endif
+
 OBJECTS		+= $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o) $(ASMFILES:.S=.o)
 CXXFLAGS    += $(CPUOPTS) $(COREFLAGS) $(FFMPEGINCFLAGS) $(INCFLAGS) $(INCFLAGS_PLATFORM) $(PLATCFLAGS) $(fpic) $(PLATCFLAGS) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)
 CFLAGS		+= $(CPUOPTS) $(COREFLAGS) $(FFMPEGINCFLAGS) $(INCFLAGS) $(INCFLAGS_PLATFORM) $(PLATCFLAGS) $(fpic) $(PLATCFLAGS) $(CPUFLAGS) $(GLFLAGS) $(DYNAFLAGS)


### PR DESCRIPTION
### Problem

`glewInit()` fails and the GL backend never comes up on any display stack that
does not provide GLX. On Wayland the log shows:

```
glewInit() failed
```

GLEW resolves its entry points through GLX unless it is built with `GLEW_EGL`.
Its `glxewInit()` returns `GLEW_ERROR_NO_GLX_DISPLAY` when there is no GLX
display to query, `glewInit()` propagates that as a failure, and the core exits
before rendering anything. GBM is affected for the same reason.

### Change

Adds an opt-in `GLEW_EGL=1` make variable that builds GLEW's EGL backend, which
resolves entry points through `eglGetProcAddress` instead, and links `-lEGL`.

```
make -f Makefile platform=unix GLEW_EGL=1
```

It is opt-in rather than the default so existing GLX builds keep exactly the
behaviour they have today. Making it the default for `platform=unix` would also
be reasonable — happy to change it if that is preferred.

### Note for anyone testing this

Changing the flag needs `ext/glew/glew.o` deleted to take effect. The Makefile
is not a prerequisite of the object, so an incremental build silently keeps the
old GLX-resolved GLEW and the failure looks unchanged.

Verified on Mesa 26.0.3 / Intel Arc under Wayland, running PSP titles through
the libretro core.
