### PR TITLE
Refactor the old Win32 debugger to be thread safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,73 @@ first - send `cpu.stepping` and `cpu.resume` to pause/unpause.
 Alternatively use the headless build, Windows/{arch}/Debug/PPSSPPHeadless.exe or build/PPSSPPHeadless on CMake-based
 platforms. Where arch is x64 or ARM64.
 
+## Debugger threading model (Core_RunOnCPUThread / g_frameMutex)
+
+CPU-thread-owned debugger state (`g_breakpoints`, `g_symbolMap`, `g_disassemblyManager`, registers,
+memory, kernel threads) used to be touched directly from other threads (the WebSocket handler
+thread, and the legacy Win32 debugger's message-pump thread) with no synchronization. Two
+mechanisms now exist for doing this safely - pick based on whether you're mutating or just reading:
+
+- **`Core_RunOnCPUThread(func)`** (`Core.h`/`Core.cpp`) - queues `func` to run on the CPU thread,
+  blocking the caller until it's done. Use for *mutations* (breakpoint add/remove, register/memory
+  writes, symbol map edits, stepping requests, thread wake/kill). Drained at the top of every
+  `Core_RunLoopUntil()` iteration, so it's reached whether the CPU is running or stepping/paused;
+  runs immediately if already called from the CPU thread. Two hard rules learned the hard way:
+  never put a modal Win32 dialog call (`MessageBox`, `DialogBoxParam`, `InputBox_GetString`,
+  `SomeDialog::exec()`) inside the queued lambda - it would block the CPU thread on user input, so
+  split the function into "read/decide", "show modal", "mutate" pieces instead. And never call
+  `SendMessage()` targeting one of your own GUI-thread windows from inside the lambda - the calling
+  GUI thread is blocked waiting on the CPU thread rather than pumping messages, so a cross-thread
+  `SendMessage()` back to it deadlocks; keep such calls outside the lambda instead.
+- **`g_frameMutex`** (`Core.h`/`Core.cpp`) - a plain `std::mutex`, held by `NativeFrame()`
+  (`UI/NativeApp.cpp`) only across the span where it actually touches that state
+  (`g_breakpoints.Frame()` through `g_screenManager->render()` - where `Core_RunLoopUntil()`/actual
+  CPU stepping happens - through `runImDebugger`/`renderImDebugger`), not across input handling or
+  the present/frame-pacing waits. Use for *reads* invoked very frequently (`WM_PAINT`, a list
+  reload triggered on every debugger-state-changed notification) where routing through
+  `Core_RunOnCPUThread` would be too slow/heavy. The legacy Win32 debugger windows do this now -
+  see `CtrlRegisterList::onPaint`, `CtrlDisAsmView::onPaint`, `CtrlMemView::onPaint`,
+  `CtrlBreakpointList::reloadBreakpoints`, `CtrlThreadList::reloadThreads`, etc. in
+  `Windows/Debugger/*.cpp`.
+
+Architecture fact that makes `g_frameMutex` correct: regardless of graphics backend, `NativeFrame()`
+(and thus CPU emulation via `Core_RunLoopUntil()`, and the Dear ImGui debugger) always runs on the
+*same* thread - see `Core/EmuThread.cpp`. When a backend needs its own thread for actual graphics
+API calls (`GraphicsContext::NeedsSeparateEmuThread()` - true for OpenGL, SDL, headless, libretro,
+Qt; false for D3D11/Vulkan on Windows), the *original* thread stays behind purely to pump
+`graphicsContext->ThreadFrame()` (i.e. just executes queued graphics API calls), and a *newly
+spawned* thread takes over `NativeFrame()`/game logic/CPU duty. So `UI/ImDebugger/*.cpp` is always
+safe to read/write this state directly, without either mechanism - it's always on the same thread
+as `Core_RunLoopUntil()`. The legacy Win32 debugger is different: its dialogs are pumped by the
+*original* `WinMain` message-loop thread, which is a genuinely separate OS thread from whichever
+thread ends up running `NativeFrame()`/CPU, regardless of backend (this split happens one level
+above the `NeedsSeparateEmuThread()` branch) - that's the whole reason it needed this mechanism.
+
+**Known gaps, found while auditing whether `BreakpointManager`'s/`SymbolMap`'s own internal mutexes
+could finally be removed** (as of 2026-08-08, not yet addressed): `Windows/MainWindowMenu.cpp` and
+`Windows/MainWindow.cpp` (outside `Windows/Debugger/`) have their own direct, unguarded
+`g_symbolMap` mutations/reads (Load/Save/Clear Symbol Map menu actions, `getAllModules()` for a
+module list) on the `WinMain` thread. `Qt/mainwindow.cpp` has the same pattern on the Qt UI thread
+(Qt always sets `NeedsSeparateEmuThread() = true`, so it's a separate thread from the CPU there
+too). `Windows/main.cpp` has an existing comment ("internal locking is performed here") explicitly
+documenting current reliance on `SymbolMap`'s own mutex at its `SortSymbols()` call sites. Until
+these are covered the same way, **`SymbolMap`'s internal locking can't be removed**.
+**`BreakpointManager`'s internal locking looks fully redundant** after this session's work (every
+touchpoint across the whole codebase was audited - WebSocket subscribers, `Windows/Debugger/*.cpp`,
+`Core/Core.cpp`'s free-threaded `Core_Break`/`Core_Resume`, `UI/ImDebugger/*.cpp`, JIT/interpreter
+backends, `Core/Debugger/MemBlockInfo.cpp` - and each is covered by one of the two mechanisms above
+or is already on the CPU/NativeFrame thread) - but removal hasn't actually been attempted yet; do
+it as its own careful, separately-tested step, not bundled with unrelated changes.
+
+Painting-problem design history, in case a similar tradeoff comes up elsewhere: routing every paint
+through `Core_RunOnCPUThread` was rejected as too slow for something invoked continuously. A
+per-window snapshot/cache with a per-row-rechecked `Core_IsStepping()` guard was tried first and
+worked, but still had a narrow TOCTOU race (the CPU could resume between the check and that row's
+reads) and the per-row-recheck pattern itself wasn't liked. Settled on `g_frameMutex` instead -
+simpler, and actually race-free rather than just lower-risk. `CtrlRegisterList` shows live values
+always now, grayed out by color alone (not cached) while the core is running, since a
+constantly-moving value isn't meaningful to read closely anyway.
+
 ## Debugging and breakpoint considerations
 
 It might be worth trying the interpreter - all types of breakpoints are the most reliable with this CPU backend.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,21 +251,35 @@ as `Core_RunLoopUntil()`. The legacy Win32 debugger is different: its dialogs ar
 thread ends up running `NativeFrame()`/CPU, regardless of backend (this split happens one level
 above the `NeedsSeparateEmuThread()` branch) - that's the whole reason it needed this mechanism.
 
