### PR TITLE
Fix assembly/disassembly for various VFPU opcodes

### DIFF
--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -305,19 +305,24 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		int ins = (op>>23) & 7;
-		VectorSize sz = GetVecSize(op);
-		MatrixSize msz = GetMtxSize(op);
+		// irregular opcode
+		// vec/mtx size stored in bits 23 & 24 instead of 7 & 15
+		int d = (op>>23) & 3;
+		MIPSOpcode dummyOp = MIPSOpcode{(op & 0xFFFF7F7F) | ((d & 2) << 14) | ((d & 1) << 7)};
+		VectorSize sz = GetVecSize(dummyOp);
+		MatrixSize msz = GetMtxSize(dummyOp);
 		int n = GetNumVectorElements(sz);
-
-		if (n == ins)
+		// instead, bits 7 & 15 indicate the type of transform
+		// for homogeneous transforms, this is one less than sz
+		VectorSize tsz = GetVecSize(op);
+		if (tsz + 1 == sz)
 		{
 			//homogenous
-			snprintf(out, outSize, "vhtfm%i%s\t%s, %s, %s", n, VSuff(op), VN(vd, sz), MN(vs, msz), VN(vt, sz));
+			snprintf(out, outSize, "vhtfm%i%s\t%s, %s, %s", n, VSuff(dummyOp), VN(vd, sz), MN(vs, msz), VN(vt, sz));
 		}
-		else if (n == ins+1)
+		else if (tsz == sz)
 		{
-			snprintf(out, outSize, "vtfm%i%s\t%s, %s, %s", n, VSuff(op), VN(vd, sz), MN(vs, msz), VN(vt, sz));
+			snprintf(out, outSize, "vtfm%i%s\t%s, %s, %s", n, VSuff(dummyOp), VN(vd, sz), MN(vs, msz), VN(vt, sz));
 		}
 		else
 		{
@@ -467,14 +472,6 @@ namespace MIPSDis
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), VN(vd, sz), VN(vs,sz), VN(vt, sz));
 	}
 
-	void Dis_Vbfy(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSize(op);
-		int vd = _VD;
-		int vs = _VS;
-		const char *name = MIPSGetName(op);
-		snprintf(out, outSize, "%s%s\t%s, %s", name, VSuff(op), VN(vd, sz), VN(vs, sz));
-	}
-
 	void Dis_Vf2i(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		VectorSize sz = GetVecSize(op);
 		int vd = _VD;
@@ -489,6 +486,11 @@ namespace MIPSDis
 		int vs = _VS;
 		const char *name = MIPSGetName(op);
 		snprintf(out, outSize, "%s%s\t%s, %s", name, VSuff(op), VN(vd, dsz), VN(vs, sz));
+	}
+
+	void Dis_Vbfy(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
+		VectorSize sz = GetVecSize(op);
+		Dis_Vx2i(op, pc, out, outSize, sz, sz);
 	}
 
 	void Dis_Vc2i(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -732,7 +732,7 @@ static const MIPSInstruction tableVFPU9[32] = // 110100 00010 xxxxx . ....... . 
 	INSTR("vbfy2", JITFUNC(Comp_Vbfy), Dis_Vbfy, Int_Vbfy, IN_OTHER|OUT_OTHER|IS_VFPU|OUT_EAT_PREFIX),
 	//4
 	INSTR("vocp", JITFUNC(Comp_Vocp), Dis_Vbfy, Int_Vocp, IN_OTHER|OUT_OTHER|IS_VFPU|OUT_EAT_PREFIX),  // one's complement
-	INSTR("vsocp", JITFUNC(Comp_Generic), Dis_Vbfy, Int_Vsocp, IN_OTHER|OUT_OTHER|IS_VFPU|OUT_EAT_PREFIX),
+	INSTR("vsocp", JITFUNC(Comp_Generic), Dis_Vs2i, Int_Vsocp, IN_OTHER|OUT_OTHER|IS_VFPU|OUT_EAT_PREFIX),
 	INSTR("vfad", JITFUNC(Comp_Vhoriz), Dis_Vfad, Int_Vfad, IN_OTHER|OUT_OTHER|IS_VFPU|OUT_EAT_PREFIX),
 	INSTR("vavg", JITFUNC(Comp_Vhoriz), Dis_Vfad, Int_Vavg, IN_OTHER|OUT_OTHER|IS_VFPU|OUT_EAT_PREFIX),
 	//8


### PR DESCRIPTION
Update armips for VFPU instruction parsing changes (Kingcom/armips#257)
- fix transposed matrix register encodings (e.g. `vmidt.p E220` was assembling to `vmidt.p E202`)
- fix immediate size for `vwbn.s` (is 8 bits, was limited to 5 bits)
- fix `vd` register size for `vsocp.s/p`
- fix `vhtfm2.p` and `vhtfm3.t` encoding
- add missing instruction `vhtfm4.q`

Fix `v(h)tfmX` disassembly (handle irregular vector size encoding)

Fix `vsocp.s/p` disassembly (`vd` is double the size of `vs`)

Identified & verified these changes by running the VFPU binaries pspautotests through a websocket API script asserting `assemble(op) == assemble(disassemble(op))`. 