### PR TITLE
Extracted ISOs: Fix savedata size not showing on the game info screen

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -774,6 +774,7 @@ handleELF:
 						std::lock_guard<std::mutex> lock(info_->lock);
 						info_->paramSFO.ReadSFO((const u8 *)paramSFOcontents.data(), paramSFOcontents.size());
 						info_->ParseParamSFO(info_->fileType);
+						info_->MarkReadyNoLock(GameInfoFlags::PARAM_SFO);
 					}
 				}
 


### PR DESCRIPTION
In `GameInfoWorkItem::Run()`,
`PSP_DISC_DIRECTORY` was the only `IdentifiedFileType` with possible `PARAM.SFO` that didn't mark `PARAM_SFO` ready inside the switch,
causing `GetSaveDataDirectories` to bail out and return an empty vector, with the following error logs:
```
E[UI]: UI\GameInfoCache.cpp:255 Can't get savedata directories if we don't have PARAM_SFO.
E[UI]: UI\GameInfoCache.cpp:255 Can't get savedata directories if we don't have PARAM_SFO.
```
one from `GetGameSavedataSizeInBytes` and the other from `GetInstallDataSizeInBytes`, called in the `if (flags_ & GameInfoFlags::SAVEDATA_SIZE)` branch,
which caused and the game info UI to show no savedata size info.
