### PR TITLE
Remove irrelevant stuff from the Windows makefile libretro build.

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -517,18 +517,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/Thread/ThreadUtil.cpp \
 	$(COMMONDIR)/Thread/ParallelLoop.cpp \
 	$(COMMONDIR)/Thread/ThreadManager.cpp \
-	$(COMMONDIR)/UI/AsyncImageFileView.cpp \
-	$(COMMONDIR)/UI/Root.cpp \
-	$(COMMONDIR)/UI/Screen.cpp \
-	$(COMMONDIR)/UI/UI.cpp \
-	$(COMMONDIR)/UI/Context.cpp \
-	$(COMMONDIR)/UI/UIScreen.cpp \
-	$(COMMONDIR)/UI/Notice.cpp \
-	$(COMMONDIR)/UI/Tween.cpp \
 	$(COMMONDIR)/UI/IconCache.cpp \
-	$(COMMONDIR)/UI/View.cpp \
-	$(COMMONDIR)/UI/ViewGroup.cpp \
-	$(COMMONDIR)/UI/ScrollView.cpp \
 	$(COMMONDIR)/System/Display.cpp \
 	$(COMMONDIR)/System/Request.cpp \
 	$(COMMONDIR)/System/OSD.cpp \


### PR DESCRIPTION
Fixes #22081 , hopefully.