-**Known gaps, found while auditing whether `BreakpointManager`'s/`SymbolMap`'s own internal mutexes
-could finally be removed** (as of 2026-08-08, not yet addressed): `Windows/MainWindowMenu.cpp` and
-`Windows/MainWindow.cpp` (outside `Windows/Debugger/`) have their own direct, unguarded
-`g_symbolMap` mutations/reads (Load/Save/Clear Symbol Map menu actions, `getAllModules()` for a
-module list) on the `WinMain` thread. `Qt/mainwindow.cpp` has the same pattern on the Qt UI thread
-(Qt always sets `NeedsSeparateEmuThread() = true`, so it's a separate thread from the CPU there
-too). `Windows/main.cpp` has an existing comment ("internal locking is performed here") explicitly
-documenting current reliance on `SymbolMap`'s own mutex at its `SortSymbols()` call sites. Until
-these are covered the same way, **`SymbolMap`'s internal locking can't be removed**.
-**`BreakpointManager`'s internal locking looks fully redundant** after this session's work (every
-touchpoint across the whole codebase was audited - WebSocket subscribers, `Windows/Debugger/*.cpp`,
-`Core/Core.cpp`'s free-threaded `Core_Break`/`Core_Resume`, `UI/ImDebugger/*.cpp`, JIT/interpreter
-backends, `Core/Debugger/MemBlockInfo.cpp` - and each is covered by one of the two mechanisms above
-or is already on the CPU/NativeFrame thread) - but removal hasn't actually been attempted yet; do
-it as its own careful, separately-tested step, not bundled with unrelated changes.
+**Update (2026-08-08): both `BreakpointManager`'s and `SymbolMap`'s internal mutexes have been
+removed** after auditing every touchpoint across the codebase (WebSocket subscribers,
+`Windows/Debugger/*.cpp`, `Windows/MainWindowMenu.cpp`/`Windows/MainWindow.cpp` main-window menu
+items, `Core/Core.cpp`'s free-threaded `Core_Break`/`Core_Resume`, `UI/ImDebugger/*.cpp`,
+JIT/interpreter backends, `Core/Debugger/MemBlockInfo.cpp`) and confirming each is covered by one of
+the two mechanisms above or is already on the CPU/NativeFrame thread. Notably, `Windows/main.cpp`'s
+`SortSymbols()` calls (fired from `System_Notify(BOOT_DONE)`/`System_Notify(SYMBOL_MAP_UPDATED)`)
+turned out to already be safe without any change - both notifications are only ever fired from the
+CPU/NativeFrame thread (`UI/EmuScreen.cpp`, `Core/HLE/sceKernelModule.cpp`), despite an old comment
+there claiming reliance on the (now-removed) internal lock. `Qt/mainwindow.cpp`/`Qt/QtMain.cpp`
+still poke at `g_symbolMap` directly and unguarded on the Qt UI thread - a pre-existing issue,
+deliberately left alone since Qt isn't a maintained backend and is slated for removal; removing the
+lock doesn't change `SymbolMap`'s public API, so Qt still builds, just without that safety net.
+`GPU/Common/GPUDebugInterface.cpp` (GE debugger expression evaluation) and `Core/MemFault.cpp`
+(crash-time diagnostics) also touch `g_symbolMap` and were deliberately not audited this round -
+different subsystem / best-effort-by-nature respectively, follow up if they ever come up.
+
+Two more things found while doing this:
+- **`Core_RunOnCPUThread()`'s queue is only drained where `Core_RunLoopUntil()` runs, which requires
+  a game to be loaded** (it's called from `EmuScreen::render()`). Calling `Core_RunOnCPUThread()`
+  while at the main menu with nothing loaded used to hang forever. Fixed by also calling the
+  (now public) `Core_ProcessCPUQueue()` directly from `NativeFrame()`, right before
+  `g_screenManager->render()`, inside the same `g_frameMutex`-locked span - so it always runs, not
+  just while a game is active.
+- **Lock-ordering rule**: because `Core_ProcessCPUQueue()` is called from inside `NativeFrame()`'s
+  `g_frameMutex`-locked span, any `Core_RunOnCPUThread()` lambda that itself tries to lock
+  `g_frameMutex` (directly, or indirectly - e.g. by calling something like
+  `CDisasm::NotifyMapLoaded()`, which locks it internally) will deadlock. Keep such calls outside
+  the queued lambda, same as the modal-dialog and `SendMessage()` rules above.
 
 Painting-problem design history, in case a similar tradeoff comes up elsewhere: routing every paint
 through `Core_RunOnCPUThread` was rejected as too slow for something invoked continuously. A

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -103,7 +103,7 @@ void Core_RunOnCPUThread(std::function<void()> func) {
 }
 
 // Called from the CPU thread only.
-static void Core_ProcessCPUQueue() {
+void Core_ProcessCPUQueue() {
 	std::call_once(g_cpuThreadIdOnce, [] {
 		g_cpuThreadId = std::this_thread::get_id();
 		g_cpuThreadIdValid.store(true, std::memory_order_release);

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -129,6 +129,10 @@ static void Core_ProcessCPUQueue() {
 	g_cpuQueueCond.notify_all();
 }
 
+// See Core.h for the rationale. Held by NativeFrame() (in NativeApp.cpp) around the span where it
+// actually touches CPU-thread-owned debugger state.
+std::mutex g_frameMutex;
+
 // This is so that external threads can wait for the CPU to become inactive.
 static std::condition_variable m_InactiveCond;
 static std::mutex m_hInactiveMutex;

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -165,6 +165,14 @@ void Core_RunLoopUntil(u64 globalticks);
 // even while it's fully running.
 void Core_RunOnCPUThread(std::function<void()> func);
 
+// Drains the queue Core_RunOnCPUThread() feeds. Normally called from the top of every
+// Core_RunLoopUntil() iteration, but that function is only reached while a game is actually
+// loaded/running (via EmuScreen) - so NativeFrame() (UI/NativeApp.cpp) also calls this directly,
+// just before it calls into the screen manager's render(), so queued work doesn't hang forever
+// waiting for a CPU loop that isn't running (e.g. from the main menu with no game loaded).
+// Called from the CPU thread only - which is whatever thread NativeFrame() itself runs on.
+void Core_ProcessCPUQueue();
+
 // Guards CPU-thread-owned debugger state (breakpoints, symbol map, registers, memory, etc.)
 // against concurrent unsynchronized reads from other threads' paint handlers.
 //

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -163,6 +164,22 @@ void Core_RunLoopUntil(u64 globalticks);
 // spin) while the CPU is stepping/paused, and at least once per call (i.e. about once per host frame)
 // even while it's fully running.
 void Core_RunOnCPUThread(std::function<void()> func);
+
+// Guards CPU-thread-owned debugger state (breakpoints, symbol map, registers, memory, etc.)
+// against concurrent unsynchronized reads from other threads' paint handlers.
+//
+// Held by NativeFrame() for the span where it actually touches that state: running the CPU
+// (Core_RunLoopUntil(), including draining Core_RunOnCPUThread()'s queue), processing breakpoints,
+// and running the ImGui debugger. Not held for the rest of NativeFrame (input handling, present/
+// vsync waits, frame pacing, etc).
+//
+// A paint handler on another thread (e.g. a legacy Win32 debugger window) that wants to read that
+// state directly - without the overhead/latency of routing through Core_RunOnCPUThread(), which
+// would be too heavy for something called on every WM_PAINT - should hold this lock for the
+// duration of the read instead. Since WM_PAINT only fires reactively rather than every frame, and
+// NativeFrame's locked span is normally just a couple of milliseconds, this should rarely block
+// for long.
+extern std::mutex g_frameMutex;
 
 extern volatile CoreState coreState;
 extern volatile bool coreStatePending;

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -16,7 +16,6 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <atomic>
-#include <mutex>
 
 #include "Common/System/System.h"
 #include "Common/Log.h"
@@ -69,7 +68,6 @@ BreakAction MemCheck::Action(u32 addr, bool write, int size, u32 pc, const char 
 	return result;
 }
 
-// Note: must lock while calling this.
 size_t BreakpointManager::FindBreakpoint(u32 addr, bool matchTemp, bool temp) {
 	size_t found = INVALID_BREAKPOINT;
 	for (size_t i = 0; i < breakPoints_.size(); ++i) {
@@ -100,7 +98,6 @@ bool BreakpointManager::IsAddressBreakPoint(u32 addr)
 {
 	if (!anyBreakPoints_)
 		return false;
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	return bp != INVALID_BREAKPOINT && breakPoints_[bp].result != BREAK_ACTION_IGNORE;
 }
@@ -109,7 +106,6 @@ bool BreakpointManager::IsAddressBreakPoint(u32 addr, bool* enabled)
 {
 	if (!anyBreakPoints_)
 		return false;
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp == INVALID_BREAKPOINT) return false;
 	if (enabled != nullptr)
@@ -119,7 +115,6 @@ bool BreakpointManager::IsAddressBreakPoint(u32 addr, bool* enabled)
 
 bool BreakpointManager::IsTempBreakPoint(u32 addr)
 {
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr, true, true);
 	return bp != INVALID_BREAKPOINT;
 }
@@ -128,7 +123,6 @@ bool BreakpointManager::RangeContainsBreakPoint(u32 addr, u32 size)
 {
 	if (!anyBreakPoints_)
 		return false;
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	const u32 end = addr + size;
 	for (const auto &bp : breakPoints_)
 	{
@@ -140,7 +134,6 @@ bool BreakpointManager::RangeContainsBreakPoint(u32 addr, u32 size)
 }
 
 int BreakpointManager::AddBreakPoint(u32 addr, bool temp) {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr, true, temp);
 	if (bp == INVALID_BREAKPOINT) {
 		BreakPoint pt;
@@ -164,7 +157,6 @@ int BreakpointManager::AddBreakPoint(u32 addr, bool temp) {
 }
 
 void BreakpointManager::RemoveBreakPoint(u32 addr) {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT) {
 		breakPoints_.erase(breakPoints_.begin() + bp);
@@ -180,7 +172,6 @@ void BreakpointManager::RemoveBreakPoint(u32 addr) {
 }
 
 void BreakpointManager::ChangeBreakPoint(u32 addr, bool status) {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT) {
 		if (status)
@@ -192,7 +183,6 @@ void BreakpointManager::ChangeBreakPoint(u32 addr, bool status) {
 }
 
 void BreakpointManager::ChangeBreakPoint(u32 addr, BreakAction result) {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT) {
 		breakPoints_[bp].result = result;
@@ -204,7 +194,6 @@ void BreakpointManager::ChangeBreakPoint(u32 addr, BreakAction result) {
 void BreakpointManager::ClearAllBreakPoints() {
 	if (!anyBreakPoints_)
 		return;
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	if (!breakPoints_.empty()) {
 		// Same strategy as ClearTemporaryBreakPoints - if there's only one, we can update just that one.
 		if (breakPoints_.size() == 1) {
@@ -220,8 +209,6 @@ void BreakpointManager::ClearTemporaryBreakPoints()
 {
 	if (!anyBreakPoints_)
 		return;
-
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 
 	std::vector<u32> addrsToUpdate;
 
@@ -248,7 +235,6 @@ void BreakpointManager::ClearTemporaryBreakPoints()
 
 void BreakpointManager::ChangeBreakPointAddCond(u32 addr, const BreakPointCond &cond)
 {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT)
 	{
@@ -259,7 +245,6 @@ void BreakpointManager::ChangeBreakPointAddCond(u32 addr, const BreakPointCond &
 }
 
 void BreakpointManager::ChangeBreakPointRemoveCond(u32 addr) {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT) {
 		breakPoints_[bp].hasCond = false;
@@ -268,7 +253,6 @@ void BreakpointManager::ChangeBreakPointRemoveCond(u32 addr) {
 }
 
 BreakPointCond *BreakpointManager::GetBreakPointCondition(u32 addr) {
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp != INVALID_BREAKPOINT && breakPoints_[bp].hasCond)
 		return &breakPoints_[bp].cond;
@@ -276,7 +260,6 @@ BreakPointCond *BreakpointManager::GetBreakPointCondition(u32 addr) {
 }
 
 void BreakpointManager::ChangeBreakPointLogFormat(u32 addr, const std::string &fmt) {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr, true, false);
 	if (bp != INVALID_BREAKPOINT) {
 		breakPoints_[bp].logFormat = fmt;
@@ -287,11 +270,9 @@ void BreakpointManager::ChangeBreakPointLogFormat(u32 addr, const std::string &f
 BreakAction BreakpointManager::ExecBreakPoint(u32 addr) {
 	if (!anyBreakPoints_)
 		return BREAK_ACTION_IGNORE;
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr, false);
 	if (bp != INVALID_BREAKPOINT) {
 		const BreakPoint &info = breakPoints_[bp];
-		guard.unlock();
 
 		if (info.hasCond) {
 			// Evaluate the breakpoint and abort if necessary.
@@ -320,8 +301,6 @@ BreakAction BreakpointManager::ExecBreakPoint(u32 addr) {
 }
 
 int BreakpointManager::AddMemCheck(u32 start, u32 end, MemCheckCondition cond, BreakAction result) {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
-
 	size_t mc = FindMemCheck(start, end);
 	if (mc == INVALID_MEMCHECK) {
 		MemCheck check;
@@ -351,8 +330,6 @@ int BreakpointManager::AddMemCheck(u32 start, u32 end, MemCheckCondition cond, B
 
 void BreakpointManager::RemoveMemCheck(u32 start, u32 end)
 {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
-
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK)
 	{
@@ -366,7 +343,6 @@ void BreakpointManager::RemoveMemCheck(u32 start, u32 end)
 
 void BreakpointManager::ChangeMemCheck(u32 start, u32 end, MemCheckCondition cond, BreakAction result)
 {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK)
 	{
@@ -378,8 +354,6 @@ void BreakpointManager::ChangeMemCheck(u32 start, u32 end, MemCheckCondition con
 
 void BreakpointManager::ClearAllMemChecks()
 {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
-
 	if (!memChecks_.empty())
 	{
 		memChecks_.clear();
@@ -392,7 +366,6 @@ void BreakpointManager::ClearAllMemChecks()
 
 
 void BreakpointManager::ChangeMemCheckAddCond(u32 start, u32 end, const BreakPointCond &cond) {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK) {
 		memChecks_[mc].hasCondition = true;
@@ -403,7 +376,6 @@ void BreakpointManager::ChangeMemCheckAddCond(u32 start, u32 end, const BreakPoi
 }
 
 void BreakpointManager::ChangeMemCheckRemoveCond(u32 start, u32 end) {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK) {
 		memChecks_[mc].hasCondition = false;
@@ -413,7 +385,6 @@ void BreakpointManager::ChangeMemCheckRemoveCond(u32 start, u32 end) {
 }
 
 BreakPointCond *BreakpointManager::GetMemCheckCondition(u32 start, u32 end) {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK && memChecks_[mc].hasCondition)
 		return &memChecks_[mc].condition;
@@ -421,7 +392,6 @@ BreakPointCond *BreakpointManager::GetMemCheckCondition(u32 start, u32 end) {
 }
 
 void BreakpointManager::ChangeMemCheckLogFormat(u32 start, u32 end, const std::string &fmt) {
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK) {
 		memChecks_[mc].logFormat = fmt;
@@ -430,7 +400,6 @@ void BreakpointManager::ChangeMemCheckLogFormat(u32 start, u32 end, const std::s
 }
 
 bool BreakpointManager::GetMemCheck(u32 start, u32 end, MemCheck *check) {
-	std::lock_guard<std::mutex> guard(memCheckMutex_);
 	size_t mc = FindMemCheck(start, end);
 	if (mc != INVALID_MEMCHECK) {
 		*check = memChecks_[mc];
@@ -447,14 +416,13 @@ static inline u32 NotCached(u32 val) {
 }
 
 bool BreakpointManager::GetMemCheckInRange(u32 address, int size, MemCheck *check) {
-	std::lock_guard<std::mutex> guard(memCheckMutex_);
-	auto result = GetMemCheckLocked(address, size);
+	auto result = FindMemCheckInRange(address, size);
 	if (result)
 		*check = *result;
 	return result != nullptr;
 }
 
-MemCheck *BreakpointManager::GetMemCheckLocked(u32 address, int size) {
+MemCheck *BreakpointManager::FindMemCheckInRange(u32 address, int size) {
 	std::vector<MemCheck>::iterator iter;
 	for (iter = memChecks_.begin(); iter != memChecks_.end(); ++iter)
 	{
@@ -479,15 +447,13 @@ BreakAction BreakpointManager::ExecMemCheck(u32 address, bool write, int size, u
 {
 	if (!anyMemChecks_)
 		return BREAK_ACTION_IGNORE;
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
-	auto check = GetMemCheckLocked(address, size);
+	MemCheck *check = FindMemCheckInRange(address, size);
 	if (check) {
 		BreakAction applyAction = check->Apply(address, write, size, pc);
 		if (applyAction == BREAK_ACTION_IGNORE)
 			return applyAction;
 
-		auto copy = *check;
-		guard.unlock();
+		MemCheck copy = *check;
 		return copy.Action(address, write, size, pc, reason);
 	}
 	return BREAK_ACTION_IGNORE;
@@ -504,8 +470,7 @@ BreakAction BreakpointManager::ExecOpMemCheck(u32 address, u32 pc) {
 	}
 
 	bool write = MIPSAnalyst::IsOpMemoryWrite(pc);
-	std::unique_lock<std::mutex> guard(memCheckMutex_);
-	auto check = GetMemCheckLocked(address, size);
+	MemCheck *check = FindMemCheckInRange(address, size);
 	if (check) {
 		int mask = MEMCHECK_WRITE | MEMCHECK_WRITE_ONCHANGE;
 		bool apply = false;
@@ -521,9 +486,7 @@ BreakAction BreakpointManager::ExecOpMemCheck(u32 address, u32 pc) {
 			if (applyAction == BREAK_ACTION_IGNORE)
 				return applyAction;
 
-			// Make a copy so we can safely unlock.
-			auto copy = *check;
-			guard.unlock();
+			MemCheck copy = *check;
 			return copy.Action(address, write, size, pc, "CPU");
 		}
 	}
@@ -563,7 +526,6 @@ static MemCheck VRAMMirror(uint8_t mirror, MemCheck mc) {
 }
 
 void BreakpointManager::UpdateCachedMemCheckRanges() {
-	std::lock_guard<std::mutex> guard(memCheckMutex_);
 	memCheckRangesRead_.clear();
 	memCheckRangesWrite_.clear();
 
@@ -592,29 +554,24 @@ void BreakpointManager::UpdateCachedMemCheckRanges() {
 }
 
 std::vector<MemCheck> BreakpointManager::GetMemCheckRanges(bool write) {
-	std::lock_guard<std::mutex> guard(memCheckMutex_);
 	if (write)
 		return memCheckRangesWrite_;
 	return memCheckRangesRead_;
 }
 
 std::vector<MemCheck> BreakpointManager::GetMemChecks() {
-	std::lock_guard<std::mutex> guard(memCheckMutex_);
 	return memChecks_;
 }
 
 std::vector<BreakPoint> BreakpointManager::GetBreakpoints() {
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	return breakPoints_;
 }
 
 void BreakpointManager::Frame() {
-	// outside the lock here, should be ok.
 	if (!needsUpdate_) {
 		return;
 	}
 
-	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	if (MIPSComp::jit && updateAddr_ != INVALID_ADDRESS) {
 		// In case this is a delay slot, clear the previous instruction too.
 		if (updateAddr_ != 0)

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -19,7 +19,6 @@
 
 #include <vector>
 #include <atomic>
-#include <mutex>
 
 #include "Core/MIPS/MIPSDebugInterface.h"
 #include "Common/Math/expression_parser.h"
@@ -190,7 +189,6 @@ public:
 	bool EvaluateLogFormat(MIPSDebugInterface *cpu, const std::string &fmt, std::string &result);
 
 private:
-	// Should be called under lock.
 	// 0 means to clear the whole jit cache, to apply some change that has been made.
 	void Update(u32 addr) {
 		needsUpdate_ = true;
@@ -199,14 +197,12 @@ private:
 	size_t FindBreakpoint(u32 addr, bool matchTemp = false, bool temp = false);
 	// Finds exactly, not using a range check.
 	size_t FindMemCheck(u32 start, u32 end);
-	MemCheck *GetMemCheckLocked(u32 address, int size);
+	// Finds a memcheck covering (part of) a range, unlike FindMemCheck() above.
+	MemCheck *FindMemCheckInRange(u32 address, int size);
 	void UpdateCachedMemCheckRanges();
 
 	std::atomic<bool> anyBreakPoints_;
 	std::atomic<bool> anyMemChecks_;
-
-	std::mutex breakPointsMutex_;
-	std::mutex memCheckMutex_;
 
 	std::vector<BreakPoint> breakPoints_;
 	u32 breakSkipFirstAt_ = 0;

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -50,13 +50,10 @@
 SymbolMap *g_symbolMap;
 
 void SymbolMap::SortSymbols() {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	AssignFunctionIndices();
 }
 
 void SymbolMap::Clear() {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	functions.clear();
 	labels.clear();
 	data.clear();
@@ -69,9 +66,8 @@ void SymbolMap::Clear() {
 }
 
 bool SymbolMap::LoadSymbolMap(const Path &filename) {
-	Clear();  // let's not recurse the lock
+	Clear();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	// TODO(scoped): Use gzdopen instead.
 
@@ -203,8 +199,6 @@ bool SymbolMap::LoadSymbolMap(const Path &filename) {
 }
 
 bool SymbolMap::SaveSymbolMap(const Path &filename) const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	// Don't bother writing a blank file.
 	if (!File::Exists(filename) && functions.empty() && data.empty()) {
 		return true;
@@ -307,7 +301,6 @@ bool SymbolMap::SaveSymbolMap(const Path &filename) const {
 }
 
 bool SymbolMap::LoadNocashSym(const Path &filename) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	FILE *f = File::OpenCFile(filename, "r");
 	if (!f)
 		return false;
@@ -364,8 +357,6 @@ bool SymbolMap::LoadNocashSym(const Path &filename) {
 }
 
 bool SymbolMap::SaveNocashSym(const Path &filename) const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	// Don't bother writing a blank file.
 	if (!File::Exists(filename) && functions.empty() && data.empty()) {
 		return false;
@@ -389,7 +380,6 @@ SymbolType SymbolMap::GetSymbolType(u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	if (activeFunctions.find(address) != activeFunctions.end())
 		return ST_FUNCTION;
 	if (activeData.find(address) != activeData.end())
@@ -439,7 +429,6 @@ u32 SymbolMap::GetNextSymbolAddress(u32 address, SymbolType symmask) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	const auto functionEntry = symmask & ST_FUNCTION ? activeFunctions.upper_bound(address) : activeFunctions.end();
 	const auto dataEntry = symmask & ST_DATA ? activeData.upper_bound(address) : activeData.end();
 
@@ -456,7 +445,6 @@ u32 SymbolMap::GetNextSymbolAddress(u32 address, SymbolType symmask) {
 }
 
 std::string SymbolMap::GetDescription(unsigned int address) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	std::string labelName;
 
 	u32 funcStart = GetFunctionStart(address);
@@ -483,7 +471,6 @@ std::vector<SymbolEntry> SymbolMap::GetAllActiveSymbols(SymbolType symmask) {
 	std::vector<SymbolEntry> result;
 
 	if (symmask & ST_FUNCTION) {
-		std::lock_guard<std::recursive_mutex> guard(lock_);
 		for (auto it = activeFunctions.begin(); it != activeFunctions.end(); it++) {
 			SymbolEntry entry;
 			entry.address = it->first;
@@ -496,7 +483,6 @@ std::vector<SymbolEntry> SymbolMap::GetAllActiveSymbols(SymbolType symmask) {
 	}
 
 	if (symmask & ST_DATA) {
-		std::lock_guard<std::recursive_mutex> guard(lock_);
 		for (auto it = activeData.begin(); it != activeData.end(); it++) {
 			SymbolEntry entry;
 			entry.address = it->first;
@@ -512,8 +498,6 @@ std::vector<SymbolEntry> SymbolMap::GetAllActiveSymbols(SymbolType symmask) {
 }
 
 void SymbolMap::AddModule(const char *name, u32 address, u32 size) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	for (auto it = modules.begin(), end = modules.end(); it != end; ++it) {
 		if (!strcmp(it->name, name)) {
 			// Just reactivate that one.
@@ -537,13 +521,11 @@ void SymbolMap::AddModule(const char *name, u32 address, u32 size) {
 }
 
 void SymbolMap::UnloadModule(u32 address, u32 size) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	activeModuleEnds.erase(address + size);
 	activeNeedUpdate_ = true;
 }
 
 u32 SymbolMap::GetModuleRelativeAddr(u32 address, int moduleIndex) const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	if (moduleIndex == -1) {
 		moduleIndex = GetModuleIndex(address);
 	}
@@ -557,7 +539,6 @@ u32 SymbolMap::GetModuleRelativeAddr(u32 address, int moduleIndex) const {
 }
 
 u32 SymbolMap::GetModuleAbsoluteAddr(u32 relative, int moduleIndex) const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	for (auto it = modules.begin(), end = modules.end(); it != end; ++it) {
 		if (it->index == moduleIndex) {
 			return it->start + relative;
@@ -567,7 +548,6 @@ u32 SymbolMap::GetModuleAbsoluteAddr(u32 relative, int moduleIndex) const {
 }
 
 int SymbolMap::GetModuleIndex(u32 address) const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto iter = activeModuleEnds.upper_bound(address);
 	if (iter == activeModuleEnds.end())
 		return -1;
@@ -579,7 +559,6 @@ bool SymbolMap::IsModuleActive(int moduleIndex) {
 		return true;
 	}
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	for (auto it = activeModuleEnds.begin(), end = activeModuleEnds.end(); it != end; ++it) {
 		if (it->second.index == moduleIndex) {
 			return true;
@@ -589,8 +568,6 @@ bool SymbolMap::IsModuleActive(int moduleIndex) {
 }
 
 std::vector<LoadedModuleInfo> SymbolMap::getAllModules() const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	std::vector<LoadedModuleInfo> result;
 	for (size_t i = 0; i < modules.size(); i++) {
 		LoadedModuleInfo m;
@@ -608,8 +585,6 @@ std::vector<LoadedModuleInfo> SymbolMap::getAllModules() const {
 }
 
 void SymbolMap::AddFunction(const char* name, u32 address, u32 size, int moduleIndex) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	if (moduleIndex == -1) {
 		moduleIndex = GetModuleIndex(address);
 	} else if (moduleIndex == 0) {
@@ -661,7 +636,6 @@ u32 SymbolMap::GetFunctionStart(u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeFunctions.upper_bound(address);
 	if (it == activeFunctions.end()) {
 		// check last element
@@ -691,7 +665,6 @@ u32 SymbolMap::FindPossibleFunctionAtAfter(u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeFunctions.lower_bound(address);
 	if (it == activeFunctions.end()) {
 		return (u32)-1;
@@ -701,7 +674,6 @@ u32 SymbolMap::FindPossibleFunctionAtAfter(u32 address) {
 
 u32 SymbolMap::GetFunctionSize(u32 startAddress) {
 	if (activeNeedUpdate_) {
-		std::lock_guard<std::recursive_mutex> guard(lock_);
 
 		// This is common, from the jit.  Direct lookup is faster than updating active symbols.
 		auto mod = activeModuleEnds.lower_bound(startAddress);
@@ -726,7 +698,6 @@ u32 SymbolMap::GetFunctionSize(u32 startAddress) {
 		return func->second.size;
 	}
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeFunctions.find(startAddress);
 	if (it == activeFunctions.end())
 		return INVALID_ADDRESS;
@@ -738,7 +709,6 @@ u32 SymbolMap::GetFunctionModuleAddress(u32 startAddress) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeFunctions.find(startAddress);
 	if (it == activeFunctions.end())
 		return INVALID_ADDRESS;
@@ -750,7 +720,6 @@ int SymbolMap::GetFunctionNum(u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	u32 start = GetFunctionStart(address);
 	if (start == INVALID_ADDRESS)
 		return INVALID_ADDRESS;
@@ -763,7 +732,6 @@ int SymbolMap::GetFunctionNum(u32 address) {
 }
 
 void SymbolMap::AssignFunctionIndices() {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	int index = 0;
 	for (auto mod = activeModuleEnds.begin(), modend = activeModuleEnds.end(); mod != modend; ++mod) {
 		int moduleIndex = mod->second.index;
@@ -777,8 +745,6 @@ void SymbolMap::AssignFunctionIndices() {
 
 // Copies functions, labels and data to the active set depending on which modules are "active".
 void SymbolMap::UpdateActiveSymbols() {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	activeFunctions.clear();
 	activeLabels.clear();
 	activeData.clear();
@@ -828,7 +794,6 @@ bool SymbolMap::SetFunctionSize(u32 startAddress, u32 newSize) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	auto funcInfo = activeFunctions.find(startAddress);
 	if (funcInfo != activeFunctions.end()) {
@@ -849,7 +814,6 @@ bool SymbolMap::RemoveFunction(u32 startAddress, bool removeName) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	auto it = activeFunctions.find(startAddress);
 	if (it == activeFunctions.end())
@@ -878,8 +842,6 @@ bool SymbolMap::RemoveFunction(u32 startAddress, bool removeName) {
 }
 
 void SymbolMap::AddLabel(const char* name, u32 address, int moduleIndex) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	if (moduleIndex == -1) {
 		moduleIndex = GetModuleIndex(address);
 	} else if (moduleIndex == 0) {
@@ -929,7 +891,6 @@ void SymbolMap::SetLabelName(const char* name, u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto labelInfo = activeLabels.find(address);
 	if (labelInfo == activeLabels.end()) {
 		AddLabel(name, address);
@@ -954,7 +915,6 @@ const char *SymbolMap::GetLabelName(u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeLabels.find(address);
 	if (it == activeLabels.end())
 		return NULL;
@@ -963,7 +923,6 @@ const char *SymbolMap::GetLabelName(u32 address) {
 }
 
 const char *SymbolMap::GetLabelNameRel(u32 relAddress, int moduleIndex) const {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = labels.find(std::make_pair(moduleIndex, relAddress));
 	if (it == labels.end())
 		return NULL;
@@ -972,7 +931,6 @@ const char *SymbolMap::GetLabelNameRel(u32 relAddress, int moduleIndex) const {
 }
 
 std::string SymbolMap::GetLabelString(u32 address) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	const char *label = GetLabelName(address);
 	if (label == NULL)
 		return "";
@@ -983,7 +941,6 @@ bool SymbolMap::GetLabelValue(const char* name, u32& dest) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	for (auto it = activeLabels.begin(); it != activeLabels.end(); it++) {
 		if (strcasecmp(name, it->second.name) == 0) {
 			dest = it->first;
@@ -995,8 +952,6 @@ bool SymbolMap::GetLabelValue(const char* name, u32& dest) {
 }
 
 void SymbolMap::AddData(u32 address, u32 size, DataType type, int moduleIndex) {
-	std::lock_guard<std::recursive_mutex> guard(lock_);
-
 	if (moduleIndex == -1) {
 		moduleIndex = GetModuleIndex(address);
 	} else if (moduleIndex == 0) {
@@ -1047,7 +1002,6 @@ u32 SymbolMap::GetDataStart(u32 address) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeData.upper_bound(address);
 	if (it == activeData.end())
 	{
@@ -1080,7 +1034,6 @@ u32 SymbolMap::GetDataSize(u32 startAddress) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeData.find(startAddress);
 	if (it == activeData.end())
 		return INVALID_ADDRESS;
@@ -1091,7 +1044,6 @@ u32 SymbolMap::GetDataModuleAddress(u32 startAddress) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeData.find(startAddress);
 	if (it == activeData.end())
 		return INVALID_ADDRESS;
@@ -1102,7 +1054,6 @@ DataType SymbolMap::GetDataType(u32 startAddress) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	auto it = activeData.find(startAddress);
 	if (it == activeData.end())
 		return DATATYPE_NONE;
@@ -1113,7 +1064,6 @@ bool SymbolMap::RemoveData(u32 startAddress, bool removeName) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	auto it = activeData.find(startAddress);
 	if (it == activeData.end())
@@ -1145,7 +1095,6 @@ void SymbolMap::GetLabels(std::vector<LabelDefinition> &dest) {
 	if (activeNeedUpdate_)
 		UpdateActiveSymbols();
 
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 	for (auto it = activeLabels.begin(); it != activeLabels.end(); it++) {
 		LabelDefinition entry;
 		entry.value = it->first;
@@ -1176,7 +1125,6 @@ void SymbolMap::FillSymbolListBox(HWND listbox,SymbolType symType) {
 		UpdateActiveSymbols();
 
 	wchar_t temp[256];
-	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	SendMessage(listbox, WM_SETREDRAW, FALSE, 0);
 	ListBox_ResetContent(listbox);

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -20,7 +20,6 @@
 #include <vector>
 #include <map>
 #include <string>
-#include <mutex>
 
 #include "Common/CommonTypes.h"
 #include "Common/File/Path.h"
@@ -172,7 +171,6 @@ private:
 	std::map<SymbolKey, DataEntry> data;
 	std::vector<ModuleEntry> modules;
 
-	mutable std::recursive_mutex lock_;
 	bool sawUnknownModule = false;
 };
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -112,20 +112,17 @@ void WebSocketMemoryReadU8(DebuggerRequest &req) {
 		return;
 	}
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
 	// Route the actual memory read to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
-
 		JsonWriter &json = req.Respond();
 		json.writeUint("value", Memory::Read_U8(addr));
 	});
@@ -144,20 +141,17 @@ void WebSocketMemoryReadU16(DebuggerRequest &req) {
 		return;
 	}
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
 	// Route the actual memory read to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
-
 		JsonWriter &json = req.Respond();
 		json.writeUint("value", Memory::Read_U16(addr));
 	});
@@ -176,20 +170,17 @@ void WebSocketMemoryReadU32(DebuggerRequest &req) {
 		return;
 	}
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
 	// Route the actual memory read to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
-
 		JsonWriter &json = req.Respond();
 		json.writeUint("value", Memory::Read_U32(addr));
 	});
@@ -215,40 +206,41 @@ void WebSocketMemoryRead(DebuggerRequest &req) {
 	if (!req.ParamBool("replacements", &replacements, DebuggerParamType::OPTIONAL))
 		return;
 
-	// Route the actual memory read to the CPU thread instead of poking at it directly
-	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
-	// Note: for a very large 'size', base64-encoding it is real CPU work that will now happen on the
-	// CPU thread itself, blocking its own frame pump for the duration - same caveat as memory.search.
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr/size, not on anything CPU-thread-owned, so fail fast here rather
+	// than making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+	if (!Memory::IsValidRange(addr, size))
+		return req.Fail("Invalid size");
+
+	// Route the actual memory read to the CPU thread instead of poking at it directly from this
+	// WebSocket handler thread - see Core_RunOnCPUThread() in Core.h. Only the raw copy (which
+	// needs replacements/emuhacks disabled) happens on the CPU thread - the base64 encoding itself
+	// happens back on this WebSocket thread afterward, so it doesn't block the CPU thread's frame
+	// pump for a large 'size'.
+	std::vector<uint8_t> raw(size);
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(replacements);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		} else if (!Memory::IsValidRange(addr, size)) {
-			req.Fail("Invalid size");
-			return;
-		}
-
-		JsonWriter &json = req.Respond();
-		// Start a value without any actual data yet...
-		json.writeRaw("base64", "");
-		req.Flush();
-
-		// Now we'll write it directly to the stream.
-		req.ws->AddFragment(false, "\"");
-		// 65535 is an "even" number of base64 characters.
-		static const size_t CHUNK_SIZE = 65535;
-		for (size_t i = 0; i < size; i += CHUNK_SIZE) {
-			size_t left = std::min(size - i, CHUNK_SIZE);
-			req.ws->AddFragment(false, Base64Encode(Memory::GetPointerUnchecked(addr) + i, left));
-		}
-		req.ws->AddFragment(false, "\"");
+		if (size != 0)
+			memcpy(raw.data(), Memory::GetPointerUnchecked(addr), size);
 	});
+
+	JsonWriter &json = req.Respond();
+	// Start a value without any actual data yet...
+	json.writeRaw("base64", "");
+	req.Flush();
+
+	// Now we'll write it directly to the stream.
+	req.ws->AddFragment(false, "\"");
+	// 65535 is an "even" number of base64 characters.
+	static const size_t CHUNK_SIZE = 65535;
+	for (size_t i = 0; i < raw.size(); i += CHUNK_SIZE) {
+		size_t left = std::min(raw.size() - i, CHUNK_SIZE);
+		req.ws->AddFragment(false, Base64Encode(&raw[i], left));
+	}
+	req.ws->AddFragment(false, "\"");
 }
 
 // Read a NUL terminated string from memory (memory.readString)
@@ -267,40 +259,39 @@ void WebSocketMemoryReadString(DebuggerRequest &req) {
 	if (!req.ParamU32("address", &addr))
 		return;
 
-	// Route the actual memory read to the CPU thread instead of poking at it directly
-	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+
+	std::string type = "utf-8";
+	if (!req.ParamString("type", &type, DebuggerParamType::OPTIONAL))
+		return;
+	if (type != "utf-8" && type != "base64")
+		return req.Fail("Invalid type, must be either utf-8 or base64");
+
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
+	// Route the actual memory read to the CPU thread instead of poking at it directly from this
+	// WebSocket handler thread - see Core_RunOnCPUThread() in Core.h. Only the raw copy happens on
+	// the CPU thread - the base64 encoding itself happens back on this WebSocket thread afterward.
+	std::string raw;
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		std::string type = "utf-8";
-		if (!req.ParamString("type", &type, DebuggerParamType::OPTIONAL))
-			return;
-		if (type != "utf-8" && type != "base64") {
-			req.Fail("Invalid type, must be either utf-8 or base64");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
-
 		// Let's try to avoid crashing and get a safe length.
 		const uint8_t *p = Memory::GetPointerUnchecked(addr);
 		size_t longest = Memory::ClampValidSizeAt(addr, Memory::g_MemorySize);
 		size_t len = strnlen((const char *)p, longest);
-
-		JsonWriter &json = req.Respond();
-		if (type == "utf-8") {
-			json.writeString("value", std::string((const char *)p, len));
-		} else if (type == "base64") {
-			json.writeString("base64", Base64Encode(p, len));
-		}
+		raw.assign((const char *)p, len);
 	});
+
+	JsonWriter &json = req.Respond();
+	if (type == "utf-8") {
+		json.writeString("value", raw);
+	} else if (type == "base64") {
+		json.writeString("base64", Base64Encode((const uint8_t *)raw.data(), raw.size()));
+	}
 }
 
 // Write a byte to memory (memory.write_u8)
@@ -320,19 +311,17 @@ void WebSocketMemoryWriteU8(DebuggerRequest &req) {
 		return;
 	}
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
 	// Route the actual memory write to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
 		currentMIPS->InvalidateICache(addr, 1);
 		Memory::Write_U8(val, addr);
 		Reporting::NotifyDebugger();
@@ -359,19 +348,17 @@ void WebSocketMemoryWriteU16(DebuggerRequest &req) {
 		return;
 	}
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
 	// Route the actual memory write to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
 		currentMIPS->InvalidateICache(addr, 2);
 		Memory::Write_U16(val, addr);
 		Reporting::NotifyDebugger();
@@ -398,19 +385,17 @@ void WebSocketMemoryWriteU32(DebuggerRequest &req) {
 		return;
 	}
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr, not on anything CPU-thread-owned, so fail fast here rather than
+	// making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+
 	// Route the actual memory write to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		}
 		currentMIPS->InvalidateICache(addr, 4);
 		Memory::Write_U32(val, addr);
 		Reporting::NotifyDebugger();
@@ -435,28 +420,26 @@ void WebSocketMemoryWrite(DebuggerRequest &req) {
 	if (!req.ParamString("base64", &encoded))
 		return;
 
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+
+	// Decoding doesn't touch anything CPU-thread-owned either, so do it - and the address/size
+	// validation that depends on it - here, before we bother queuing to the CPU thread at all.
+	std::vector<uint8_t> value = Base64Decode(&encoded[0], encoded.size());
+	uint32_t size = (uint32_t)value.size();
+
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+	if (value.size() != (size_t)size || !Memory::IsValidRange(addr, size))
+		return req.Fail("Invalid size");
+
 	// Route the actual memory write to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-
-		std::vector<uint8_t> value = Base64Decode(&encoded[0], encoded.size());
-		uint32_t size = (uint32_t)value.size();
-
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		} else if (value.size() != (size_t)size || !Memory::IsValidRange(addr, size)) {
-			req.Fail("Invalid size");
-			return;
-		}
-
 		currentMIPS->InvalidateICache(addr, size);
-		Memory::MemcpyUnchecked(addr, &value[0], size);
+		if (size != 0)
+			Memory::MemcpyUnchecked(addr, &value[0], size);
 		Reporting::NotifyDebugger();
 		req.Respond();
 	});
@@ -498,87 +481,79 @@ void WebSocketMemorySearch(DebuggerRequest &req) {
 	if (!req.ParamString("type", &type))
 		return;
 
-	// Route the actual memory scan to the CPU thread instead of poking at it directly
-	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
-	// Note: 'size' has no cap beyond valid memory range, so a very large scan will now block the CPU
-	// thread's own frame pump for its duration, rather than running unqueued on this thread as before.
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+	// This only depends on addr/size, not on anything CPU-thread-owned, so fail fast here rather
+	// than making a round trip through the queue for a request we already know is invalid.
+	if (!Memory::IsValidAddress(addr))
+		return req.Fail("Invalid address");
+	if (!Memory::IsValidRange(addr, size))
+		return req.Fail("Invalid size");
+
+	// None of the rest of the parameter parsing/validation below touches anything CPU-thread-owned
+	// either, so it all happens here too, before we bother queuing to the CPU thread at all.
+	uint32_t align = 1;
+	uint32_t needleSize = 0;
+	uint32_t needleValue = 0;
+	std::vector<uint8_t> needleBytes;
+	std::vector<uint8_t> maskBytes;
+
+	if (type == "u8" || type == "u16" || type == "u32") {
+		needleSize = type == "u8" ? 1 : type == "u16" ? 2 : 4;
+		align = needleSize;
+		if (!req.ParamU32("value", &needleValue, false))
+			return;
+	} else if (type == "float") {
+		needleSize = 4;
+		align = 4;
+		// allowFloatBits: accepts a string like "1.5" and gives us its raw bit pattern.
+		if (!req.ParamU32("value", &needleValue, true))
+			return;
+	} else if (type == "bytes") {
+		std::string encoded;
+		if (!req.ParamString("base64", &encoded))
+			return;
+		needleBytes = Base64Decode(&encoded[0], encoded.size());
+		if (needleBytes.empty())
+			return req.Fail("'base64' must decode to at least one byte");
+		needleSize = (uint32_t)needleBytes.size();
+		align = 1;
+
+		if (req.HasParam("maskBase64")) {
+			std::string maskEncoded;
+			if (!req.ParamString("maskBase64", &maskEncoded))
+				return;
+			maskBytes = Base64Decode(&maskEncoded[0], maskEncoded.size());
+			if (maskBytes.size() != needleBytes.size())
+				return req.Fail("'maskBase64' must decode to the same length as 'base64'");
+		}
+	} else {
+		return req.Fail("Invalid 'type', must be u8, u16, u32, float, or bytes");
+	}
+
+	if (needleSize > size)
+		return req.Fail("'size' is smaller than the pattern/value being searched for");
+
+	if (!req.ParamU32("align", &align, false, DebuggerParamType::OPTIONAL))
+		return;
+	if (align == 0)
+		return req.Fail("'align' must not be zero");
+
+	uint32_t maxResults = 1000;
+	if (!req.ParamU32("maxResults", &maxResults, false, DebuggerParamType::OPTIONAL))
+		return;
+	if (maxResults == 0)
+		maxResults = 1000;
+	else if (maxResults > 100000)
+		maxResults = 100000;
+
+	// Route the actual memory scan to the CPU thread instead of poking at it directly from this
+	// WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
+	// Note: 'size' has no cap beyond valid memory range, so a very large scan will still block the
+	// CPU thread's own frame pump for its duration - at least the parameter validation above no
+	// longer costs a round trip through the queue first.
 	Core_RunOnCPUThread([&] {
 		AutoDisabledReplacements memLock = LockMemory(true);
-		if (!currentDebugMIPS->isAlive() || !Memory::IsActive()) {
-			req.Fail("CPU not started");
-			return;
-		}
-		if (!Memory::IsValidAddress(addr)) {
-			req.Fail("Invalid address");
-			return;
-		} else if (!Memory::IsValidRange(addr, size)) {
-			req.Fail("Invalid size");
-			return;
-		}
-
-		uint32_t align = 1;
-		uint32_t needleSize = 0;
-		uint32_t needleValue = 0;
-		std::vector<uint8_t> needleBytes;
-		std::vector<uint8_t> maskBytes;
-
-		if (type == "u8" || type == "u16" || type == "u32") {
-			needleSize = type == "u8" ? 1 : type == "u16" ? 2 : 4;
-			align = needleSize;
-			if (!req.ParamU32("value", &needleValue, false))
-				return;
-		} else if (type == "float") {
-			needleSize = 4;
-			align = 4;
-			// allowFloatBits: accepts a string like "1.5" and gives us its raw bit pattern.
-			if (!req.ParamU32("value", &needleValue, true))
-				return;
-		} else if (type == "bytes") {
-			std::string encoded;
-			if (!req.ParamString("base64", &encoded))
-				return;
-			needleBytes = Base64Decode(&encoded[0], encoded.size());
-			if (needleBytes.empty()) {
-				req.Fail("'base64' must decode to at least one byte");
-				return;
-			}
-			needleSize = (uint32_t)needleBytes.size();
-			align = 1;
-
-			if (req.HasParam("maskBase64")) {
-				std::string maskEncoded;
-				if (!req.ParamString("maskBase64", &maskEncoded))
-					return;
-				maskBytes = Base64Decode(&maskEncoded[0], maskEncoded.size());
-				if (maskBytes.size() != needleBytes.size()) {
-					req.Fail("'maskBase64' must decode to the same length as 'base64'");
-					return;
-				}
-			}
-		} else {
-			req.Fail("Invalid 'type', must be u8, u16, u32, float, or bytes");
-			return;
-		}
-
-		if (needleSize > size) {
-			req.Fail("'size' is smaller than the pattern/value being searched for");
-			return;
-		}
-
-		if (!req.ParamU32("align", &align, false, DebuggerParamType::OPTIONAL))
-			return;
-		if (align == 0) {
-			req.Fail("'align' must not be zero");
-			return;
-		}
-
-		uint32_t maxResults = 1000;
-		if (!req.ParamU32("maxResults", &maxResults, false, DebuggerParamType::OPTIONAL))
-			return;
-		if (maxResults == 0)
-			maxResults = 1000;
-		else if (maxResults > 100000)
-			maxResults = 100000;
 
 		const uint8_t *base = Memory::GetPointerUnchecked(addr);
 		std::vector<uint32_t> matches;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1257,29 +1257,37 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 
 	g_requestManager.ProcessRequests();
 
-	g_breakpoints.Frame();
+	// Guards the span where we actually touch CPU-thread-owned debugger state (breakpoints,
+	// symbol map, registers, memory, etc.) against unsynchronized reads from other threads' paint
+	// handlers - see g_frameMutex in Core.h.
+	ScreenRenderFlags renderFlags = ScreenRenderFlags::NONE;
+	{
+		std::lock_guard<std::mutex> emuStateGuard(g_frameMutex);
 
-	// Apply the UIContext bounds as a 2D transformation matrix.
-	// NOTE: We compensate for the Y and Z conventions in the shaders, so we can use the same matrices in all backends.
-	Matrix4x4 ortho = ComputeOrthoMatrix(g_display.dp_xres, g_display.dp_yres, g_draw->GetDeviceCaps().coordConvention);
+		g_breakpoints.Frame();
 
-	// Can be overridden by sceDisplay which may pass true for the second argument.
-	g_frameTiming.ComputePresentMode(g_draw, false);
+		// Apply the UIContext bounds as a 2D transformation matrix.
+		// NOTE: We compensate for the Y and Z conventions in the shaders, so we can use the same matrices in all backends.
+		Matrix4x4 ortho = ComputeOrthoMatrix(g_display.dp_xres, g_display.dp_yres, g_draw->GetDeviceCaps().coordConvention);
 
-	ui_draw2d.PushDrawMatrix(ortho);
+		// Can be overridden by sceDisplay which may pass true for the second argument.
+		g_frameTiming.ComputePresentMode(g_draw, false);
 
-	g_screenManager->getUIContext()->SetTintSaturation(g_Config.fUITint, g_Config.fUISaturation);
+		ui_draw2d.PushDrawMatrix(ortho);
 
-	// All actual rendering (and also emulation) happens in this render() call.
-	ScreenRenderFlags renderFlags = g_screenManager->render();
-	if (g_screenManager->getUIContext()->Text()) {
-		g_screenManager->getUIContext()->Text()->OncePerFrame();
+		g_screenManager->getUIContext()->SetTintSaturation(g_Config.fUITint, g_Config.fUISaturation);
+
+		// All actual rendering (and also emulation) happens in this render() call.
+		renderFlags = g_screenManager->render();
+		if (g_screenManager->getUIContext()->Text()) {
+			g_screenManager->getUIContext()->Text()->OncePerFrame();
+		}
+
+		ui_draw2d.PopDrawMatrix();
+
+		runImDebugger(g_draw);
+		renderImDebugger(g_draw);
 	}
-
-	ui_draw2d.PopDrawMatrix();
-
-	runImDebugger(g_draw);
-	renderImDebugger(g_draw);
 	g_draw->EndFrame();
 
 	// This, between EndFrame and Present, is where we should actually wait to do present time management.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1277,6 +1277,13 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 
 		g_screenManager->getUIContext()->SetTintSaturation(g_Config.fUITint, g_Config.fUISaturation);
 
+		// Drain any work queued by Core_RunOnCPUThread() from other threads. Core_RunLoopUntil()
+		// (called from within render() below, but only while a game is actually loaded/running)
+		// also does this, but that path isn't reached at all outside a game - e.g. from the main
+		// menu - so queued work would otherwise hang forever waiting for it. See Core_ProcessCPUQueue()
+		// in Core.h.
+		Core_ProcessCPUQueue();
+
 		// All actual rendering (and also emulation) happens in this render() call.
 		renderFlags = g_screenManager->render();
 		if (g_screenManager->getUIContext()->Text()) {

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -60,6 +60,10 @@ void CtrlDisAsmView::deinit()
 
 void CtrlDisAsmView::scanVisibleFunctions()
 {
+	// Reads live memory/symbol state to detect function boundaries - hold g_frameMutex for the
+	// duration, which NativeFrame() also holds while it's actually touching that state. See
+	// g_frameMutex in Core.h.
+	std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 	g_disassemblyManager.analyze(windowStart, g_disassemblyManager.getNthNextAddress(windowStart,visibleRows)-windowStart);
 }
 
@@ -453,8 +457,13 @@ void CtrlDisAsmView::drawArguments(HDC hdc, const DisassemblyLineInfo &line, int
 
 void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 {
-	auto memLock = Memory::Lock();
+	Memory::MemoryInitedLock memLock = Memory::Lock();
 	if (!debugger->isAlive() || Achievements::HardcoreModeActive()) return;
+
+	// Reading live disassembly/symbol/breakpoint state here on the GUI thread would otherwise race
+	// with the CPU thread - hold g_frameMutex for the duration of the read, which NativeFrame()
+	// also holds while it's actually touching that state. See g_frameMutex in Core.h.
+	std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 
 	PAINTSTRUCT ps;
 	HDC actualHdc = BeginPaint(wnd, &ps);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -6,10 +6,12 @@
 #include "Windows/MainWindow.h"
 #include "Windows/InputBox.h"
 
+#include "Core/Core.h"
 #include "Core/MIPS/MIPSAsm.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/Config.h"
+#include "Core/Debugger/Breakpoints.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/Reporting.h"
 #include "Common/StringUtils.h"
@@ -237,7 +239,7 @@ std::string trimString(std::string input)
 
 void CtrlDisAsmView::assembleOpcode(u32 address, const std::string &defaultText)
 {
-	auto memLock = Memory::Lock();
+	Memory::MemoryInitedLock memLock = Memory::Lock();
 	if (!Core_IsStepping()) {
 		MessageBox(wnd,L"Cannot change code while the core is running!",L"Error",MB_OK);
 		return;
@@ -249,7 +251,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, const std::string &defaultText)
 	}
 
 	// check if it changes registers first
-	auto separator = op.find('=');
+	size_t separator = op.find('=');
 	if (separator != std::string::npos)
 	{
 		std::string registerName = trimString(op.substr(0,separator));
@@ -264,8 +266,12 @@ void CtrlDisAsmView::assembleOpcode(u32 address, const std::string &defaultText)
 				{
 					if (strcasecmp(debugger->GetRegName(cat,reg).c_str(), registerName.c_str()) == 0)
 					{
-						debugger->SetRegValue(cat,reg,value);
-						Reporting::NotifyDebugger();
+						// Route the actual register write to the CPU thread instead of poking at it
+						// directly from this GUI thread - see Core_RunOnCPUThread() in Core.h.
+						Core_RunOnCPUThread([&] {
+							debugger->SetRegValue(cat,reg,value);
+							Reporting::NotifyDebugger();
+						});
 						SendMessage(GetParent(wnd),WM_DEB_UPDATE,0,0);
 						return;
 					}
@@ -276,9 +282,13 @@ void CtrlDisAsmView::assembleOpcode(u32 address, const std::string &defaultText)
 		// try to assemble the input if it failed
 	}
 
+	// Route the actual code assembly to the CPU thread instead of poking at it directly
+	// from this GUI thread - see Core_RunOnCPUThread() in Core.h.
 	std::string error;
-	result = MipsAssembleOpcode(op, debugger, address, &error);
-	Reporting::NotifyDebugger();
+	Core_RunOnCPUThread([&] {
+		result = MipsAssembleOpcode(op, debugger, address, &error);
+		Reporting::NotifyDebugger();
+	});
 	if (result) {
 		scanVisibleFunctions();
 
@@ -640,29 +650,37 @@ void CtrlDisAsmView::editBreakpoint()
 {
 	BreakpointWindow win(wnd,debugger);
 
+	// Route the actual breakpoint read to the CPU thread instead of poking at it directly
+	// from this GUI thread - see Core_RunOnCPUThread() in Core.h.
 	bool exists = false;
-	if (g_breakpoints.IsAddressBreakPoint(curAddress))
-	{
-		auto breakpoints = g_breakpoints.GetBreakpoints();
-		for (size_t i = 0; i < breakpoints.size(); i++)
+	Core_RunOnCPUThread([&] {
+		if (g_breakpoints.IsAddressBreakPoint(curAddress))
 		{
-			if (breakpoints[i].addr == curAddress)
+			std::vector<BreakPoint> breakpoints = g_breakpoints.GetBreakpoints();
+			for (size_t i = 0; i < breakpoints.size(); i++)
 			{
-				win.loadFromBreakpoint(breakpoints[i]);
-				exists = true;
-				break;
+				if (breakpoints[i].addr == curAddress)
+				{
+					win.loadFromBreakpoint(breakpoints[i]);
+					exists = true;
+					break;
+				}
 			}
 		}
-	}
+	});
 
 	if (!exists)
 		win.initBreakpoint(curAddress);
 
+	// win.exec() is a modal dialog - must stay outside any queued callback, or we'd block the
+	// CPU thread on user input.
 	if (win.exec())
 	{
-		if (exists)
-			g_breakpoints.RemoveBreakPoint(curAddress);
-		win.addBreakpoint();
+		Core_RunOnCPUThread([&] {
+			if (exists)
+				g_breakpoints.RemoveBreakPoint(curAddress);
+			win.addBreakpoint();
+		});
 	}
 }
 
@@ -767,7 +785,10 @@ void CtrlDisAsmView::onKeyDown(WPARAM wParam, LPARAM lParam)
 			displaySymbols = !displaySymbols;
 			break;
 		case VK_SPACE:
-			debugger->toggleBreakpoint(curAddress);
+			{
+				u32 toggleAddress = curAddress;
+				Core_RunOnCPUThread([&] { debugger->toggleBreakpoint(toggleAddress); });
+			}
 			break;
 		case VK_F3:
 			search(true);
@@ -818,25 +839,34 @@ void CtrlDisAsmView::redraw()
 
 void CtrlDisAsmView::toggleBreakpoint(bool toggleEnabled)
 {
-	bool enabled;
-	if (g_breakpoints.IsAddressBreakPoint(curAddress, &enabled)) {
+	// Route the breakpoint read to the CPU thread instead of poking at it directly from this GUI
+	// thread - see Core_RunOnCPUThread() in Core.h. The possible MessageBox() below is modal, so we
+	// can't just wrap the whole function - figure out what to do first, ask if needed, then mutate.
+	bool exists = false, enabled = false, hasCondition = false;
+	Core_RunOnCPUThread([&] {
+		exists = g_breakpoints.IsAddressBreakPoint(curAddress, &enabled);
+		if (exists)
+			hasCondition = g_breakpoints.GetBreakPointCondition(curAddress) != nullptr;
+	});
+
+	if (exists) {
 		if (!enabled) {
 			// enable disabled breakpoints
-			g_breakpoints.ChangeBreakPoint(curAddress, true);
-		} else if (!toggleEnabled && g_breakpoints.GetBreakPointCondition(curAddress) != nullptr) {
+			Core_RunOnCPUThread([&] { g_breakpoints.ChangeBreakPoint(curAddress, true); });
+		} else if (!toggleEnabled && hasCondition) {
 			// don't just delete a breakpoint with a custom condition
 			int ret = MessageBox(wnd,L"This breakpoint has a custom condition.\nDo you want to remove it?",L"Confirmation",MB_YESNO);
 			if (ret == IDYES)
-				g_breakpoints.RemoveBreakPoint(curAddress);
+				Core_RunOnCPUThread([&] { g_breakpoints.RemoveBreakPoint(curAddress); });
 		} else if (toggleEnabled) {
 			// disable breakpoint
-			g_breakpoints.ChangeBreakPoint(curAddress, false);
+			Core_RunOnCPUThread([&] { g_breakpoints.ChangeBreakPoint(curAddress, false); });
 		} else {
 			// otherwise just remove breakpoint
-			g_breakpoints.RemoveBreakPoint(curAddress);
+			Core_RunOnCPUThread([&] { g_breakpoints.RemoveBreakPoint(curAddress); });
 		}
 	} else {
-		g_breakpoints.AddBreakPoint(curAddress);
+		Core_RunOnCPUThread([&] { g_breakpoints.AddBreakPoint(curAddress); });
 	}
 }
 
@@ -912,13 +942,17 @@ void CtrlDisAsmView::CopyFunctionHash(u32 addr) {
 
 
 void CtrlDisAsmView::NopInstructions(u32 selectRangeStart, u32 selectRangeEnd) {
-	for (u32 addr = selectRangeStart; addr < selectRangeEnd; addr += 4) {
-		Memory::Write_U32(0, addr);
-	}
+	// Route the memory writes to the CPU thread instead of poking at it directly from this GUI
+	// thread - see Core_RunOnCPUThread() in Core.h.
+	Core_RunOnCPUThread([&] {
+		for (u32 addr = selectRangeStart; addr < selectRangeEnd; addr += 4) {
+			Memory::Write_U32(0, addr);
+		}
 
-	if (currentMIPS) {
-		currentMIPS->InvalidateICache(selectRangeStart, selectRangeEnd - selectRangeStart);
-	}
+		if (currentMIPS) {
+			currentMIPS->InvalidateICache(selectRangeStart, selectRangeEnd - selectRangeStart);
+		}
+	});
 }
 
 void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
@@ -970,16 +1004,22 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			break;
 		case ID_DISASM_EDITSYMBOLS:
 			{
+				// esw.exec() is a modal dialog - must stay outside any queued callback, or we'd
+				// block the CPU thread on user input. Only the resulting mutation is routed to the
+				// CPU thread - see Core_RunOnCPUThread() in Core.h.
 				EditSymbolsWindow esw(wnd, debugger);
 				if (esw.exec()) {
-					esw.eval();
+					Core_RunOnCPUThread([&] { esw.eval(); });
 					SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
 					redraw();
 				}
 			}
 			break;
 		case ID_DISASM_SETPCTOHERE:
-			debugger->SetPC(curAddress);
+			{
+				u32 newPC = curAddress;
+				Core_RunOnCPUThread([&] { debugger->SetPC(newPC); });
+			}
 			redraw();
 			break;
 		case ID_DISASM_FOLLOWBRANCH:
@@ -993,18 +1033,29 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			break;
 		case ID_DISASM_RENAMEFUNCTION:
 			{
-				u32 funcBegin = g_symbolMap->GetFunctionStart(curAddress);
+				// Route the symbol map reads/mutations to the CPU thread instead of poking at it
+				// directly from this GUI thread - see Core_RunOnCPUThread() in Core.h.
+				// InputBox_GetString() is modal, so it must stay outside any queued callback, or
+				// we'd block the CPU thread on user input.
+				u32 funcBegin = -1;
+				char name[256] = {0};
+				Core_RunOnCPUThread([&] {
+					funcBegin = g_symbolMap->GetFunctionStart(curAddress);
+					if (funcBegin != -1)
+						truncate_cpy(name, g_symbolMap->GetLabelString(funcBegin));
+				});
+
 				if (funcBegin != -1)
 				{
-					char name[256];
 					std::string newname;
-					truncate_cpy(name, g_symbolMap->GetLabelString(funcBegin));
 					if (InputBox_GetString(MainWindow::GetHInstance(), MainWindow::GetHWND(), L"New function name", name, newname)) {
-						g_symbolMap->SetLabelName(newname.c_str(), funcBegin);
-						u32 funcSize = g_symbolMap->GetFunctionSize(funcBegin);
-						MIPSAnalyst::RegisterFunction(funcBegin, funcSize, newname.c_str());
-						MIPSAnalyst::UpdateHashMap();
-						MIPSAnalyst::ApplyHashMap();
+						Core_RunOnCPUThread([&] {
+							g_symbolMap->SetLabelName(newname.c_str(), funcBegin);
+							u32 funcSize = g_symbolMap->GetFunctionSize(funcBegin);
+							MIPSAnalyst::RegisterFunction(funcBegin, funcSize, newname.c_str());
+							MIPSAnalyst::UpdateHashMap();
+							MIPSAnalyst::ApplyHashMap();
+						});
 						SendMessage(GetParent(wnd),WM_DEB_MAPLOADED,0,0);
 						redraw();
 					}
@@ -1017,25 +1068,37 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			break;
 		case ID_DISASM_REMOVEFUNCTION:
 			{
-				char statusBarTextBuff[256];
-				u32 funcBegin = g_symbolMap->GetFunctionStart(curAddress);
-				if (funcBegin != -1)
-				{
-					u32 prevBegin = g_symbolMap->GetFunctionStart(funcBegin-1);
-					if (prevBegin != -1)
+				// Route the symbol map reads/mutations to the CPU thread instead of poking at it
+				// directly from this GUI thread - see Core_RunOnCPUThread() in Core.h. SendMessage()
+				// must stay outside the lambda: this GUI thread is blocked waiting for the CPU
+				// thread while the lambda runs, so a SendMessage() to one of our own windows from
+				// inside it would deadlock.
+				bool found = false;
+				Core_RunOnCPUThread([&] {
+					u32 funcBegin = g_symbolMap->GetFunctionStart(curAddress);
+					if (funcBegin != -1)
 					{
-						u32 expandedSize = g_symbolMap->GetFunctionSize(prevBegin) + g_symbolMap->GetFunctionSize(funcBegin);
-						g_symbolMap->SetFunctionSize(prevBegin,expandedSize);
-					}
-					
-					g_symbolMap->RemoveFunction(funcBegin,true);
-					g_symbolMap->SortSymbols();
-					g_disassemblyManager.clear();
+						found = true;
+						u32 prevBegin = g_symbolMap->GetFunctionStart(funcBegin-1);
+						if (prevBegin != -1)
+						{
+							u32 expandedSize = g_symbolMap->GetFunctionSize(prevBegin) + g_symbolMap->GetFunctionSize(funcBegin);
+							g_symbolMap->SetFunctionSize(prevBegin,expandedSize);
+						}
 
+						g_symbolMap->RemoveFunction(funcBegin,true);
+						g_symbolMap->SortSymbols();
+						g_disassemblyManager.clear();
+					}
+				});
+
+				if (found)
+				{
 					SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
 				}
 				else
 				{
+					char statusBarTextBuff[256];
 					snprintf(statusBarTextBuff,256, "WARNING: unable to find function symbol here");
 					SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
 				}
@@ -1044,39 +1107,49 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			break;
 		case ID_DISASM_ADDFUNCTION:
 			{
-				char statusBarTextBuff[256];
-				u32 prevBegin = g_symbolMap->GetFunctionStart(curAddress);
-				if (prevBegin != -1)
-				{
-					if (prevBegin == curAddress)
+				// Same SendMessage-must-stay-outside-the-lambda reasoning as ID_DISASM_REMOVEFUNCTION
+				// above.
+				bool alreadyExists = false;
+				Core_RunOnCPUThread([&] {
+					u32 prevBegin = g_symbolMap->GetFunctionStart(curAddress);
+					if (prevBegin != -1)
 					{
-						snprintf(statusBarTextBuff,256, "WARNING: There's already a function entry point at this adress");
-						SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
+						if (prevBegin == curAddress)
+						{
+							alreadyExists = true;
+						}
+						else
+						{
+							char symname[128];
+							u32 prevSize = g_symbolMap->GetFunctionSize(prevBegin);
+							u32 newSize = curAddress-prevBegin;
+							g_symbolMap->SetFunctionSize(prevBegin,newSize);
+
+							newSize = prevSize-newSize;
+							snprintf(symname,128,"u_un_%08X",curAddress);
+							g_symbolMap->AddFunction(symname,curAddress,newSize);
+							g_symbolMap->SortSymbols();
+							g_disassemblyManager.clear();
+						}
 					}
 					else
 					{
 						char symname[128];
-						u32 prevSize = g_symbolMap->GetFunctionSize(prevBegin);
-						u32 newSize = curAddress-prevBegin;
-						g_symbolMap->SetFunctionSize(prevBegin,newSize);
-
-						newSize = prevSize-newSize;
-						snprintf(symname,128,"u_un_%08X",curAddress);
-						g_symbolMap->AddFunction(symname,curAddress,newSize);
+						int newSize = selectRangeEnd - selectRangeStart;
+						snprintf(symname, 128, "u_un_%08X", selectRangeStart);
+						g_symbolMap->AddFunction(symname, selectRangeStart, newSize);
 						g_symbolMap->SortSymbols();
-						g_disassemblyManager.clear();
-
-						SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
 					}
+				});
+
+				if (alreadyExists)
+				{
+					char statusBarTextBuff[256];
+					snprintf(statusBarTextBuff,256, "WARNING: There's already a function entry point at this adress");
+					SendMessage(GetParent(wnd), WM_DEB_SETSTATUSBARTEXT, 0, (LPARAM) statusBarTextBuff);
 				}
 				else
 				{
-					char symname[128];
-					int newSize = selectRangeEnd - selectRangeStart;
-					snprintf(symname, 128, "u_un_%08X", selectRangeStart);
-					g_symbolMap->AddFunction(symname, selectRangeStart, newSize);
-					g_symbolMap->SortSymbols();
-
 					SendMessage(GetParent(wnd), WM_DEB_MAPLOADED, 0, 0);
 				}
 				redraw();

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -5,6 +5,7 @@
 #include "ext/xxhash.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"
+#include "Core/Core.h"
 #include "Core/System.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
@@ -416,7 +417,7 @@ void CtrlMemView::onKeyDown(WPARAM wParam, LPARAM lParam) {
 }
 
 void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam) {
-	auto memLock = Memory::Lock();
+	Memory::MemoryInitedLock memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
@@ -428,12 +429,10 @@ void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam) {
 		return;
 	}
 
-	bool active = Core_IsActive();
-	if (active)
-		Core_Break(BreakReason::MemoryAccess, curAddress_);
-
+	// Route the actual memory write to the CPU thread instead of poking at it directly from this
+	// GUI thread - see Core_RunOnCPUThread() in Core.h. No need to force the core to pause first.
 	if (asciiSelected_) {
-		Memory::WriteUnchecked_U8((u8)wParam, curAddress_);
+		Core_RunOnCPUThread([&] { Memory::WriteUnchecked_U8((u8)wParam, curAddress_); });
 		ScrollCursor(1, GotoMode::RESET);
 	} else {
 		wParam = tolower(wParam);
@@ -445,17 +444,17 @@ void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam) {
 		if (inputValue >= 0) {
 			int shiftAmount = (1 - selectedNibble_) * 4;
 
-			u8 oldValue = Memory::ReadUnchecked_U8(curAddress_);
-			oldValue &= ~(0xF << shiftAmount);
-			u8 newValue = oldValue | (inputValue << shiftAmount);
-			Memory::WriteUnchecked_U8(newValue, curAddress_);
+			Core_RunOnCPUThread([&] {
+				u8 oldValue = Memory::ReadUnchecked_U8(curAddress_);
+				oldValue &= ~(0xF << shiftAmount);
+				u8 newValue = oldValue | (inputValue << shiftAmount);
+				Memory::WriteUnchecked_U8(newValue, curAddress_);
+			});
 			ScrollCursor(1, GotoMode::RESET);
 		}
 	}
 
 	Reporting::NotifyDebugger();
-	if (active)
-		Core_Resume();
 }
 
 void CtrlMemView::redraw() {

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -181,7 +181,11 @@ void CtrlMemView::onPaint(WPARAM wParam, LPARAM lParam) {
 	if (Achievements::HardcoreModeActive())
 		return;
 
-	auto memLock = Memory::Lock();
+	Memory::MemoryInitedLock memLock = Memory::Lock();
+	// Reading live memory/tracking state here on the GUI thread would otherwise race with the CPU
+	// thread - hold g_frameMutex for the duration of the read, which NativeFrame() also holds
+	// while it's actually touching that state. See g_frameMutex in Core.h.
+	std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 
 	// draw to a bitmap for double buffering
 	PAINTSTRUCT ps;	

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -3,6 +3,7 @@
 #include "Common/System/Display.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Core/Config.h"
+#include "Core/Core.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "Windows/W32Util/ContextMenu.h"
@@ -416,7 +417,11 @@ void CtrlRegisterList::editRegisterValue()
 	}
 
 	char temp[24];
-	u32 val = getSelectedRegValue(temp, 24);
+	// Route the register read/mutation to the CPU thread instead of poking at it directly from
+	// this GUI thread - see Core_RunOnCPUThread() in Core.h. InputBox_GetString() is modal, so it
+	// must stay outside any queued callback, or we'd block the CPU thread on user input.
+	u32 val = 0;
+	Core_RunOnCPUThread([&] { val = getSelectedRegValue(temp, 24); });
 	int reg = selection;
 
 	std::string value = temp;
@@ -424,22 +429,24 @@ void CtrlRegisterList::editRegisterValue()
 		if (parseExpression(value.c_str(),cpu,val) == false) {
 			displayExpressionError(wnd);
 		} else {
-			switch (reg)
-			{
-			case REGISTER_PC:
-				cpu->SetPC(val);
-				break;
-			case REGISTER_HI:
-				cpu->SetHi(val);
-				break;
-			case REGISTER_LO:
-				cpu->SetLo(val);
-				break;
-			default:
-				cpu->SetRegValue(category, reg, val);
-				break;
-			}
-			Reporting::NotifyDebugger();
+			Core_RunOnCPUThread([&] {
+				switch (reg)
+				{
+				case REGISTER_PC:
+					cpu->SetPC(val);
+					break;
+				case REGISTER_HI:
+					cpu->SetHi(val);
+					break;
+				case REGISTER_LO:
+					cpu->SetLo(val);
+					break;
+				default:
+					cpu->SetRegValue(category, reg, val);
+					break;
+				}
+				Reporting::NotifyDebugger();
+			});
 			redraw();
 			SendMessage(GetParent(wnd),WM_DEB_UPDATE,0,0);	// registers changed -> disassembly needs to be updated
 		}

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -199,6 +199,14 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 
 	int numRows=rect.bottom/rowHeight;
 
+	// Reading live CPU-thread-owned register state here on the GUI thread would otherwise race
+	// with the CPU thread - hold g_frameMutex for the duration of the read, which NativeFrame()
+	// also holds while it's actually touching that state. See g_frameMutex in Core.h.
+	std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+	// The values are a moving target while the core is running - gray them out rather than trying
+	// to highlight "changes" that are really just noise at that point.
+	bool running = !Core_IsStepping();
+
 	for (int i=0; i<numRows; i++)
 	{
 		int rowY1 = rowHeight*(i+1);
@@ -233,7 +241,7 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 				changedCat0Regs[j] = v != lastCat0Values[j];
 				lastCat0Values[j] = v;
 			}
-			
+
 			changedCat0Regs[REGISTER_PC] = cpu->GetPC() != lastCat0Values[REGISTER_PC];
 			lastCat0Values[REGISTER_PC] = cpu->GetPC();
 			changedCat0Regs[REGISTER_HI] = cpu->GetHi() != lastCat0Values[REGISTER_HI];
@@ -250,12 +258,13 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 		{
 			char temp[256];
 			int temp_len = snprintf(temp, sizeof(temp), "%s", cpu->GetRegName(category, i).c_str());
-			SetTextColor(hdc,0x600000);
+			SetTextColor(hdc, running ? 0x808080 : 0x600000);
 			TextOutA(hdc,17,rowY1,temp,temp_len);
-			SetTextColor(hdc,0x000000);
 
 			cpu->PrintRegValue(category, i, temp, sizeof(temp));
-			if (category == 0 && changedCat0Regs[i])
+			if (running)
+				SetTextColor(hdc, 0x808080);
+			else if (category == 0 && changedCat0Regs[i])
 				SetTextColor(hdc, 0x0000FF);
 			else
 				SetTextColor(hdc,0x004000);
@@ -286,10 +295,12 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 				break;
 			}
 
-			SetTextColor(hdc,0x600000);
+			SetTextColor(hdc, running ? 0x808080 : 0x600000);
 			TextOutA(hdc,17,rowY1,temp,len);
 			len = snprintf(temp, sizeof(temp), "%08X",value);
-			if (changedCat0Regs[i])
+			if (running)
+				SetTextColor(hdc, 0x808080);
+			else if (changedCat0Regs[i])
 				SetTextColor(hdc, 0x0000FF);
 			else
 				SetTextColor(hdc,0x004000);

--- a/Windows/Debugger/CtrlRegisterList.h
+++ b/Windows/Debugger/CtrlRegisterList.h
@@ -28,7 +28,7 @@ class CtrlRegisterList {
 	int category = 0;
 
 	int oldSelection = 0;
-	
+
 	bool selecting = false;
 	bool hasFocus = false;
 	MIPSDebugInterface *cpu = nullptr;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -726,6 +726,10 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 void CDisasm::Show(bool bShow, bool includeToTop) {
 	if (deferredSymbolFill_ && bShow) {
 		if (g_symbolMap) {
+			// Reading the live symbol map here on the GUI thread would otherwise race with the CPU
+			// thread - hold g_frameMutex for the duration of the read, which NativeFrame() also
+			// holds while it's actually touching that state. See g_frameMutex in Core.h.
+			std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 			g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
 			deferredSymbolFill_ = false;
 		}
@@ -735,6 +739,7 @@ void CDisasm::Show(bool bShow, bool includeToTop) {
 
 void CDisasm::NotifyMapLoaded() {
 	if (m_bShowState != SW_HIDE && g_symbolMap) {
+		std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 		g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
 	} else {
 		deferredSymbolFill_ = true;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -206,7 +206,9 @@ void CDisasm::step(CPUStepType stepType) {
 	ptr->setDontRedraw(true);
 	lastTicks_ = CoreTiming::GetTicks();
 
-	Core_RequestCPUStep(stepType, 1);
+	// Route the actual step request to the CPU thread instead of poking at it directly from this
+	// GUI thread - see Core_RunOnCPUThread() in Core.h.
+	Core_RunOnCPUThread([&] { Core_RequestCPUStep(stepType, 1); });
 }
 
 void CDisasm::runToLine() {
@@ -219,7 +221,9 @@ void CDisasm::runToLine() {
 
 	lastTicks_ = CoreTiming::GetTicks();
 	ptr->setDontRedraw(true);
-	breakpoints_->AddBreakPoint(pos,true);
+	// Route the breakpoint mutation to the CPU thread instead of poking at it directly from this
+	// GUI thread - see Core_RunOnCPUThread() in Core.h. Core_Resume() itself is free-threaded.
+	Core_RunOnCPUThread([&] { breakpoints_->AddBreakPoint(pos,true); });
 	Core_Resume();
 }
 
@@ -294,17 +298,16 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 					CtrlDisAsmView *view = DisAsmView();
 					keepStatusBarText = true;
 					view->LockPosition();
-					bool isRunning = Core_IsActive();
-					if (isRunning) {
-						Core_Break(BreakReason::AddBreakpoint, 0);
-						Core_WaitInactive();
-					}
 
 					BreakpointWindow bpw(m_hDlg,cpu);
-					if (bpw.exec()) bpw.addBreakpoint();
+					if (bpw.exec()) {
+						// Route the actual breakpoint mutation to the CPU thread instead of poking
+						// at it directly from this GUI thread - see Core_RunOnCPUThread() in
+						// Core.h. No need to force the core to pause first: Core_RunOnCPUThread()
+						// runs the callback whether the CPU is running or already stepping.
+						Core_RunOnCPUThread([&] { bpw.addBreakpoint(); });
+					}
 
-					if (isRunning)
-						Core_Resume();
 					view->UnlockPosition();
 					keepStatusBarText = false;
 				}
@@ -422,7 +425,10 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 						break;
 					lastTicks_ = CoreTiming::GetTicks();
 
-					hleDebugBreak();
+					// Route the actual HLE-break mutation to the CPU thread instead of poking at
+					// it directly from this GUI thread - see Core_RunOnCPUThread() in Core.h.
+					// Core_Resume() itself is free-threaded.
+					Core_RunOnCPUThread([&] { hleDebugBreak(); });
 					Core_Resume();
 				}
 				break;

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -11,6 +11,7 @@
 #include "Windows/resource.h"
 #include "Windows/main.h"
 #include "Common/Data/Encoding/Utf8.h"
+#include "Core/Core.h"
 #include "Core/HLE/sceKernelThread.h"
 
 enum { TL_NAME, TL_PROGRAMCOUNTER, TL_ENTRYPOINT, TL_PRIORITY, TL_STATE, TL_WAITTYPE, TL_COLUMNCOUNT };
@@ -148,11 +149,19 @@ void CtrlThreadList::showMenu(int itemIndex, const POINT &pt)
 	switch (TriggerContextMenu(ContextMenuID::THREADLIST, GetHandle(), ContextPoint::FromClient(pt)))
 	{
 	case ID_DISASM_THREAD_FORCERUN:
-		__KernelResumeThreadFromWait(threadInfo.id, 0);
+		{
+			// Route the actual thread-state mutation to the CPU thread instead of poking at it
+			// directly from this GUI thread - see Core_RunOnCPUThread() in Core.h.
+			SceUID threadID = threadInfo.id;
+			Core_RunOnCPUThread([&] { __KernelResumeThreadFromWait(threadID, 0); });
+		}
 		reloadThreads();
 		break;
 	case ID_DISASM_THREAD_KILL:
-		sceKernelTerminateThread(threadInfo.id);
+		{
+			SceUID threadID = threadInfo.id;
+			Core_RunOnCPUThread([&] { sceKernelTerminateThread(threadID); });
+		}
 		reloadThreads();
 		break;
 	}
@@ -342,6 +351,9 @@ void CtrlBreakpointList::editBreakpoint(int itemIndex)
 	int index = getBreakpointIndex(itemIndex, isMemory);
 	if (index == -1) return;
 
+	// Route the breakpoint mutation to the CPU thread instead of poking at it directly from this
+	// GUI thread - see Core_RunOnCPUThread() in Core.h. win.exec() is a modal dialog, so it must
+	// stay outside any queued callback, or we'd block the CPU thread on user input.
 	BreakpointWindow win(GetHandle(),cpu);
 	if (isMemory)
 	{
@@ -349,16 +361,20 @@ void CtrlBreakpointList::editBreakpoint(int itemIndex)
 		win.loadFromMemcheck(mem);
 		if (win.exec())
 		{
-			g_breakpoints.RemoveMemCheck(mem.start,mem.end);
-			win.addBreakpoint();
+			Core_RunOnCPUThread([&] {
+				g_breakpoints.RemoveMemCheck(mem.start,mem.end);
+				win.addBreakpoint();
+			});
 		}
 	} else {
 		auto bp = displayedBreakPoints_[index];
 		win.loadFromBreakpoint(bp);
 		if (win.exec())
 		{
-			g_breakpoints.RemoveBreakPoint(bp.addr);
-			win.addBreakpoint();
+			Core_RunOnCPUThread([&] {
+				g_breakpoints.RemoveBreakPoint(bp.addr);
+				win.addBreakpoint();
+			});
 		}
 	}
 }
@@ -369,12 +385,14 @@ void CtrlBreakpointList::toggleEnabled(int itemIndex)
 	int index = getBreakpointIndex(itemIndex, isMemory);
 	if (index == -1) return;
 
+	// Route the breakpoint mutation to the CPU thread instead of poking at it directly from this
+	// GUI thread - see Core_RunOnCPUThread() in Core.h.
 	if (isMemory) {
 		MemCheck mcPrev = displayedMemChecks_[index];
-		g_breakpoints.ChangeMemCheck(mcPrev.start, mcPrev.end, mcPrev.cond, BreakAction(mcPrev.result ^ BREAK_ACTION_PAUSE));
+		Core_RunOnCPUThread([&] { g_breakpoints.ChangeMemCheck(mcPrev.start, mcPrev.end, mcPrev.cond, BreakAction(mcPrev.result ^ BREAK_ACTION_PAUSE)); });
 	} else {
 		BreakPoint bpPrev = displayedBreakPoints_[index];
-		g_breakpoints.ChangeBreakPoint(bpPrev.addr, BreakAction(bpPrev.result ^ BREAK_ACTION_PAUSE));
+		Core_RunOnCPUThread([&] { g_breakpoints.ChangeBreakPoint(bpPrev.addr, BreakAction(bpPrev.result ^ BREAK_ACTION_PAUSE)); });
 	}
 }
 
@@ -404,12 +422,14 @@ void CtrlBreakpointList::removeBreakpoint(int itemIndex)
 	int index = getBreakpointIndex(itemIndex,isMemory);
 	if (index == -1) return;
 
+	// Route the breakpoint mutation to the CPU thread instead of poking at it directly from this
+	// GUI thread - see Core_RunOnCPUThread() in Core.h.
 	if (isMemory) {
 		auto mc = displayedMemChecks_[index];
-		g_breakpoints.RemoveMemCheck(mc.start, mc.end);
+		Core_RunOnCPUThread([&] { g_breakpoints.RemoveMemCheck(mc.start, mc.end); });
 	} else {
 		u32 address = displayedBreakPoints_[index].addr;
-		g_breakpoints.RemoveBreakPoint(address);
+		Core_RunOnCPUThread([&] { g_breakpoints.RemoveBreakPoint(address); });
 	}
 }
 
@@ -583,8 +603,12 @@ void CtrlBreakpointList::showBreakpointMenu(int itemIndex, const POINT &pt)
 		{
 		case ID_DISASM_ADDNEWBREAKPOINT:
 			{		
+				// bpw.exec() is a modal dialog - must stay outside any queued callback, or we'd
+				// block the CPU thread on user input - see Core_RunOnCPUThread() in Core.h.
 				BreakpointWindow bpw(GetHandle(),cpu);
-				if (bpw.exec()) bpw.addBreakpoint();
+				if (bpw.exec()) {
+					Core_RunOnCPUThread([&] { bpw.addBreakpoint(); });
+				}
 			}
 			break;
 		}
@@ -607,10 +631,12 @@ void CtrlBreakpointList::showBreakpointMenu(int itemIndex, const POINT &pt)
 		switch (TriggerContextMenu(ContextMenuID::BREAKPOINTLIST, GetHandle(), ContextPoint::FromClient(pt)))
 		{
 		case ID_DISASM_DISABLEBREAKPOINT:
+			// Route the breakpoint mutation to the CPU thread instead of poking at it directly
+			// from this GUI thread - see Core_RunOnCPUThread() in Core.h.
 			if (isMemory) {
-				g_breakpoints.ChangeMemCheck(mcPrev.start, mcPrev.end, mcPrev.cond, BreakAction(mcPrev.result ^ BREAK_ACTION_PAUSE));
+				Core_RunOnCPUThread([&] { g_breakpoints.ChangeMemCheck(mcPrev.start, mcPrev.end, mcPrev.cond, BreakAction(mcPrev.result ^ BREAK_ACTION_PAUSE)); });
 			} else {
-				g_breakpoints.ChangeBreakPoint(bpPrev.addr, BreakAction(bpPrev.result ^ BREAK_ACTION_PAUSE));
+				Core_RunOnCPUThread([&] { g_breakpoints.ChangeBreakPoint(bpPrev.addr, BreakAction(bpPrev.result ^ BREAK_ACTION_PAUSE)); });
 			}
 			break;
 		case ID_DISASM_EDITBREAKPOINT:
@@ -618,8 +644,12 @@ void CtrlBreakpointList::showBreakpointMenu(int itemIndex, const POINT &pt)
 			break;
 		case ID_DISASM_ADDNEWBREAKPOINT:
 			{		
+				// bpw.exec() is a modal dialog - must stay outside any queued callback, or we'd
+				// block the CPU thread on user input - see Core_RunOnCPUThread() in Core.h.
 				BreakpointWindow bpw(GetHandle(),cpu);
-				if (bpw.exec()) bpw.addBreakpoint();
+				if (bpw.exec()) {
+					Core_RunOnCPUThread([&] { bpw.addBreakpoint(); });
+				}
 			}
 			break;
 		case ID_DISASM_DELETEBREAKPOINT:

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -255,7 +255,13 @@ void CtrlThreadList::OnRightClick(int itemIndex, int column, const POINT& point)
 
 void CtrlThreadList::reloadThreads()
 {
-	threads = GetThreadsInfo();
+	// Reading live kernel thread state here on the GUI thread would otherwise race with the CPU
+	// thread - hold g_frameMutex for the duration of the read, which NativeFrame() also holds
+	// while it's actually touching that state. See g_frameMutex in Core.h.
+	{
+		std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+		threads = GetThreadsInfo();
+	}
 	Update();
 }
 
@@ -325,9 +331,13 @@ bool CtrlBreakpointList::WindowMessage(UINT msg, WPARAM wParam, LPARAM lParam, L
 
 void CtrlBreakpointList::reloadBreakpoints()
 {
-	// Update the items we're displaying from the debugger.
-	displayedBreakPoints_ = g_breakpoints.GetBreakpoints();
-	displayedMemChecks_= g_breakpoints.GetMemChecks();
+	// Update the items we're displaying from the debugger. g_frameMutex guards this against races
+	// with the CPU thread - see g_frameMutex in Core.h.
+	{
+		std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+		displayedBreakPoints_ = g_breakpoints.GetBreakpoints();
+		displayedMemChecks_= g_breakpoints.GetMemChecks();
+	}
 
 	for (int i = 0; i < GetRowCount(); i++)
 	{
@@ -744,11 +754,16 @@ void CtrlStackTraceView::OnDoubleClick(int itemIndex, int column)
 }
 
 void CtrlStackTraceView::loadStackTrace() {
-	auto memLock = Memory::Lock();
+	Memory::MemoryInitedLock memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
-	auto threads = GetThreadsInfo();
+	// Reading live thread/register/stack state here on the GUI thread would otherwise race with
+	// the CPU thread - hold g_frameMutex for the duration of the read, which NativeFrame() also
+	// holds while it's actually touching that state. See g_frameMutex in Core.h.
+	std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+
+	std::vector<DebugThreadInfo> threads = GetThreadsInfo();
 
 	u32 entry = 0, stackTop = 0;
 	for (size_t i = 0; i < threads.size(); i++)
@@ -835,10 +850,16 @@ void CtrlModuleList::OnDoubleClick(int itemIndex, int column)
 
 void CtrlModuleList::loadModules()
 {
-	if (g_symbolMap) {
-		modules = g_symbolMap->getAllModules();
-	} else {
-		modules.clear();
+	// Reading the live symbol map here on the GUI thread would otherwise race with the CPU thread -
+	// hold g_frameMutex for the duration of the read, which NativeFrame() also holds while it's
+	// actually touching that state. See g_frameMutex in Core.h.
+	{
+		std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+		if (g_symbolMap) {
+			modules = g_symbolMap->getAllModules();
+		} else {
+			modules.clear();
+		}
 	}
 	Update();
 }
@@ -855,6 +876,11 @@ CtrlWatchList::CtrlWatchList(HWND hwnd, DebugInterface *cpu)
 }
 
 void CtrlWatchList::RefreshValues() {
+	// Evaluating watch expressions reads live registers/memory here on the GUI thread, which would
+	// otherwise race with the CPU thread - hold g_frameMutex for the duration, which NativeFrame()
+	// also holds while it's actually touching that state. See g_frameMutex in Core.h.
+	std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+
 	int steppingCounter = Core_GetSteppingCounter();
 	int changes = false;
 	for (auto &watch : watches_) {

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -6,6 +6,7 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/System/Display.h"
 
+#include "Core/Core.h"
 #include "Core/Debugger/MemBlockInfo.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
@@ -131,10 +132,15 @@ void CMemoryDlg::searchBoxRedraw(const std::vector<u32> &results) {
 
 
 void CMemoryDlg::NotifyMapLoaded() {
-	if (m_hDlg && g_symbolMap)
+	if (m_hDlg && g_symbolMap) {
+		// Reading the live symbol map here on the GUI thread would otherwise race with the CPU
+		// thread - hold g_frameMutex for the duration of the read, which NativeFrame() also holds
+		// while it's actually touching that state. See g_frameMutex in Core.h.
+		std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 		g_symbolMap->FillSymbolListBox(symListHdl, ST_DATA);
-	else
+	} else {
 		mapLoadPending_ = true;
+	}
 	Update();
 }
 
@@ -221,6 +227,7 @@ BOOL CMemoryDlg::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 
 	case WM_DEB_UPDATE:
 		if (mapLoadPending_ && m_hDlg && g_symbolMap) {
+			std::lock_guard<std::mutex> frameGuard(g_frameMutex);
 			g_symbolMap->FillSymbolListBox(symListHdl, ST_DATA);
 			mapLoadPending_ = false;
 		}

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -80,49 +80,51 @@ INT_PTR CALLBACK DumpMemoryWindow::dlgFunc(HWND hwnd, UINT iMsg, WPARAM wParam, 
 			break;
 		case IDOK:
 			if (bp->fetchDialogData(hwnd)) {
-				bool priorDumpWasStepping = Core_IsStepping();
-				if (!priorDumpWasStepping && PSP_IsInited()) {
-					// If emulator isn't paused force paused state, but wait before locking.
-					Core_Break(BreakReason::MemoryAccess, bp->start);
-					Core_WaitInactive();
-				}
+				bool includeReplacements = SendMessage(GetDlgItem(hwnd, IDC_DUMP_INCLUDEHACKS), BM_GETCHECK, 0, 0) != 0;
 
-				auto memLock = Memory::Lock();
-				if (!PSP_IsInited())
-					break;
+				// Route the actual memory dump to the CPU thread instead of forcing the emulator
+				// to pause and poking at it directly from this GUI thread - see
+				// Core_RunOnCPUThread() in Core.h. MessageBoxA() is modal, so it stays outside the
+				// queued callback.
+				enum class Outcome { NotInited, OpenFailed, Success } outcome = Outcome::NotInited;
+				Core_RunOnCPUThread([&] {
+					Memory::MemoryInitedLock memLock = Memory::Lock();
+					if (!PSP_IsInited())
+						return;
 
-				FILE *output = _wfopen(bp->fileName_.c_str(), L"wb");
-				if (output == nullptr) {
+					FILE *output = _wfopen(bp->fileName_.c_str(), L"wb");
+					if (output == nullptr) {
+						outcome = Outcome::OpenFailed;
+						return;
+					}
+
+					if (includeReplacements) {
+						fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
+					} else {
+						auto savedReplacements = SaveAndClearReplacements();
+						std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+						if (MIPSComp::jit) {
+							auto savedBlocks = MIPSComp::jit->SaveAndClearEmuHackOps();
+							fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
+							MIPSComp::jit->RestoreSavedEmuHackOps(savedBlocks);
+						} else {
+							fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
+						}
+						RestoreSavedReplacements(savedReplacements);
+					}
+
+					fclose(output);
+					outcome = Outcome::Success;
+				});
+
+				if (outcome == Outcome::OpenFailed) {
 					char errorMessage[2048];
 					snprintf(errorMessage, sizeof(errorMessage), "Could not open file \"%S\".", bp->fileName_.c_str());
 					MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
-					break;
+				} else if (outcome == Outcome::Success) {
+					MessageBoxA(hwnd, "Done.", "Information", MB_OK);
+					EndDialog(hwnd, true);
 				}
-
-				bool includeReplacements = SendMessage(GetDlgItem(hwnd, IDC_DUMP_INCLUDEHACKS), BM_GETCHECK, 0, 0) != 0;
-				if (includeReplacements) {
-					fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
-				} else {
-					auto savedReplacements = SaveAndClearReplacements();
-					std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-					if (MIPSComp::jit) {
-						auto savedBlocks = MIPSComp::jit->SaveAndClearEmuHackOps();
-						fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
-						MIPSComp::jit->RestoreSavedEmuHackOps(savedBlocks);
-					} else {
-						fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
-					}
-					RestoreSavedReplacements(savedReplacements);
-				}
-
-				fclose(output);
-				if (!priorDumpWasStepping) {
-					// If emulator wasn't paused before memory dump resume emulation automatically.
-					Core_Resume();
-				}
-
-				MessageBoxA(hwnd, "Done.", "Information", MB_OK);
-				EndDialog(hwnd, true);
 			}
 			break;
 		case IDCANCEL:

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -725,8 +725,12 @@ namespace MainWindow {
 			{
 				return 0;
 			}
-			// Get all modules from symbol map
-			auto modules = g_symbolMap->getAllModules();
+			// Get all modules from symbol map. Reading it here on the GUI thread would otherwise
+			// race with the CPU thread - hold g_frameMutex for the duration of the read, which
+			// NativeFrame() also holds while it's actually touching that state. See g_frameMutex
+			// in Core.h.
+			std::lock_guard<std::mutex> frameGuard(g_frameMutex);
+			std::vector<LoadedModuleInfo> modules = g_symbolMap->getAllModules();
 			for (const auto& module : modules)
 			{
 				if (module.name == moduleName)

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -769,34 +769,41 @@ namespace MainWindow {
 			break;
 		}
 
+		// g_symbolMap access below is routed through Core_RunOnCPUThread() instead of poking at it
+		// directly from this GUI thread - see Core_RunOnCPUThread() in Core.h. The file-browse
+		// dialogs are modal, so they stay outside the queued callback; NotifyDebuggerMapLoaded()
+		// also stays outside, since it locks g_frameMutex internally (CDisasm/CMemoryDlg's
+		// NotifyMapLoaded()) and Core_RunOnCPUThread's queue can be drained from inside a
+		// g_frameMutex-locked NativeFrame() span, so calling it from within the lambda could
+		// deadlock.
 		case ID_DEBUG_LOADMAPFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .ppmap", nullptr, nullptr, L"Maps\0*.ppmap\0All files\0*.*\0\0", L"ppmap", fn)) {
-				g_symbolMap->LoadSymbolMap(Path(fn));
+				Core_RunOnCPUThread([&] { g_symbolMap->LoadSymbolMap(Path(fn)); });
 				NotifyDebuggerMapLoaded();
 			}
 			break;
 
 		case ID_DEBUG_SAVEMAPFILE:
 			if (W32Util::BrowseForFileName(false, hWnd, L"Save .ppmap", nullptr, L"map.ppmap", L"Maps\0*.ppmap\0All files\0*.*\0\0", L"ppmap", fn)) {
-				g_symbolMap->SaveSymbolMap(Path(fn));
+				Core_RunOnCPUThread([&] { g_symbolMap->SaveSymbolMap(Path(fn)); });
 			}
 			break;
 
 		case ID_DEBUG_LOADSYMFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .sym", nullptr, nullptr, L"Symbols\0*.sym\0All files\0*.*\0\0", L"sym", fn)) {
-				g_symbolMap->LoadNocashSym(Path(fn));
+				Core_RunOnCPUThread([&] { g_symbolMap->LoadNocashSym(Path(fn)); });
 				NotifyDebuggerMapLoaded();
 			}
 			break;
 
 		case ID_DEBUG_SAVESYMFILE:
 			if (W32Util::BrowseForFileName(false, hWnd, L"Save .sym", nullptr, L"symbols.sym", L"Symbols\0*.sym\0All files\0*.*\0\0", L"sym", fn)) {
-				g_symbolMap->SaveNocashSym(Path(fn));
+				Core_RunOnCPUThread([&] { g_symbolMap->SaveNocashSym(Path(fn)); });
 			}
 			break;
 
 		case ID_DEBUG_RESETSYMBOLTABLE:
-			g_symbolMap->Clear();
+			Core_RunOnCPUThread([&] { g_symbolMap->Clear(); });
 			NotifyDebuggerMapLoaded();
 			break;
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -508,7 +508,7 @@ void System_Notify(SystemNotification notification) {
 	case SystemNotification::BOOT_DONE:
 	{
 		if (g_symbolMap)
-			g_symbolMap->SortSymbols();  // internal locking is performed here
+			g_symbolMap->SortSymbols();  // Always fired from the CPU/NativeFrame thread, see AGENTS.md
 		PostMessage(MainWindow::GetHWND(), WM_USER + 1, 0, 0);
 
 		if (Achievements::HardcoreModeActive()) {
@@ -548,7 +548,7 @@ void System_Notify(SystemNotification notification) {
 
 	case SystemNotification::SYMBOL_MAP_UPDATED:
 		if (g_symbolMap)
-			g_symbolMap->SortSymbols();  // internal locking is performed here
+			g_symbolMap->SortSymbols();  // Always fired from the CPU/NativeFrame thread, see AGENTS.md
 		PostMessage(MainWindow::GetHWND(), WM_USER + 1, 0, 0);
 		break;
 


### PR DESCRIPTION
This eliminates the need to have a lot of ugly locking in BreakpointManager and SymbolMap which both are very awkward and risky to change currently, but will now be easier to deal with.

Followup to #22051 , also made in cooperation with Claude. This took some detailed steering, certainly not automatic at all, but having it do all the mechanical work at least was great.