### PR TITLE
Debugger: Add a whole bunch of features that Claude wanted for an investigation. Fix multiple bugs

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -307,6 +307,8 @@ add_library(Core STATIC
 	Debugger/WebSocket/ClientConfigSubscriber.h
 	Debugger/WebSocket/GPUBufferSubscriber.cpp
 	Debugger/WebSocket/GPUBufferSubscriber.h
+	Debugger/WebSocket/GPUDisasmSubscriber.cpp
+	Debugger/WebSocket/GPUDisasmSubscriber.h
 	Debugger/WebSocket/GPURecordSubscriber.cpp
 	Debugger/WebSocket/GPURecordSubscriber.h
 	Debugger/WebSocket/GPUStatsSubscriber.cpp

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -213,6 +213,7 @@ const char *BreakReasonToString(BreakReason reason) {
 	case BreakReason::SavestateCrash: return "savestate.crash";
 	case BreakReason::MemoryBreakpoint: return "memory.breakpoint";
 	case BreakReason::CpuBreakpoint: return "cpu.breakpoint";
+	case BreakReason::GPRBreakpoint: return "cpu.gprBreakpoint";
 	case BreakReason::MemoryAccess: return "memory.access";  // ???
 	case BreakReason::JitBranchDebug: return "jit.branchdebug";
 	case BreakReason::RABreak: return "ra.break";

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -793,12 +793,45 @@ void Core_MemoryExceptionHLE(MIPSState *mips, u32 address, u32 accessSize, Memor
 	}
 }
 
-// Can't be ignored, must break. Not sure we can get a meaningful stack trace here (since the PC is invalid).
+// Can't be ignored, must break. If JUMP, not sure we can get a meaningful stack trace here (since the PC is invalid).
+// address != pc when this is called for a jump instruction. pc then is the source address of the jump.
 void Core_ExecException(u32 address, u32 pc, ExecExceptionType type) {
 	const char *desc = ExecExceptionTypeAsString(type);
 
+	char pcStr[32] = "(invalid)";
+	if (Memory::IsValid4AlignedAddress(pc)) {
+		snprintf(pcStr, sizeof(pcStr), "[%08x]", Memory::ReadUnchecked_U32(pc));
+	}
+
 	char msg[512];
-	snprintf(msg, sizeof(msg), "%s: Invalid exec address %08x%s pc=%08x%s ra=%08x%s", desc, address, ModuleAddressSuffix(address).c_str(), pc, ModuleAddressSuffix(pc).c_str(), currentMIPS->r[MIPS_REG_RA], ModuleAddressSuffix(currentMIPS->r[MIPS_REG_RA]).c_str());
+	switch (type) {
+	case ExecExceptionType::JUMP:
+	{
+		snprintf(msg, sizeof(msg), "%s: Invalid jump to %08x%s from PC %08x%s %s RA %08x%s", desc, address, ModuleAddressSuffix(address).c_str(),
+			pc, pcStr, ModuleAddressSuffix(pc).c_str(), currentMIPS->r[MIPS_REG_RA], ModuleAddressSuffix(currentMIPS->r[MIPS_REG_RA]).c_str());
+		Core_SendDebugOutput(LogLevel::LERROR, msg);
+		break;
+	}
+	case ExecExceptionType::THREAD:
+	{
+		snprintf(msg, sizeof(msg), "%s: Invalid thread switch to %08x%s from PC %08x%s RA %08x%s", desc, address, ModuleAddressSuffix(address).c_str(),
+			pc, ModuleAddressSuffix(pc).c_str(), currentMIPS->r[MIPS_REG_RA], ModuleAddressSuffix(currentMIPS->r[MIPS_REG_RA]).c_str());
+		Core_SendDebugOutput(LogLevel::LERROR, msg);
+		break;
+	}
+	case ExecExceptionType::ILLEGAL:
+	{
+		snprintf(msg, sizeof(msg), "%s: Illegal instruction at %08x%s %s RA %08x%s", desc,
+			pc, pcStr, ModuleAddressSuffix(pc).c_str(), currentMIPS->r[MIPS_REG_RA], ModuleAddressSuffix(currentMIPS->r[MIPS_REG_RA]).c_str());
+		// For illegal instructions, there might be a useful stack trace.
+		const std::string stackTrace = FormatStackTrace(WalkCurrentStack(-1));
+		Core_SendDebugOutput(LogLevel::LERROR, StringFromFormat("%s\n%s", msg, stackTrace.c_str()));
+		break;
+	}
+	default:
+		truncate_cpy(msg, sizeof(msg), "Unknown exec exception");
+		break;
+	}
 	Core_SendDebugOutput(LogLevel::LERROR, msg);
 
 	MIPSExceptionInfo &e = g_exceptionInfo;

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -213,7 +213,7 @@ const char *BreakReasonToString(BreakReason reason) {
 	case BreakReason::SavestateCrash: return "savestate.crash";
 	case BreakReason::MemoryBreakpoint: return "memory.breakpoint";
 	case BreakReason::CpuBreakpoint: return "cpu.breakpoint";
-	case BreakReason::GPRBreakpoint: return "cpu.gprBreakpoint";
+	case BreakReason::RegBreakpoint: return "cpu.regBreakpoint";
 	case BreakReason::MemoryAccess: return "memory.access";  // ???
 	case BreakReason::JitBranchDebug: return "jit.branchdebug";
 	case BreakReason::RABreak: return "ra.break";

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -64,7 +64,7 @@ enum class BreakReason {
 	SavestateCrash,
 	MemoryBreakpoint,
 	CpuBreakpoint,
-	GPRBreakpoint,
+	RegBreakpoint,
 	MemoryAccess,  // ???
 	JitBranchDebug,
 	BreakOnBoot,

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -64,6 +64,7 @@ enum class BreakReason {
 	SavestateCrash,
 	MemoryBreakpoint,
 	CpuBreakpoint,
+	GPRBreakpoint,
 	MemoryAccess,  // ???
 	JitBranchDebug,
 	BreakOnBoot,

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -449,6 +449,7 @@
     <ClCompile Include="Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="Debugger\WebSocket\GameSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GPUBufferSubscriber.cpp" />
+    <ClCompile Include="Debugger\WebSocket\GPUDisasmSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GPURecordSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GPUStatsSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\HLESubscriber.cpp" />
@@ -987,6 +988,7 @@
     <ClInclude Include="Debugger\WebSocket\GameSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\DisasmSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GPUBufferSubscriber.h" />
+    <ClInclude Include="Debugger\WebSocket\GPUDisasmSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GPURecordSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GPUStatsSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\HLESubscriber.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -754,6 +754,9 @@
     <ClCompile Include="Debugger\WebSocket\GPUBufferSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\WebSocket\GPUDisasmSubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="HLE\sceUsbAcc.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
@@ -2023,6 +2026,9 @@
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\GPUBufferSubscriber.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\WebSocket\GPUDisasmSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="ConfigValues.h">

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -418,10 +418,14 @@ bool BreakpointManager::GetMemCheck(u32 start, u32 end, MemCheck *check) {
 }
 
 static inline u32 NotCached(u32 val) {
-	// Remove the cached part of the address as well as any mirror.
+	// Remove the cached part of the address as well as any mirror. Also ignores the kernel
+	// bit (0x80000000) - not just the uncached bit (0x40000000) - so a memcheck registered
+	// via one alias (e.g. user-space cached) still matches an access made through another
+	// (e.g. kernel-space uncached). VRAM has no kernel-flagged mirror (see IsValidAddress),
+	// so that case only needs the uncached bit masked.
 	if ((val & 0x3F800000) == 0x04000000)
 		return val & ~0x40600000;
-	return val & ~0x40000000;
+	return val & ~0xC0000000;
 }
 
 bool BreakpointManager::GetMemCheckInRange(u32 address, int size, MemCheck *check) {
@@ -670,10 +674,20 @@ u32 BreakpointManager::CheckSkipFirst() {
 }
 
 static MemCheck NotCached(MemCheck mc) {
-	// Toggle the cached part of the address.
+	// Toggle the uncached bit (0x40000000) of the address.
 	mc.start ^= 0x40000000;
 	if (mc.end != 0)
 		mc.end ^= 0x40000000;
+	return mc;
+}
+
+static MemCheck NotKernel(MemCheck mc) {
+	// Toggle the kernel bit (0x80000000) of the address - independent of, and combinable
+	// with, the uncached bit above. Not applied to VRAM ranges: VRAM has no kernel-flagged
+	// mirror (see IsValidAddress's "disallow kernel-flagged VRAM" comment).
+	mc.start ^= 0x80000000;
+	if (mc.end != 0)
+		mc.end ^= 0x80000000;
 	return mc;
 }
 
@@ -711,8 +725,12 @@ void BreakpointManager::UpdateCachedMemCheckRanges() {
 				add(read, write, NotCached(copy));
 			}
 		} else {
+			// All four combinations of the independent uncached (0x40000000) and kernel
+			// (0x80000000) address bits - see NotCached(u32)/NotKernel() above.
 			add(read, write, check);
 			add(read, write, NotCached(check));
+			add(read, write, NotKernel(check));
+			add(read, write, NotKernel(NotCached(check)));
 		}
 	}
 }

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -94,13 +94,13 @@ size_t BreakpointManager::FindMemCheck(u32 start, u32 end) {
 	return INVALID_MEMCHECK;
 }
 
-size_t BreakpointManager::FindGPRBreakpoint(int reg) {
-	for (size_t i = 0; i < gprBreakpoints_.size(); ++i) {
-		if (gprBreakpoints_[i].reg == reg)
+size_t BreakpointManager::FindRegBreakpoint(int reg) {
+	for (size_t i = 0; i < regBreakpoints_.size(); ++i) {
+		if (regBreakpoints_[i].reg == reg)
 			return i;
 	}
 
-	return INVALID_GPR_BREAKPOINT;
+	return INVALID_REG_BREAKPOINT;
 }
 
 bool BreakpointManager::IsAddressBreakPoint(u32 addr)
@@ -506,30 +506,30 @@ BreakAction BreakpointManager::ExecOpMemCheck(u32 address, u32 pc) {
 	return BREAK_ACTION_IGNORE;
 }
 
-void BreakpointManager::RecomputeGPRBreakpointMask() {
+void BreakpointManager::RecomputeRegBreakpointMask() {
 	u32 mask = 0;
-	for (const auto &bp : gprBreakpoints_) {
+	for (const auto &bp : regBreakpoints_) {
 		if (bp.result != BREAK_ACTION_IGNORE)
 			mask |= 1u << bp.reg;
 	}
-	gprBreakpointMask_ = mask;
+	regBreakpointMask_ = mask;
 }
 
-int BreakpointManager::AddGPRBreakpoint(int reg) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp == INVALID_GPR_BREAKPOINT) {
-		GPRBreakpoint pt;
+int BreakpointManager::AddRegBreakpoint(int reg) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp == INVALID_REG_BREAKPOINT) {
+		RegBreakpoint pt;
 		pt.reg = reg;
 		pt.result |= BREAK_ACTION_PAUSE;
 
-		gprBreakpoints_.push_back(pt);
-		RecomputeGPRBreakpointMask();
+		regBreakpoints_.push_back(pt);
+		RecomputeRegBreakpointMask();
 		Update(INVALID_ADDRESS);  // Not baked into JIT code, no cache invalidation needed.
-		return (int)gprBreakpoints_.size() - 1;
-	} else if (!gprBreakpoints_[bp].IsEnabled()) {
-		gprBreakpoints_[bp].result |= BREAK_ACTION_PAUSE;
-		gprBreakpoints_[bp].hasCond = false;
-		RecomputeGPRBreakpointMask();
+		return (int)regBreakpoints_.size() - 1;
+	} else if (!regBreakpoints_[bp].IsEnabled()) {
+		regBreakpoints_[bp].result |= BREAK_ACTION_PAUSE;
+		regBreakpoints_[bp].hasCond = false;
+		RecomputeRegBreakpointMask();
 		Update(INVALID_ADDRESS);
 		return (int)bp;
 	} else {
@@ -537,106 +537,106 @@ int BreakpointManager::AddGPRBreakpoint(int reg) {
 	}
 }
 
-void BreakpointManager::RemoveGPRBreakpoint(int reg) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
-		gprBreakpoints_.erase(gprBreakpoints_.begin() + bp);
-		RecomputeGPRBreakpointMask();
+void BreakpointManager::RemoveRegBreakpoint(int reg) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
+		regBreakpoints_.erase(regBreakpoints_.begin() + bp);
+		RecomputeRegBreakpointMask();
 		Update(INVALID_ADDRESS);
 	}
 }
 
-void BreakpointManager::ChangeGPRBreakpoint(int reg, bool status) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
+void BreakpointManager::ChangeRegBreakpoint(int reg, bool status) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
 		if (status)
-			gprBreakpoints_[bp].result |= BREAK_ACTION_PAUSE;
+			regBreakpoints_[bp].result |= BREAK_ACTION_PAUSE;
 		else
-			gprBreakpoints_[bp].result = BreakAction(gprBreakpoints_[bp].result & ~BREAK_ACTION_PAUSE);
-		RecomputeGPRBreakpointMask();
+			regBreakpoints_[bp].result = BreakAction(regBreakpoints_[bp].result & ~BREAK_ACTION_PAUSE);
+		RecomputeRegBreakpointMask();
 		Update(INVALID_ADDRESS);
 	}
 }
 
-void BreakpointManager::ChangeGPRBreakpoint(int reg, BreakAction result) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
-		gprBreakpoints_[bp].result = result;
-		RecomputeGPRBreakpointMask();
+void BreakpointManager::ChangeRegBreakpoint(int reg, BreakAction result) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
+		regBreakpoints_[bp].result = result;
+		RecomputeRegBreakpointMask();
 		Update(INVALID_ADDRESS);
 	}
 }
 
-void BreakpointManager::ClearAllGPRBreakpoints() {
-	if (!gprBreakpoints_.empty()) {
-		gprBreakpoints_.clear();
-		gprBreakpointMask_ = 0;
+void BreakpointManager::ClearAllRegBreakpoints() {
+	if (!regBreakpoints_.empty()) {
+		regBreakpoints_.clear();
+		regBreakpointMask_ = 0;
 		Update(INVALID_ADDRESS);
 	}
 }
 
-void BreakpointManager::ChangeGPRBreakpointAddCond(int reg, const BreakPointCond &cond) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
-		gprBreakpoints_[bp].hasCond = true;
-		gprBreakpoints_[bp].cond = cond;
+void BreakpointManager::ChangeRegBreakpointAddCond(int reg, const BreakPointCond &cond) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
+		regBreakpoints_[bp].hasCond = true;
+		regBreakpoints_[bp].cond = cond;
 		// No need to update jit for a condition add/remove, they're not baked in.
 		Update(INVALID_ADDRESS);
 	}
 }
 
-void BreakpointManager::ChangeGPRBreakpointRemoveCond(int reg) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
-		gprBreakpoints_[bp].hasCond = false;
+void BreakpointManager::ChangeRegBreakpointRemoveCond(int reg) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
+		regBreakpoints_[bp].hasCond = false;
 		Update(INVALID_ADDRESS);
 	}
 }
 
-BreakPointCond *BreakpointManager::GetGPRBreakpointCondition(int reg) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT && gprBreakpoints_[bp].hasCond)
-		return &gprBreakpoints_[bp].cond;
+BreakPointCond *BreakpointManager::GetRegBreakpointCondition(int reg) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT && regBreakpoints_[bp].hasCond)
+		return &regBreakpoints_[bp].cond;
 	return nullptr;
 }
 
-void BreakpointManager::ChangeGPRBreakpointLogFormat(int reg, const std::string &fmt) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
-		gprBreakpoints_[bp].logFormat = fmt;
+void BreakpointManager::ChangeRegBreakpointLogFormat(int reg, const std::string &fmt) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
+		regBreakpoints_[bp].logFormat = fmt;
 		Update(INVALID_ADDRESS);
 	}
 }
 
-bool BreakpointManager::IsGPRBreakpoint(int reg) {
-	return (gprBreakpointMask_ & (1u << reg)) != 0;
+bool BreakpointManager::IsRegBreakpoint(int reg) {
+	return (regBreakpointMask_ & (1u << reg)) != 0;
 }
 
-bool BreakpointManager::GetGPRBreakpoint(int reg, GPRBreakpoint *check) {
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp != INVALID_GPR_BREAKPOINT) {
-		*check = gprBreakpoints_[bp];
+bool BreakpointManager::GetRegBreakpoint(int reg, RegBreakpoint *check) {
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp != INVALID_REG_BREAKPOINT) {
+		*check = regBreakpoints_[bp];
 		return true;
 	}
 	return false;
 }
 
-std::vector<GPRBreakpoint> BreakpointManager::GetGPRBreakpoints() {
-	return gprBreakpoints_;
+std::vector<RegBreakpoint> BreakpointManager::GetRegBreakpoints() {
+	return regBreakpoints_;
 }
 
-BreakAction BreakpointManager::ExecGPRBreakpoint(int reg, u32 pc) {
-	// Callers are expected to have already checked GetGPRBreakpointMask() themselves (that's
+BreakAction BreakpointManager::ExecRegBreakpoint(int reg, u32 pc) {
+	// Callers are expected to have already checked GetRegBreakpointMask() themselves (that's
 	// the whole point of exposing it - a single shift+and in the hot interpreter loop, skipping
 	// a function call entirely in the overwhelmingly common no-breakpoint case), but check again
 	// here too since this is also reachable directly.
-	if ((gprBreakpointMask_ & (1u << reg)) == 0)
+	if ((regBreakpointMask_ & (1u << reg)) == 0)
 		return BREAK_ACTION_IGNORE;
-	size_t bp = FindGPRBreakpoint(reg);
-	if (bp == INVALID_GPR_BREAKPOINT)
+	size_t bp = FindRegBreakpoint(reg);
+	if (bp == INVALID_REG_BREAKPOINT)
 		return BREAK_ACTION_IGNORE;
 
-	GPRBreakpoint &info = gprBreakpoints_[bp];
+	RegBreakpoint &info = regBreakpoints_[bp];
 	if (info.result == BREAK_ACTION_IGNORE)
 		return BREAK_ACTION_IGNORE;
 
@@ -647,15 +647,15 @@ BreakAction BreakpointManager::ExecGPRBreakpoint(int reg, u32 pc) {
 
 	if (info.result & BREAK_ACTION_LOG) {
 		if (info.logFormat.empty()) {
-			NOTICE_LOG(Log::JIT, "BKP GPR write r%d, PC=%08x (%s)", reg, pc, g_symbolMap->GetDescription(pc).c_str());
+			NOTICE_LOG(Log::JIT, "BKP reg write r%d, PC=%08x (%s)", reg, pc, g_symbolMap->GetDescription(pc).c_str());
 		} else {
 			std::string formatted;
 			BreakpointManager::EvaluateLogFormat(currentDebugMIPS, info.logFormat, formatted);
-			NOTICE_LOG(Log::JIT, "BKP GPR write r%d, PC=%08x: %s", reg, pc, formatted.c_str());
+			NOTICE_LOG(Log::JIT, "BKP reg write r%d, PC=%08x: %s", reg, pc, formatted.c_str());
 		}
 	}
 	if (info.result & BREAK_ACTION_PAUSE) {
-		Core_Break(BreakReason::GPRBreakpoint, pc);
+		Core_Break(BreakReason::RegBreakpoint, pc);
 	}
 
 	return info.result;

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -94,6 +94,15 @@ size_t BreakpointManager::FindMemCheck(u32 start, u32 end) {
 	return INVALID_MEMCHECK;
 }
 
+size_t BreakpointManager::FindGPRBreakpoint(int reg) {
+	for (size_t i = 0; i < gprBreakpoints_.size(); ++i) {
+		if (gprBreakpoints_[i].reg == reg)
+			return i;
+	}
+
+	return INVALID_GPR_BREAKPOINT;
+}
+
 bool BreakpointManager::IsAddressBreakPoint(u32 addr)
 {
 	if (!anyBreakPoints_)
@@ -491,6 +500,161 @@ BreakAction BreakpointManager::ExecOpMemCheck(u32 address, u32 pc) {
 		}
 	}
 	return BREAK_ACTION_IGNORE;
+}
+
+void BreakpointManager::RecomputeGPRBreakpointMask() {
+	u32 mask = 0;
+	for (const auto &bp : gprBreakpoints_) {
+		if (bp.result != BREAK_ACTION_IGNORE)
+			mask |= 1u << bp.reg;
+	}
+	gprBreakpointMask_ = mask;
+}
+
+int BreakpointManager::AddGPRBreakpoint(int reg) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp == INVALID_GPR_BREAKPOINT) {
+		GPRBreakpoint pt;
+		pt.reg = reg;
+		pt.result |= BREAK_ACTION_PAUSE;
+
+		gprBreakpoints_.push_back(pt);
+		RecomputeGPRBreakpointMask();
+		Update(INVALID_ADDRESS);  // Not baked into JIT code, no cache invalidation needed.
+		return (int)gprBreakpoints_.size() - 1;
+	} else if (!gprBreakpoints_[bp].IsEnabled()) {
+		gprBreakpoints_[bp].result |= BREAK_ACTION_PAUSE;
+		gprBreakpoints_[bp].hasCond = false;
+		RecomputeGPRBreakpointMask();
+		Update(INVALID_ADDRESS);
+		return (int)bp;
+	} else {
+		return (int)bp;
+	}
+}
+
+void BreakpointManager::RemoveGPRBreakpoint(int reg) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		gprBreakpoints_.erase(gprBreakpoints_.begin() + bp);
+		RecomputeGPRBreakpointMask();
+		Update(INVALID_ADDRESS);
+	}
+}
+
+void BreakpointManager::ChangeGPRBreakpoint(int reg, bool status) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		if (status)
+			gprBreakpoints_[bp].result |= BREAK_ACTION_PAUSE;
+		else
+			gprBreakpoints_[bp].result = BreakAction(gprBreakpoints_[bp].result & ~BREAK_ACTION_PAUSE);
+		RecomputeGPRBreakpointMask();
+		Update(INVALID_ADDRESS);
+	}
+}
+
+void BreakpointManager::ChangeGPRBreakpoint(int reg, BreakAction result) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		gprBreakpoints_[bp].result = result;
+		RecomputeGPRBreakpointMask();
+		Update(INVALID_ADDRESS);
+	}
+}
+
+void BreakpointManager::ClearAllGPRBreakpoints() {
+	if (!gprBreakpoints_.empty()) {
+		gprBreakpoints_.clear();
+		gprBreakpointMask_ = 0;
+		Update(INVALID_ADDRESS);
+	}
+}
+
+void BreakpointManager::ChangeGPRBreakpointAddCond(int reg, const BreakPointCond &cond) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		gprBreakpoints_[bp].hasCond = true;
+		gprBreakpoints_[bp].cond = cond;
+		// No need to update jit for a condition add/remove, they're not baked in.
+		Update(INVALID_ADDRESS);
+	}
+}
+
+void BreakpointManager::ChangeGPRBreakpointRemoveCond(int reg) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		gprBreakpoints_[bp].hasCond = false;
+		Update(INVALID_ADDRESS);
+	}
+}
+
+BreakPointCond *BreakpointManager::GetGPRBreakpointCondition(int reg) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT && gprBreakpoints_[bp].hasCond)
+		return &gprBreakpoints_[bp].cond;
+	return nullptr;
+}
+
+void BreakpointManager::ChangeGPRBreakpointLogFormat(int reg, const std::string &fmt) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		gprBreakpoints_[bp].logFormat = fmt;
+		Update(INVALID_ADDRESS);
+	}
+}
+
+bool BreakpointManager::IsGPRBreakpoint(int reg) {
+	return (gprBreakpointMask_ & (1u << reg)) != 0;
+}
+
+bool BreakpointManager::GetGPRBreakpoint(int reg, GPRBreakpoint *check) {
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp != INVALID_GPR_BREAKPOINT) {
+		*check = gprBreakpoints_[bp];
+		return true;
+	}
+	return false;
+}
+
+std::vector<GPRBreakpoint> BreakpointManager::GetGPRBreakpoints() {
+	return gprBreakpoints_;
+}
+
+BreakAction BreakpointManager::ExecGPRBreakpoint(int reg, u32 pc) {
+	// Callers are expected to have already checked GetGPRBreakpointMask() themselves (that's
+	// the whole point of exposing it - a single shift+and in the hot interpreter loop, skipping
+	// a function call entirely in the overwhelmingly common no-breakpoint case), but check again
+	// here too since this is also reachable directly.
+	if ((gprBreakpointMask_ & (1u << reg)) == 0)
+		return BREAK_ACTION_IGNORE;
+	size_t bp = FindGPRBreakpoint(reg);
+	if (bp == INVALID_GPR_BREAKPOINT)
+		return BREAK_ACTION_IGNORE;
+
+	GPRBreakpoint &info = gprBreakpoints_[bp];
+	if (info.result == BREAK_ACTION_IGNORE)
+		return BREAK_ACTION_IGNORE;
+
+	if (info.hasCond && !info.cond.Evaluate())
+		return BREAK_ACTION_IGNORE;
+
+	++info.numHits;
+
+	if (info.result & BREAK_ACTION_LOG) {
+		if (info.logFormat.empty()) {
+			NOTICE_LOG(Log::JIT, "BKP GPR write r%d, PC=%08x (%s)", reg, pc, g_symbolMap->GetDescription(pc).c_str());
+		} else {
+			std::string formatted;
+			BreakpointManager::EvaluateLogFormat(currentDebugMIPS, info.logFormat, formatted);
+			NOTICE_LOG(Log::JIT, "BKP GPR write r%d, PC=%08x: %s", reg, pc, formatted.c_str());
+		}
+	}
+	if (info.result & BREAK_ACTION_PAUSE) {
+		Core_Break(BreakReason::GPRBreakpoint, pc);
+	}
+
+	return info.result;
 }
 
 void BreakpointManager::SetSkipFirst(u32 pc) {

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -281,7 +281,7 @@ BreakAction BreakpointManager::ExecBreakPoint(u32 addr) {
 		return BREAK_ACTION_IGNORE;
 	size_t bp = FindBreakpoint(addr, false);
 	if (bp != INVALID_BREAKPOINT) {
-		const BreakPoint &info = breakPoints_[bp];
+		BreakPoint &info = breakPoints_[bp];
 
 		if (info.hasCond) {
 			// Evaluate the breakpoint and abort if necessary.
@@ -289,6 +289,8 @@ BreakAction BreakpointManager::ExecBreakPoint(u32 addr) {
 			if (cond && !cond->Evaluate())
 				return BREAK_ACTION_IGNORE;
 		}
+
+		++info.numHits;
 
 		if (info.result & BREAK_ACTION_LOG) {
 			if (info.logFormat.empty()) {

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -114,11 +114,13 @@ struct MemCheck {
 	}
 };
 
-// A breakpoint that trips whenever a general-purpose register is written to by an
-// instruction, regardless of address - identified by register index (0-31), not addr/range.
+// A breakpoint that trips whenever a register is written to by an instruction, regardless of
+// address - identified by register index (0-31), not addr/range. Currently only GPRs are
+// supported (reg is a GPR index), but the naming is kept general since this is expected to grow
+// to cover other register files too (e.g. FPU registers like $f10).
 // Interpreter-only for now (see RunUntilDowncountZeroWithChecks in MIPSTables.cpp) - the JITs
 // don't check this at all, so it has no effect unless running with the plain interpreter core.
-struct GPRBreakpoint {
+struct RegBreakpoint {
 	int reg = 0;  // 0-31, general-purpose register index (matches OUT_RT/OUT_RD/OUT_RA fields).
 
 	BreakAction result = BREAK_ACTION_IGNORE;
@@ -133,7 +135,7 @@ struct GPRBreakpoint {
 		return (result & BREAK_ACTION_PAUSE) != 0;
 	}
 
-	bool operator == (const GPRBreakpoint &other) const {
+	bool operator == (const RegBreakpoint &other) const {
 		return reg == other.reg;
 	}
 };
@@ -145,7 +147,7 @@ class BreakpointManager {
 public:
 	static const size_t INVALID_BREAKPOINT = -1;
 	static const size_t INVALID_MEMCHECK = -1;
-	static const size_t INVALID_GPR_BREAKPOINT = -1;
+	static const size_t INVALID_REG_BREAKPOINT = -1;
 
 	bool IsAddressBreakPoint(u32 addr);
 	bool IsAddressBreakPoint(u32 addr, bool* enabled);
@@ -183,26 +185,26 @@ public:
 	BreakAction ExecMemCheck(u32 address, bool write, int size, u32 pc, const char *reason);
 	BreakAction ExecOpMemCheck(u32 address, u32 pc);
 
-	// GPR write breakpoints - see GPRBreakpoint above. reg is a 0-31 GPR index.
-	int AddGPRBreakpoint(int reg);  // Returns the breakpoint index.
-	void RemoveGPRBreakpoint(int reg);
-	void ChangeGPRBreakpoint(int reg, bool enable);
-	void ChangeGPRBreakpoint(int reg, BreakAction result);
-	void ClearAllGPRBreakpoints();
+	// Register write breakpoints - see RegBreakpoint above. reg is a 0-31 GPR index.
+	int AddRegBreakpoint(int reg);  // Returns the breakpoint index.
+	void RemoveRegBreakpoint(int reg);
+	void ChangeRegBreakpoint(int reg, bool enable);
+	void ChangeRegBreakpoint(int reg, BreakAction result);
+	void ClearAllRegBreakpoints();
 
-	void ChangeGPRBreakpointAddCond(int reg, const BreakPointCond &cond);
-	void ChangeGPRBreakpointRemoveCond(int reg);
-	BreakPointCond *GetGPRBreakpointCondition(int reg);
+	void ChangeRegBreakpointAddCond(int reg, const BreakPointCond &cond);
+	void ChangeRegBreakpointRemoveCond(int reg);
+	BreakPointCond *GetRegBreakpointCondition(int reg);
 
-	void ChangeGPRBreakpointLogFormat(int reg, const std::string &fmt);
+	void ChangeRegBreakpointLogFormat(int reg, const std::string &fmt);
 
-	bool IsGPRBreakpoint(int reg);
-	bool GetGPRBreakpoint(int reg, GPRBreakpoint *bp);
-	std::vector<GPRBreakpoint> GetGPRBreakpoints();
+	bool IsRegBreakpoint(int reg);
+	bool GetRegBreakpoint(int reg, RegBreakpoint *bp);
+	std::vector<RegBreakpoint> GetRegBreakpoints();
 
 	// Called from the interpreter (RunUntilDowncountZeroWithChecks) right before executing an
 	// instruction that would write to reg - does not itself execute the instruction.
-	BreakAction ExecGPRBreakpoint(int reg, u32 pc);
+	BreakAction ExecRegBreakpoint(int reg, u32 pc);
 
 	void SetSkipFirst(u32 pc);
 	u32 CheckSkipFirst();
@@ -228,14 +230,14 @@ public:
 	bool HasMemChecks() const {
 		return anyMemChecks_;
 	}
-	bool HasGPRBreakpoints() const {
-		return gprBreakpointMask_ != 0;
+	bool HasRegBreakpoints() const {
+		return regBreakpointMask_ != 0;
 	}
-	// Bit i set means register i has an active (non-ignored) GPR breakpoint - a cheap way for
-	// the interpreter's hot per-instruction loop to test "would this write trip anything" with
-	// a single shift+and, without touching gprBreakpoints_ at all in the common no-match case.
-	u32 GetGPRBreakpointMask() const {
-		return gprBreakpointMask_;
+	// Bit i set means register i has an active (non-ignored) register breakpoint - a cheap way
+	// for the interpreter's hot per-instruction loop to test "would this write trip anything"
+	// with a single shift+and, without touching regBreakpoints_ at all in the common no-match case.
+	u32 GetRegBreakpointMask() const {
+		return regBreakpointMask_;
 	}
 
 	void Frame();
@@ -255,12 +257,12 @@ private:
 	// Finds a memcheck covering (part of) a range, unlike FindMemCheck() above.
 	MemCheck *FindMemCheckInRange(u32 address, int size);
 	void UpdateCachedMemCheckRanges();
-	size_t FindGPRBreakpoint(int reg);
-	void RecomputeGPRBreakpointMask();
+	size_t FindRegBreakpoint(int reg);
+	void RecomputeRegBreakpointMask();
 
 	std::atomic<bool> anyBreakPoints_;
 	std::atomic<bool> anyMemChecks_;
-	std::atomic<u32> gprBreakpointMask_;
+	std::atomic<u32> regBreakpointMask_;
 
 	std::vector<BreakPoint> breakPoints_;
 	u32 breakSkipFirstAt_ = 0;
@@ -270,7 +272,7 @@ private:
 	std::vector<MemCheck> memCheckRangesRead_;
 	std::vector<MemCheck> memCheckRangesWrite_;
 
-	std::vector<GPRBreakpoint> gprBreakpoints_;
+	std::vector<RegBreakpoint> regBreakpoints_;
 
 	bool needsUpdate_ = true;
 	u32 updateAddr_ = 0;

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -61,6 +61,11 @@ struct BreakPoint {
 	bool hasCond = false;
 	BreakPointCond cond;
 
+	// Matches MemCheck's numHits below - added after repeatedly needing to tell "is this
+	// breakpoint even being reached at all" from "it's reached but the log isn't showing up
+	// where I'm looking" during the VSH boot investigation (see docs/VSHBootInvestigation.md).
+	u32 numHits = 0;
+
 	bool IsEnabled() const {
 		return (result & BREAK_ACTION_PAUSE) != 0;
 	}

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -114,6 +114,30 @@ struct MemCheck {
 	}
 };
 
+// A breakpoint that trips whenever a general-purpose register is written to by an
+// instruction, regardless of address - identified by register index (0-31), not addr/range.
+// Interpreter-only for now (see RunUntilDowncountZeroWithChecks in MIPSTables.cpp) - the JITs
+// don't check this at all, so it has no effect unless running with the plain interpreter core.
+struct GPRBreakpoint {
+	int reg = 0;  // 0-31, general-purpose register index (matches OUT_RT/OUT_RD/OUT_RA fields).
+
+	BreakAction result = BREAK_ACTION_IGNORE;
+	std::string logFormat;
+
+	bool hasCond = false;
+	BreakPointCond cond;
+
+	u32 numHits = 0;
+
+	bool IsEnabled() const {
+		return (result & BREAK_ACTION_PAUSE) != 0;
+	}
+
+	bool operator == (const GPRBreakpoint &other) const {
+		return reg == other.reg;
+	}
+};
+
 // BreakPoints cannot overlap, only one is allowed per address.
 // MemChecks can overlap, as long as their ends are different.
 // WARNING: MemChecks are not always tracked in HLE currently.
@@ -121,6 +145,7 @@ class BreakpointManager {
 public:
 	static const size_t INVALID_BREAKPOINT = -1;
 	static const size_t INVALID_MEMCHECK = -1;
+	static const size_t INVALID_GPR_BREAKPOINT = -1;
 
 	bool IsAddressBreakPoint(u32 addr);
 	bool IsAddressBreakPoint(u32 addr, bool* enabled);
@@ -158,6 +183,27 @@ public:
 	BreakAction ExecMemCheck(u32 address, bool write, int size, u32 pc, const char *reason);
 	BreakAction ExecOpMemCheck(u32 address, u32 pc);
 
+	// GPR write breakpoints - see GPRBreakpoint above. reg is a 0-31 GPR index.
+	int AddGPRBreakpoint(int reg);  // Returns the breakpoint index.
+	void RemoveGPRBreakpoint(int reg);
+	void ChangeGPRBreakpoint(int reg, bool enable);
+	void ChangeGPRBreakpoint(int reg, BreakAction result);
+	void ClearAllGPRBreakpoints();
+
+	void ChangeGPRBreakpointAddCond(int reg, const BreakPointCond &cond);
+	void ChangeGPRBreakpointRemoveCond(int reg);
+	BreakPointCond *GetGPRBreakpointCondition(int reg);
+
+	void ChangeGPRBreakpointLogFormat(int reg, const std::string &fmt);
+
+	bool IsGPRBreakpoint(int reg);
+	bool GetGPRBreakpoint(int reg, GPRBreakpoint *bp);
+	std::vector<GPRBreakpoint> GetGPRBreakpoints();
+
+	// Called from the interpreter (RunUntilDowncountZeroWithChecks) right before executing an
+	// instruction that would write to reg - does not itself execute the instruction.
+	BreakAction ExecGPRBreakpoint(int reg, u32 pc);
+
 	void SetSkipFirst(u32 pc);
 	u32 CheckSkipFirst();
 
@@ -182,6 +228,15 @@ public:
 	bool HasMemChecks() const {
 		return anyMemChecks_;
 	}
+	bool HasGPRBreakpoints() const {
+		return gprBreakpointMask_ != 0;
+	}
+	// Bit i set means register i has an active (non-ignored) GPR breakpoint - a cheap way for
+	// the interpreter's hot per-instruction loop to test "would this write trip anything" with
+	// a single shift+and, without touching gprBreakpoints_ at all in the common no-match case.
+	u32 GetGPRBreakpointMask() const {
+		return gprBreakpointMask_;
+	}
 
 	void Frame();
 
@@ -200,9 +255,12 @@ private:
 	// Finds a memcheck covering (part of) a range, unlike FindMemCheck() above.
 	MemCheck *FindMemCheckInRange(u32 address, int size);
 	void UpdateCachedMemCheckRanges();
+	size_t FindGPRBreakpoint(int reg);
+	void RecomputeGPRBreakpointMask();
 
 	std::atomic<bool> anyBreakPoints_;
 	std::atomic<bool> anyMemChecks_;
+	std::atomic<u32> gprBreakpointMask_;
 
 	std::vector<BreakPoint> breakPoints_;
 	u32 breakSkipFirstAt_ = 0;
@@ -211,6 +269,8 @@ private:
 	std::vector<MemCheck> memChecks_;
 	std::vector<MemCheck> memCheckRangesRead_;
 	std::vector<MemCheck> memCheckRangesWrite_;
+
+	std::vector<GPRBreakpoint> gprBreakpoints_;
 
 	bool needsUpdate_ = true;
 	u32 updateAddr_ = 0;

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -54,6 +54,7 @@
 #include "Core/Debugger/WebSocket/DisasmSubscriber.h"
 #include "Core/Debugger/WebSocket/GameSubscriber.h"
 #include "Core/Debugger/WebSocket/GPUBufferSubscriber.h"
+#include "Core/Debugger/WebSocket/GPUDisasmSubscriber.h"
 #include "Core/Debugger/WebSocket/GPURecordSubscriber.h"
 #include "Core/Debugger/WebSocket/GPUStatsSubscriber.h"
 #include "Core/Debugger/WebSocket/HLESubscriber.h"
@@ -71,6 +72,7 @@ static const std::vector<SubscriberInit> subscribers({
 	&WebSocketDisasmInit,
 	&WebSocketGameInit,
 	&WebSocketGPUBufferInit,
+	&WebSocketGPUDisasmInit,
 	&WebSocketGPURecordInit,
 	&WebSocketGPUStatsInit,
 	&WebSocketHLEInit,

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
@@ -247,6 +247,9 @@ void WebSocketCPUBreakpointRemove(DebuggerRequest &req) {
 //     - logFormat: null, or string to log when breakpoint trips, may include {expression} parts.
 //     - symbol: null, or string label or symbol at breakpoint address.
 //     - code: string disassembly of breakpoint address.
+//     - hits: unsigned integer, how many times this breakpoint's address has been reached
+//       (and any condition passed) since it was added - useful for confirming a breakpoint is
+//       actually being reached at all, independently of whether log/enabled is set.
 void WebSocketCPUBreakpointList(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive()) {
 		return req.Fail("CPU not started");
@@ -266,6 +269,7 @@ void WebSocketCPUBreakpointList(DebuggerRequest &req) {
 			json.writeUint("address", bp.addr);
 			json.writeBool("enabled", bp.IsEnabled());
 			json.writeBool("log", (bp.result & BREAK_ACTION_LOG) != 0);
+			json.writeUint("hits", bp.numHits);
 			if (bp.hasCond)
 				json.writeString("condition", bp.cond.expressionString);
 			else

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
@@ -36,17 +36,17 @@ DebuggerSubscriber *WebSocketBreakpointInit(DebuggerEventHandlerMap &map) {
 	map["memory.breakpoint.remove"] = &WebSocketMemoryBreakpointRemove;
 	map["memory.breakpoint.list"] = &WebSocketMemoryBreakpointList;
 
-	map["cpu.gprBreakpoint.add"] = &WebSocketGPRBreakpointAdd;
-	map["cpu.gprBreakpoint.update"] = &WebSocketGPRBreakpointUpdate;
-	map["cpu.gprBreakpoint.remove"] = &WebSocketGPRBreakpointRemove;
-	map["cpu.gprBreakpoint.list"] = &WebSocketGPRBreakpointList;
+	map["cpu.regBreakpoint.add"] = &WebSocketRegBreakpointAdd;
+	map["cpu.regBreakpoint.update"] = &WebSocketRegBreakpointUpdate;
+	map["cpu.regBreakpoint.remove"] = &WebSocketRegBreakpointRemove;
+	map["cpu.regBreakpoint.list"] = &WebSocketRegBreakpointList;
 
 	return nullptr;
 }
 
 // Resolves a GPR by name (e.g. "s3", case-insensitive) or 0-31 index. Interpreter-only feature -
-// see GPRBreakpoint in Breakpoints.h - has no effect while running under a JIT backend.
-static bool ParseGPRBreakpointReg(DebuggerRequest &req, int *reg) {
+// see RegBreakpoint in Breakpoints.h - has no effect while running under a JIT backend.
+static bool ParseRegBreakpointReg(DebuggerRequest &req, int *reg) {
 	if (req.HasParam("name")) {
 		std::string name;
 		if (!req.ParamString("name", &name))
@@ -550,7 +550,7 @@ void WebSocketMemoryBreakpointList(DebuggerRequest &req) {
 	});
 }
 
-struct WebSocketGPRBreakpointParams {
+struct WebSocketRegBreakpointParams {
 	int reg = 0;
 	bool hasEnabled = false;
 	bool hasLog = false;
@@ -569,7 +569,7 @@ struct WebSocketGPRBreakpointParams {
 			return false;
 		}
 
-		if (!ParseGPRBreakpointReg(req, &reg))
+		if (!ParseRegBreakpointReg(req, &reg))
 			return false;
 
 		hasEnabled = req.HasParam("enabled");
@@ -606,18 +606,18 @@ struct WebSocketGPRBreakpointParams {
 			cond.debug = currentDebugMIPS;
 			cond.expressionString = condition;
 			cond.expression = compiledCondition;
-			g_breakpoints.ChangeGPRBreakpointAddCond(reg, cond);
+			g_breakpoints.ChangeRegBreakpointAddCond(reg, cond);
 		} else if (hasCondition && condition.empty()) {
-			g_breakpoints.ChangeGPRBreakpointRemoveCond(reg);
+			g_breakpoints.ChangeRegBreakpointRemoveCond(reg);
 		}
 
 		if (hasLogFormat) {
-			g_breakpoints.ChangeGPRBreakpointLogFormat(reg, logFormat);
+			g_breakpoints.ChangeRegBreakpointLogFormat(reg, logFormat);
 		}
 
 		if (hasLog && !hasEnabled) {
-			GPRBreakpoint bp;
-			if (g_breakpoints.GetGPRBreakpoint(reg, &bp))
+			RegBreakpoint bp;
+			if (g_breakpoints.GetRegBreakpoint(reg, &bp))
 				enabled = bp.IsEnabled();
 			hasEnabled = true;
 		}
@@ -627,16 +627,16 @@ struct WebSocketGPRBreakpointParams {
 				result |= BREAK_ACTION_LOG;
 			if (enabled)
 				result |= BREAK_ACTION_PAUSE;
-			g_breakpoints.ChangeGPRBreakpoint(reg, result);
+			g_breakpoints.ChangeRegBreakpoint(reg, result);
 		} else if (hasEnabled) {
-			g_breakpoints.ChangeGPRBreakpoint(reg, enabled);
+			g_breakpoints.ChangeRegBreakpoint(reg, enabled);
 		}
 	}
 };
 
-// Add a new GPR write breakpoint (cpu.gprBreakpoint.add)
+// Add a new register write breakpoint (cpu.regBreakpoint.add)
 //
-// Interpreter-only for now - see GPRBreakpoint in Core/Debugger/Breakpoints.h. Has no effect
+// Interpreter-only for now - see RegBreakpoint in Core/Debugger/Breakpoints.h. Has no effect
 // while running under a JIT backend (force the interpreter core, e.g. -i on the command line).
 //
 // Parameters:
@@ -649,28 +649,28 @@ struct WebSocketGPRBreakpointParams {
 //
 // Response (same event name) with no extra data.
 //
-// Note: will replace any GPR breakpoint already set on the same register.
-void WebSocketGPRBreakpointAdd(DebuggerRequest &req) {
-	WebSocketGPRBreakpointParams params;
+// Note: will replace any register breakpoint already set on the same register.
+void WebSocketRegBreakpointAdd(DebuggerRequest &req) {
+	WebSocketRegBreakpointParams params;
 	if (!params.Parse(req))
 		return;
 
 	// Route the actual breakpoint manipulation to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
-		g_breakpoints.AddGPRBreakpoint(params.reg);
+		g_breakpoints.AddRegBreakpoint(params.reg);
 		params.Apply();
 	});
 	req.Respond();
 }
 
-// Update a GPR write breakpoint (cpu.gprBreakpoint.update)
+// Update a register write breakpoint (cpu.regBreakpoint.update)
 //
-// Parameters: same as cpu.gprBreakpoint.add.
+// Parameters: same as cpu.regBreakpoint.add.
 //
 // Response (same event name) with no extra data.
-void WebSocketGPRBreakpointUpdate(DebuggerRequest &req) {
-	WebSocketGPRBreakpointParams params;
+void WebSocketRegBreakpointUpdate(DebuggerRequest &req) {
+	WebSocketRegBreakpointParams params;
 	if (!params.Parse(req))
 		return;
 
@@ -678,8 +678,8 @@ void WebSocketGPRBreakpointUpdate(DebuggerRequest &req) {
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	bool found = false;
 	Core_RunOnCPUThread([&] {
-		GPRBreakpoint bp;
-		found = g_breakpoints.GetGPRBreakpoint(params.reg, &bp);
+		RegBreakpoint bp;
+		found = g_breakpoints.GetRegBreakpoint(params.reg, &bp);
 		if (found)
 			params.Apply();
 	});
@@ -689,31 +689,31 @@ void WebSocketGPRBreakpointUpdate(DebuggerRequest &req) {
 	req.Respond();
 }
 
-// Remove a GPR write breakpoint (cpu.gprBreakpoint.remove)
+// Remove a register write breakpoint (cpu.regBreakpoint.remove)
 //
 // Parameters:
 //  - register: unsigned integer 0-31 GPR index. Ignored if name given.
 //  - name: string register name (e.g. "s3"), case-insensitive. Takes priority over 'register'.
 //
 // Response (same event name) with no extra data.
-void WebSocketGPRBreakpointRemove(DebuggerRequest &req) {
+void WebSocketRegBreakpointRemove(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive()) {
 		return req.Fail("CPU not started");
 	}
 
 	int reg;
-	if (!ParseGPRBreakpointReg(req, &reg))
+	if (!ParseRegBreakpointReg(req, &reg))
 		return;
 
 	// Route the actual breakpoint manipulation to the CPU thread instead of poking at it directly
 	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
 	Core_RunOnCPUThread([&] {
-		g_breakpoints.RemoveGPRBreakpoint(reg);
+		g_breakpoints.RemoveRegBreakpoint(reg);
 	});
 	req.Respond();
 }
 
-// List all GPR write breakpoints (cpu.gprBreakpoint.list)
+// List all register write breakpoints (cpu.regBreakpoint.list)
 //
 // No parameters.
 //
@@ -727,7 +727,7 @@ void WebSocketGPRBreakpointRemove(DebuggerRequest &req) {
 //       whether it paused - i.e. even with enabled false, if log is true.)
 //     - condition: null, or string expression to evaluate - breakpoint does not trip if false.
 //     - logFormat: null, or string to log when breakpoint trips, may include {expression} parts.
-void WebSocketGPRBreakpointList(DebuggerRequest &req) {
+void WebSocketRegBreakpointList(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive()) {
 		return req.Fail("CPU not started");
 	}
@@ -737,8 +737,8 @@ void WebSocketGPRBreakpointList(DebuggerRequest &req) {
 	Core_RunOnCPUThread([&] {
 		JsonWriter &json = req.Respond();
 		json.pushArray("breakpoints");
-		std::vector<GPRBreakpoint> bps = g_breakpoints.GetGPRBreakpoints();
-		for (const GPRBreakpoint &bp : bps) {
+		std::vector<RegBreakpoint> bps = g_breakpoints.GetRegBreakpoints();
+		for (const RegBreakpoint &bp : bps) {
 			json.pushDict();
 			json.writeInt("register", bp.reg);
 			json.writeString("name", MIPSDebugInterface::GetRegName(0, bp.reg));

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
@@ -36,7 +36,40 @@ DebuggerSubscriber *WebSocketBreakpointInit(DebuggerEventHandlerMap &map) {
 	map["memory.breakpoint.remove"] = &WebSocketMemoryBreakpointRemove;
 	map["memory.breakpoint.list"] = &WebSocketMemoryBreakpointList;
 
+	map["cpu.gprBreakpoint.add"] = &WebSocketGPRBreakpointAdd;
+	map["cpu.gprBreakpoint.update"] = &WebSocketGPRBreakpointUpdate;
+	map["cpu.gprBreakpoint.remove"] = &WebSocketGPRBreakpointRemove;
+	map["cpu.gprBreakpoint.list"] = &WebSocketGPRBreakpointList;
+
 	return nullptr;
+}
+
+// Resolves a GPR by name (e.g. "s3", case-insensitive) or 0-31 index. Interpreter-only feature -
+// see GPRBreakpoint in Breakpoints.h - has no effect while running under a JIT backend.
+static bool ParseGPRBreakpointReg(DebuggerRequest &req, int *reg) {
+	if (req.HasParam("name")) {
+		std::string name;
+		if (!req.ParamString("name", &name))
+			return false;
+		for (int i = 0; i < 32; ++i) {
+			if (!strcasecmp(name.c_str(), MIPSDebugInterface::GetRegName(0, i).c_str())) {
+				*reg = i;
+				return true;
+			}
+		}
+		req.Fail(StringFromFormat("Unknown register name: %s", name.c_str()));
+		return false;
+	}
+
+	uint32_t regU32;
+	if (!req.ParamU32("register", &regU32))
+		return false;
+	if (regU32 >= 32) {
+		req.Fail("Invalid 'register' parameter, must be 0-31");
+		return false;
+	}
+	*reg = (int)regU32;
+	return true;
 }
 
 struct WebSocketCPUBreakpointParams {
@@ -510,6 +543,216 @@ void WebSocketMemoryBreakpointList(DebuggerRequest &req) {
 				json.writeNull("symbol");
 			else
 				json.writeString("symbol", symbol);
+
+			json.pop();
+		}
+		json.pop();
+	});
+}
+
+struct WebSocketGPRBreakpointParams {
+	int reg = 0;
+	bool hasEnabled = false;
+	bool hasLog = false;
+	bool hasCondition = false;
+	bool hasLogFormat = false;
+
+	bool enabled;
+	bool log;
+	std::string condition;
+	PostfixExpression compiledCondition;
+	std::string logFormat;
+
+	bool Parse(DebuggerRequest &req) {
+		if (!currentDebugMIPS->isAlive()) {
+			req.Fail("CPU not started");
+			return false;
+		}
+
+		if (!ParseGPRBreakpointReg(req, &reg))
+			return false;
+
+		hasEnabled = req.HasParam("enabled");
+		if (hasEnabled) {
+			if (!req.ParamBool("enabled", &enabled))
+				return false;
+		}
+		hasLog = req.HasParam("log");
+		if (hasLog) {
+			if (!req.ParamBool("log", &log))
+				return false;
+		}
+		hasCondition = req.HasParam("condition");
+		if (hasCondition) {
+			if (!req.ParamString("condition", &condition))
+				return false;
+			if (!initExpression(currentDebugMIPS, condition.c_str(), compiledCondition)) {
+				req.Fail(StringFromFormat("Could not parse expression syntax: %s", getExpressionError()));
+				return false;
+			}
+		}
+		hasLogFormat = req.HasParam("logFormat");
+		if (hasLogFormat) {
+			if (!req.ParamString("logFormat", &logFormat))
+				return false;
+		}
+
+		return true;
+	}
+
+	void Apply() {
+		if (hasCondition && !condition.empty()) {
+			BreakPointCond cond;
+			cond.debug = currentDebugMIPS;
+			cond.expressionString = condition;
+			cond.expression = compiledCondition;
+			g_breakpoints.ChangeGPRBreakpointAddCond(reg, cond);
+		} else if (hasCondition && condition.empty()) {
+			g_breakpoints.ChangeGPRBreakpointRemoveCond(reg);
+		}
+
+		if (hasLogFormat) {
+			g_breakpoints.ChangeGPRBreakpointLogFormat(reg, logFormat);
+		}
+
+		if (hasLog && !hasEnabled) {
+			GPRBreakpoint bp;
+			if (g_breakpoints.GetGPRBreakpoint(reg, &bp))
+				enabled = bp.IsEnabled();
+			hasEnabled = true;
+		}
+		if (hasLog && hasEnabled) {
+			BreakAction result = BREAK_ACTION_IGNORE;
+			if (log)
+				result |= BREAK_ACTION_LOG;
+			if (enabled)
+				result |= BREAK_ACTION_PAUSE;
+			g_breakpoints.ChangeGPRBreakpoint(reg, result);
+		} else if (hasEnabled) {
+			g_breakpoints.ChangeGPRBreakpoint(reg, enabled);
+		}
+	}
+};
+
+// Add a new GPR write breakpoint (cpu.gprBreakpoint.add)
+//
+// Interpreter-only for now - see GPRBreakpoint in Core/Debugger/Breakpoints.h. Has no effect
+// while running under a JIT backend (force the interpreter core, e.g. -i on the command line).
+//
+// Parameters:
+//  - register: unsigned integer 0-31 GPR index to break on write to. Ignored if name given.
+//  - name: string register name (e.g. "s3"), case-insensitive. Takes priority over 'register'.
+//  - enabled: optional boolean, whether to actually enter stepping when this breakpoint trips.
+//  - log: optional boolean, whether to log when this breakpoint trips.
+//  - condition: optional string expression to evaluate - breakpoint does not trip if false.
+//  - logFormat: optional string to log when breakpoint trips, may include {expression} parts.
+//
+// Response (same event name) with no extra data.
+//
+// Note: will replace any GPR breakpoint already set on the same register.
+void WebSocketGPRBreakpointAdd(DebuggerRequest &req) {
+	WebSocketGPRBreakpointParams params;
+	if (!params.Parse(req))
+		return;
+
+	// Route the actual breakpoint manipulation to the CPU thread instead of poking at it directly
+	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
+	Core_RunOnCPUThread([&] {
+		g_breakpoints.AddGPRBreakpoint(params.reg);
+		params.Apply();
+	});
+	req.Respond();
+}
+
+// Update a GPR write breakpoint (cpu.gprBreakpoint.update)
+//
+// Parameters: same as cpu.gprBreakpoint.add.
+//
+// Response (same event name) with no extra data.
+void WebSocketGPRBreakpointUpdate(DebuggerRequest &req) {
+	WebSocketGPRBreakpointParams params;
+	if (!params.Parse(req))
+		return;
+
+	// Route the actual breakpoint manipulation to the CPU thread instead of poking at it directly
+	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
+	bool found = false;
+	Core_RunOnCPUThread([&] {
+		GPRBreakpoint bp;
+		found = g_breakpoints.GetGPRBreakpoint(params.reg, &bp);
+		if (found)
+			params.Apply();
+	});
+
+	if (!found)
+		return req.Fail("Breakpoint not found");
+	req.Respond();
+}
+
+// Remove a GPR write breakpoint (cpu.gprBreakpoint.remove)
+//
+// Parameters:
+//  - register: unsigned integer 0-31 GPR index. Ignored if name given.
+//  - name: string register name (e.g. "s3"), case-insensitive. Takes priority over 'register'.
+//
+// Response (same event name) with no extra data.
+void WebSocketGPRBreakpointRemove(DebuggerRequest &req) {
+	if (!currentDebugMIPS->isAlive()) {
+		return req.Fail("CPU not started");
+	}
+
+	int reg;
+	if (!ParseGPRBreakpointReg(req, &reg))
+		return;
+
+	// Route the actual breakpoint manipulation to the CPU thread instead of poking at it directly
+	// from this WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
+	Core_RunOnCPUThread([&] {
+		g_breakpoints.RemoveGPRBreakpoint(reg);
+	});
+	req.Respond();
+}
+
+// List all GPR write breakpoints (cpu.gprBreakpoint.list)
+//
+// No parameters.
+//
+// Response (same event name):
+//  - breakpoints: array of objects, each with properties:
+//     - register: unsigned integer 0-31 GPR index.
+//     - name: string register name (e.g. "s3").
+//     - enabled: boolean, whether to actually enter stepping when this breakpoint trips.
+//     - log: boolean, whether to log when this breakpoint trips.
+//     - hits: unsigned integer, number of times this breakpoint has tripped (regardless of
+//       whether it paused - i.e. even with enabled false, if log is true.)
+//     - condition: null, or string expression to evaluate - breakpoint does not trip if false.
+//     - logFormat: null, or string to log when breakpoint trips, may include {expression} parts.
+void WebSocketGPRBreakpointList(DebuggerRequest &req) {
+	if (!currentDebugMIPS->isAlive()) {
+		return req.Fail("CPU not started");
+	}
+
+	// Route the breakpoint reads to the CPU thread instead of poking at them directly from this
+	// WebSocket handler thread - see Core_RunOnCPUThread() in Core.h.
+	Core_RunOnCPUThread([&] {
+		JsonWriter &json = req.Respond();
+		json.pushArray("breakpoints");
+		std::vector<GPRBreakpoint> bps = g_breakpoints.GetGPRBreakpoints();
+		for (const GPRBreakpoint &bp : bps) {
+			json.pushDict();
+			json.writeInt("register", bp.reg);
+			json.writeString("name", MIPSDebugInterface::GetRegName(0, bp.reg));
+			json.writeBool("enabled", bp.IsEnabled());
+			json.writeBool("log", (bp.result & BREAK_ACTION_LOG) != 0);
+			json.writeUint("hits", bp.numHits);
+			if (bp.hasCond)
+				json.writeString("condition", bp.cond.expressionString);
+			else
+				json.writeNull("condition");
+			if (!bp.logFormat.empty())
+				json.writeString("logFormat", bp.logFormat);
+			else
+				json.writeNull("logFormat");
 
 			json.pop();
 		}

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.h
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.h
@@ -31,7 +31,7 @@ void WebSocketMemoryBreakpointUpdate(DebuggerRequest &req);
 void WebSocketMemoryBreakpointRemove(DebuggerRequest &req);
 void WebSocketMemoryBreakpointList(DebuggerRequest &req);
 
-void WebSocketGPRBreakpointAdd(DebuggerRequest &req);
-void WebSocketGPRBreakpointUpdate(DebuggerRequest &req);
-void WebSocketGPRBreakpointRemove(DebuggerRequest &req);
-void WebSocketGPRBreakpointList(DebuggerRequest &req);
+void WebSocketRegBreakpointAdd(DebuggerRequest &req);
+void WebSocketRegBreakpointUpdate(DebuggerRequest &req);
+void WebSocketRegBreakpointRemove(DebuggerRequest &req);
+void WebSocketRegBreakpointList(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.h
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.h
@@ -30,3 +30,8 @@ void WebSocketMemoryBreakpointAdd(DebuggerRequest &req);
 void WebSocketMemoryBreakpointUpdate(DebuggerRequest &req);
 void WebSocketMemoryBreakpointRemove(DebuggerRequest &req);
 void WebSocketMemoryBreakpointList(DebuggerRequest &req);
+
+void WebSocketGPRBreakpointAdd(DebuggerRequest &req);
+void WebSocketGPRBreakpointUpdate(DebuggerRequest &req);
+void WebSocketGPRBreakpointRemove(DebuggerRequest &req);
+void WebSocketGPRBreakpointList(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/DisasmSubscriber.cpp
+++ b/Core/Debugger/WebSocket/DisasmSubscriber.cpp
@@ -49,6 +49,7 @@ public:
 protected:
 	void WriteDisasmLine(JsonWriter &json, const DisassemblyLineInfo &l);
 	void WriteBranchGuide(JsonWriter &json, const BranchLine &l);
+	std::string FormatDisasmLineCompact(const DisassemblyLineInfo &l, DebugInterface *cpuDebug);
 };
 
 DebuggerSubscriber *WebSocketDisasmInit(DebuggerEventHandlerMap &map) {
@@ -234,6 +235,46 @@ void WebSocketDisasmState::WriteDisasmLine(JsonWriter &json, const DisassemblyLi
 	json.pop();
 }
 
+// One line of "ADDR  name params" text, with a leading marker column ('>' = current PC,
+// '*' = enabled breakpoint here, 'o' = disabled breakpoint here) and the symbol name inlined
+// if known. Meant for compact=true: full-JSON disasm lines (WriteDisasmLine above, ~15 fields
+// each) are precise but slow to skim by hand - every manual disassembly read this session (see
+// docs/VSHBootInvestigation.md) ended up needing a throwaway script to reduce them to exactly
+// this, and at least once that script's own parsing bug produced misleading output. Doing the
+// reduction here instead means there's one correct implementation instead of a new ad hoc one
+// each time.
+std::string WebSocketDisasmState::FormatDisasmLineCompact(const DisassemblyLineInfo &l, DebugInterface *cpuDebug) {
+	u32 addr = l.info.opcodeAddress;
+	bool enabled = false;
+	bool hasBreakpoint = false;
+	for (u32 i = 0; i < l.totalSize; i += 4) {
+		if (g_breakpoints.IsAddressBreakPoint(addr + i, &enabled)) {
+			hasBreakpoint = true;
+			if (enabled)
+				break;
+		}
+	}
+
+	char marker = ' ';
+	if (cpuDebug->GetPC() == addr)
+		marker = '>';
+	else if (hasBreakpoint)
+		marker = enabled ? '*' : 'o';
+
+	std::string line = StringFromFormat("%c %08x  ", marker, addr);
+	const std::string symbol = g_symbolMap->GetLabelString(addr);
+	if (!symbol.empty()) {
+		line += symbol;
+		line += ": ";
+	}
+	line += l.name;
+	if (!l.params.empty()) {
+		line += " ";
+		line += l.params;
+	}
+	return line;
+}
+
 void WebSocketDisasmState::WriteBranchGuide(JsonWriter &json, const BranchLine &l) {
 	json.pushDict();
 	json.writeUint("top", l.first);
@@ -269,12 +310,14 @@ void WebSocketDisasmState::Base(DebuggerRequest &req) {
 //  - address: number specifying the start address.
 //  - count: number of lines to return (may be clamped to an internal limit.)
 //  - displaySymbols: boolean true to show symbol names in instruction params.
+//  - compact: optional boolean, default false. See "lines" below.
 //
 // Parameters (by end address):
 //  - thread: optional number indicating the thread id for branch info.
 //  - address: number specifying the start address.
 //  - end: number which must be after the start address (may be clamped to an internal limit.)
 //  - displaySymbols: boolean true to show symbol names in instruction params.
+//  - compact: optional boolean, default false. See "lines" below.
 //
 // Response (same event name):
 //  - range: object with result "start" and "end" properties, the addresses actually used.
@@ -284,7 +327,7 @@ void WebSocketDisasmState::Base(DebuggerRequest &req) {
 //     - bottom: the later address as a number.
 //     - direction: "up", "down", or "right" depending on the flow of the branch.
 //     - lane: number index to avoid overlapping guides.
-//  - lines: array of objects:
+//  - lines: with compact=false (default), array of objects:
 //     - type: "opcode", "macro", "data", or "other".
 //     - address: address of first actual instruction.
 //     - addressSize: bytes used by this line (might be more than 4.)
@@ -293,6 +336,10 @@ void WebSocketDisasmState::Base(DebuggerRequest &req) {
 //     - name: string name of the instruction.
 //     - params: formatted parameters for the instruction.
 //     - (other info about the disassembled line.)
+//    with compact=true, array of strings instead, one per line, formatted as
+//    "M AAAAAAAA  [symbol: ]name params" where M is '>' for the current PC, '*'/'o' for an
+//    enabled/disabled breakpoint at that address, or ' ' otherwise - meant for skimming a
+//    range by eye by hand instead of parsing the full per-field JSON.
 void WebSocketDisasmState::Disasm(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
 		return req.Fail("CPU not started");
@@ -351,6 +398,9 @@ void WebSocketDisasmState::Disasm(DebuggerRequest &req) {
 		bool displaySymbols = true;
 		if (!req.ParamBool("displaySymbols", &displaySymbols, DebuggerParamType::OPTIONAL))
 			return;
+		bool compact = false;
+		if (!req.ParamBool("compact", &compact, DebuggerParamType::OPTIONAL))
+			return;
 
 		JsonWriter &json = req.Respond();
 		json.pushDict("range");
@@ -363,7 +413,10 @@ void WebSocketDisasmState::Disasm(DebuggerRequest &req) {
 		uint32_t addr = start;
 		for (uint32_t i = 0; i < count; ++i) {
 			g_disassemblyManager.getLine(addr, displaySymbols, line, cpuDebug);
-			WriteDisasmLine(json, line);
+			if (compact)
+				json.writeString(FormatDisasmLineCompact(line, cpuDebug));
+			else
+				WriteDisasmLine(json, line);
 			addr += line.totalSize;
 
 			// These are pretty long, so let's grease the wheels a bit.
@@ -388,9 +441,18 @@ void WebSocketDisasmState::Disasm(DebuggerRequest &req) {
 //  - end: optional end address as a number (otherwise uses start address.)
 //  - match: string to search for.
 //  - displaySymbols: optional, specify false to hide symbols in the searched parameters.
+//  - findAll: optional boolean, default false. When true, scans the whole range instead of
+//    stopping at the first match - e.g. for "every jal/jalr/j targeting this address" call-graph
+//    style queries (search for the target's hex address, or its symbol name if it has one),
+//    where the first match alone isn't the answer. Capped at 1000 results; a huge range with a
+//    very common match (e.g. an empty/near-universal 'match' string) will still stop there
+//    rather than building an unbounded response.
 //
 // Response (same event name):
-//  - address: number address of match or null if none was found.
+//  - address: number address of the first match, or null if none was found (same as before
+//    findAll existed - set from the same scan even when findAll is true).
+//  - addresses: array of numbers, every match found. With findAll=false this has at most one
+//    entry (the same value as "address"); with findAll=true, up to 1000.
 void WebSocketDisasmState::SearchDisasm(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
 		return req.Fail("CPU not started");
@@ -407,6 +469,10 @@ void WebSocketDisasmState::SearchDisasm(DebuggerRequest &req) {
 	bool displaySymbols = true;
 	if (!req.ParamBool("displaySymbols", &displaySymbols, DebuggerParamType::OPTIONAL))
 		return;
+	bool findAll = false;
+	if (!req.ParamBool("findAll", &findAll, DebuggerParamType::OPTIONAL))
+		return;
+	static const size_t MAX_RESULTS = 1000;
 
 	bool loopSearch = end <= start;
 	start = RoundMemAddressUp(start);
@@ -414,6 +480,8 @@ void WebSocketDisasmState::SearchDisasm(DebuggerRequest &req) {
 		// We must've passed end by rounding up.
 		JsonWriter &json = req.Respond();
 		json.writeNull("address");
+		json.pushArray("addresses");
+		json.pop();
 		return;
 	}
 
@@ -432,7 +500,7 @@ void WebSocketDisasmState::SearchDisasm(DebuggerRequest &req) {
 			return;
 
 		DisassemblyLineInfo line;
-		bool found = false;
+		std::vector<uint32_t> matches;
 		uint32_t addr = start;
 		do {
 			g_disassemblyManager.getLine(addr, displaySymbols, line, cpuDebug);
@@ -454,18 +522,23 @@ void WebSocketDisasmState::SearchDisasm(DebuggerRequest &req) {
 			inserter = std::transform(line.params.begin(), line.params.end(), inserter, ::tolower);
 
 			if (mergeForSearch.find(match) != mergeForSearch.npos) {
-				found = true;
-				break;
+				matches.push_back(addr);
+				if (!findAll || matches.size() >= MAX_RESULTS)
+					break;
 			}
 
 			addr = RoundMemAddressUp(addr + line.totalSize);
 		} while (addr != end);
 
 		JsonWriter &json = req.Respond();
-		if (found)
-			json.writeUint("address", addr);
+		if (!matches.empty())
+			json.writeUint("address", matches[0]);
 		else
 			json.writeNull("address");
+		json.pushArray("addresses");
+		for (uint32_t m : matches)
+			json.writeUint(m);
+		json.pop();
 	});
 }
 

--- a/Core/Debugger/WebSocket/GPUDisasmSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GPUDisasmSubscriber.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2026- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include <algorithm>
+
+#include "Common/StringUtils.h"
+#include "Core/Debugger/WebSocket/GPUDisasmSubscriber.h"
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+#include "Core/MemMap.h"
+#include "GPU/GPU.h"
+#include "GPU/GPUCommon.h"
+#include "GPU/Common/GPUDebugInterface.h"
+
+DebuggerSubscriber *WebSocketGPUDisasmInit(DebuggerEventHandlerMap &map) {
+	// No need to bind or alloc state, this is all global (the "gpu" global and raw memory reads).
+	map["gpu.displaylist.disasm"] = &WebSocketGPUDisplayListDisasm;
+	return nullptr;
+}
+
+// Disassemble a range of GE display list memory into named commands (gpu.displaylist.disasm)
+//
+// GE command words live in normal guest RAM (same as CPU code), so this decodes memory
+// directly rather than requiring the CPU/GPU to be paused first - unlike gpu.buffer.*, which
+// reads live host-side render target/texture data and does need CORE_STEPPING_CPU.
+//
+// Parameters (by count):
+//  - address: number specifying the start address (a display list address, e.g. from
+//    sceGe.cpp's "Starting DL execution at ..." log, or dlid via hle - not a CPU code address).
+//  - count: number of GE command words to decode.
+//  - compact: optional boolean, default false. See "lines" below.
+//
+// Parameters (by end address):
+//  - address: number specifying the start address.
+//  - end: number which must be after the start address (exclusive).
+//  - compact: optional boolean, default false. See "lines" below.
+//
+// Response (same event name):
+//  - lines: with compact=false (default), array of objects:
+//     - address: address of this command word.
+//     - cmd: unsigned integer, the command byte (op >> 24).
+//     - op: unsigned integer, the raw 32-bit command word.
+//     - desc: string description of the command (name and decoded parameters).
+//    with compact=true, array of strings instead, one per command, formatted as
+//    "AAAAAAAA  desc" - meant for skimming a display list by eye instead of parsing full JSON,
+//    same idea as memory.disasm's own compact mode.
+void WebSocketGPUDisplayListDisasm(DebuggerRequest &req) {
+	if (!gpu) {
+		return req.Fail("No GPU active (game not booted?)");
+	}
+	if (!Memory::IsActive()) {
+		return req.Fail("Memory not active");
+	}
+
+	// Mirrors memory.disasm's own limit - keeps a client typo (e.g. count=0xFFFFFFFF) from
+	// blocking the debugger connection for an unreasonable amount of time.
+	static const uint32_t MAX_RANGE = 10000;
+
+	uint32_t start;
+	if (!req.ParamU32("address", &start))
+		return;
+	uint32_t end;
+	uint32_t count = 0;
+	if (req.ParamU32("count", &count, false, DebuggerParamType::OPTIONAL) && count != 0) {
+		count = std::min(count, MAX_RANGE);
+		end = start + count * 4;
+	} else if (req.ParamU32("end", &end, false, DebuggerParamType::OPTIONAL)) {
+		end = std::max(start, end);
+		if (end - start > MAX_RANGE * 4)
+			end = start + MAX_RANGE * 4;
+	} else {
+		return req.Fail("Must specify either 'count' or 'end'");
+	}
+
+	bool compact = false;
+	if (!req.ParamBool("compact", &compact, DebuggerParamType::OPTIONAL))
+		return;
+
+	std::vector<GPUDebugOp> ops = gpu->DisassembleOpRange(start, end);
+
+	JsonWriter &json = req.Respond();
+	json.pushArray("lines");
+	for (const GPUDebugOp &op : ops) {
+		if (compact) {
+			json.writeString(StringFromFormat("%08x  %s", op.pc, op.desc.c_str()));
+		} else {
+			json.pushDict();
+			json.writeUint("address", op.pc);
+			json.writeUint("cmd", op.cmd);
+			json.writeUint("op", op.op);
+			json.writeString("desc", op.desc);
+			json.pop();
+		}
+	}
+	json.pop();
+}

--- a/Core/Debugger/WebSocket/GPUDisasmSubscriber.h
+++ b/Core/Debugger/WebSocket/GPUDisasmSubscriber.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2026- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+
+DebuggerSubscriber *WebSocketGPUDisasmInit(DebuggerEventHandlerMap &map);
+
+void WebSocketGPUDisplayListDisasm(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/LogBroadcaster.cpp
+++ b/Core/Debugger/WebSocket/LogBroadcaster.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <mutex>
 #include "Common/Log/LogManager.h"
+#include "Common/StringUtils.h"
+#include "Common/TimeUtil.h"
 #include "Core/Debugger/WebSocket/LogBroadcaster.h"
 #include "Core/Debugger/WebSocket/WebSocketUtils.h"
 
@@ -36,8 +38,17 @@ public:
 		std::lock_guard<std::mutex> guard(lock_);
 		int splitPoint;
 		int readCount;
+		// A source that logs faster than this listener gets polled (WebSocket.cpp's event loop,
+		// up to 1000Hz under high activity) - a log-only breakpoint hit thousands of times in a
+		// tight loop is a real example, see docs/VSHBootInvestigation.md - can wrap the ring
+		// buffer before GetMessages() ever reads the oldest entries, silently losing them. That
+		// used to just look like "my breakpoint only logged a few hits" from the client's side,
+		// indistinguishable from the breakpoint genuinely not firing - synthesize a warning
+		// message reporting exactly how many were lost instead of staying silent about it.
+		int droppedCount = 0;
 		if (read_ + BUFFER_SIZE < count_) {
 			// We'll start with our oldest then.
+			droppedCount = (count_ - BUFFER_SIZE) - read_;
 			splitPoint = nextMessage_;
 			readCount = Count();
 		} else {
@@ -48,6 +59,15 @@ public:
 		read_ = count_;
 
 		std::vector<LogMessage> results;
+		if (droppedCount > 0) {
+			LogMessage dropped;
+			dropped.level = LogLevel::LWARNING;
+			dropped.log = "Debugger";
+			GetCurrentTimeFormatted(dropped.timestamp);
+			truncate_cpy(dropped.header, "LogBroadcaster: ring buffer overflow");
+			dropped.msg = StringFromFormat("%d log message(s) dropped - client polling too slow for this volume\n", droppedCount);
+			results.push_back(dropped);
+		}
 		int splitEnd = std::min(splitPoint + readCount, (int)BUFFER_SIZE);
 		for (int i = splitPoint; i < splitEnd; ++i) {
 			results.push_back(messages_[i]);

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -82,7 +82,9 @@ static DebugInterface *CPUFromRequest(DebuggerRequest &req, uint32_t *threadID =
 // Parameters:
 //  - thread: optional number indicating the thread id to plan stepping on.
 //
-// No immediate response.  A cpu.stepping event will be sent once complete.
+// No immediate response on success.  A cpu.stepping event will be sent once complete.
+// May fail (same-thread case only) if another step/run request is already pending this host
+// frame - safe to retry shortly after.
 //
 // Note: any thread can wake the cpu when it hits the next instruction currently.
 void WebSocketSteppingState::Into(DebuggerRequest &req) {
@@ -108,7 +110,16 @@ void WebSocketSteppingState::Into(DebuggerRequest &req) {
 			// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 			g_breakpoints.SetSkipFirst(currentMIPS->pc);
 
-			Core_RequestCPUStep(CPUStepType::Into, 1);
+			// Core_RequestCPUStep() can fail (a step or run request is already queued this host
+			// frame - see its own "Can't submit two steps in one host frame" log). Previously
+			// unchecked here: on failure, no step ever happens and no cpu.stepping event ever
+			// fires, but the client got no response either (this event's contract is "no
+			// immediate response, a cpu.stepping event follows") - so a rejected step looked
+			// identical to one that's just still in flight, indefinitely. Surface it instead.
+			if (!Core_RequestCPUStep(CPUStepType::Into, 1)) {
+				req.Fail("Could not step: a step or run request is already pending");
+				return;
+			}
 		} else {
 			uint32_t breakpointAddress = cpuDebug->GetPC();
 			PrepareResume();

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -291,7 +291,23 @@ uint32_t WebSocketSteppingState::GetNextAddress(DebugInterface *cpuDebug) {
 void WebSocketSteppingState::PrepareResume() {
 	if (currentMIPS->inDelaySlot) {
 		// Delay slot instructions are never joined, so we pass 1.
-		Core_RequestCPUStep(CPUStepType::Into, 1);
+		//
+		// This must happen synchronously, not via Core_RequestCPUStep(): that only queues the
+		// step for Core_ProcessStepping() to perform later (on the next iteration of the normal
+		// stepping-mode loop), while every caller of PrepareResume() immediately inspects
+		// currentMIPS->pc/inDelaySlot right after this returns to decide whether to add a
+		// breakpoint and call Core_Resume(). Core_Resume() itself sets coreState back to
+		// CORE_RUNNING_CPU, which makes Core_ProcessStepping() skip its pending-step check
+		// entirely - so the queued step was not just late, it was silently dropped, leaving
+		// g_cpuStepCommand permanently set until the next Core_Break() reset it. Any stepping
+		// request issued by the debugger client in that window (e.g. a script or fast-clicking
+		// UI immediately re-stepping instead of waiting for a fresh cpu.stepping event) hit
+		// Core_RequestCPUStep()'s "Can't submit two steps in one host frame" guard and got
+		// silently ignored - the "step-out sometimes just doesn't do anything" flakiness this
+		// was found while tracking down. PrepareResume() is only ever called from within a
+		// Core_RunOnCPUThread() callback (Into/Over/Out/RunUntil/HLE below), so it's always
+		// already running on the CPU thread - safe to single-step directly instead of queuing.
+		currentMIPS->SingleStep();
 	} else {
 		// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 		g_breakpoints.SetSkipFirst(currentMIPS->pc);

--- a/Core/MIPS/Interpreter.cpp
+++ b/Core/MIPS/Interpreter.cpp
@@ -685,6 +685,50 @@ namespace MIPSInt {
 		PC += 4;
 	}
 
+	// Dummy COP0 register file, for kernel-mode code (e.g. flash0:/reboot.bin) that reads/
+	// writes COP0 state directly - ordinary PSP user-mode code never executes these
+	// instructions (kernel state is reached via HLE syscalls instead), so this doesn't need
+	// to model real COP0 semantics (interrupts, exceptions, TLB, ...), just be non-fatal and
+	// give writes-then-reads-back-same-value behavior. Not part of MIPSState (which is
+	// layout-sensitive for JIT register allocation) and not save-stated, in keeping with
+	// "dummy" - revisit if this ever needs to be more than a bail-out.
+	static u32 g_cop0Regs[32];
+
+	void Int_Cop0(MIPSState *mips, MIPSOpcode op) {
+		int rt = _RT;
+		int rd = _RD;
+
+		switch ((op >> 21) & 0x1f) {
+		case 0: //mfc0
+			if (rt != 0)
+				R(rt) = g_cop0Regs[rd];
+			break;
+
+		case 4: //mtc0
+			g_cop0Regs[rd] = R(rt);
+			break;
+
+		case 10: //rdpgpr
+			if (rt != 0)
+				R(rt) = R(rd);
+			break;
+
+		case 11: //mfmc0 (di/ei)
+			if (rt != 0)
+				R(rt) = g_cop0Regs[12];  // Status
+			break;
+
+		case 14: //wrpgpr
+			R(rd) = R(rt);
+			break;
+
+		default:
+			_dbg_assert_msg_(false, "Trying to interpret COP0 instruction that can't be interpreted");
+			break;
+		}
+		PC += 4;
+	}
+
 	void Int_RType2(MIPSState *mips, MIPSOpcode op) {
 		int rs = _RS;
 		int rd = _RD;

--- a/Core/MIPS/Interpreter.cpp
+++ b/Core/MIPS/Interpreter.cpp
@@ -25,6 +25,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/Config.h"
 #include "Core/Core.h"
+#include "Core/CoreTiming.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -93,19 +94,24 @@ int MIPS_SingleStep(MIPSState *mips) {
 }
 
 // Dummy functions, for any future MMIO support.
+// Unregistered reads return a distinctive poison value (not 0) so it's obvious in a live trace
+// when some later computation's input traces back to an unimplemented MMIO register, rather
+// than looking like an ordinary, legitimate zero (see docs/VSHBootInvestigation.md "Attempt 9").
+constexpr u32 UNKNOWN_MMIO_POISON = 0x1337BEEF;
+
 static u8 ReadMMIO_U8(MIPSState *mips, u32 addr) {
 	WARN_LOG(Log::CPU, "MMIO Read8 at %08x", addr);
-	return 0;
+	return (u8)UNKNOWN_MMIO_POISON;
 }
 
 static u16 ReadMMIO_U16(MIPSState *mips, u32 addr) {
 	WARN_LOG(Log::CPU, "MMIO Read16 at %08x", addr);
-	return 0;
+	return (u16)UNKNOWN_MMIO_POISON;
 }
 
 static u32 ReadMMIO_U32(MIPSState *mips, u32 addr) {
 	WARN_LOG(Log::CPU, "MMIO Read32 at %08x", addr);
-	return 0;
+	return UNKNOWN_MMIO_POISON;
 }
 
 void WriteMMIO_U8(MIPSState *mips, u32 addr, u8 value) {
@@ -700,8 +706,19 @@ namespace MIPSInt {
 
 		switch ((op >> 21) & 0x1f) {
 		case 0: //mfc0
-			if (rt != 0)
-				R(rt) = g_cop0Regs[rd];
+			if (rt != 0) {
+				// Real MIPS COP0 register 9 (Count) free-runs on its own (incrementing every
+				// other cycle) regardless of software writes - unlike the rest of this dummy
+				// shadow file, a plain "read back whatever was last written" (defaulting to a
+				// constant 0) would be wrong here and could plausibly starve boot-time
+				// calibration code of a nonzero seed/divisor. Tie it to CoreTiming instead;
+				// still not real COP0 semantics (no Compare-triggered interrupt), just a
+				// closer approximation. See docs/VSHBootInvestigation.md "Attempt 9".
+				if (rd == 9)
+					R(rt) = (u32)CoreTiming::GetTicks(mips);
+				else
+					R(rt) = g_cop0Regs[rd];
+			}
 			break;
 
 		case 4: //mtc0

--- a/Core/MIPS/Interpreter.h
+++ b/Core/MIPS/Interpreter.h
@@ -27,6 +27,7 @@ namespace MIPSInt
 	void Int_Syscall(MIPSState *mips, MIPSOpcode op);
 
 	void Int_mxc1(MIPSState *mips, MIPSOpcode op);
+	void Int_Cop0(MIPSState *mips, MIPSOpcode op);
 	void Int_RelBranch(MIPSState *mips, MIPSOpcode op);
 	void Int_RelBranchRI(MIPSState *mips, MIPSOpcode op);
 	void Int_IType(MIPSState *mips, MIPSOpcode op);

--- a/Core/MIPS/InterpreterDispatch.cpp
+++ b/Core/MIPS/InterpreterDispatch.cpp
@@ -144,6 +144,14 @@ int ExecInstruction(MIPSState *mips, MIPSOpcode op) {
     case 16:
     {
         switch ((op.encoding >> 21) & 0x1f) {
+        // mfc0, mtc0, rdpgpr, mfmc0, wrpgpr
+        case 0:
+        case 4:
+        case 10:
+        case 11:
+        case 14:
+            MIPSInt::Int_Cop0(mips, op);
+            return 1;
         case 16:
         case 17:
         case 18:

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1171,11 +1171,19 @@ static void RunUntilDowncountZeroWithChecks(MIPSState *mips, u64 globalTicks) {
 			// Replacements and similar are processed here, intentionally.
 			const MIPSInstruction *instr = MIPSGetInstruction(op);
 
-			// Check for breakpoint
+			// Check for breakpoint. Route through ExecBreakPoint() (also used by the JIT
+			// backends and the IR interpreter, via JitBreakpoint()/IRRunBreakpoint()) rather
+			// than breaking unconditionally - it's what actually respects BREAK_ACTION_LOG vs
+			// BREAK_ACTION_PAUSE (a log-only breakpoint, added with log=true and no/false
+			// enabled, must not stop execution here). The old code called Core_Break()
+			// directly whenever IsAddressBreakPoint() was true - true for *any* non-ignored
+			// breakpoint, log-only included - so log-only address breakpoints always paused
+			// too, contradicting their own documented behavior.
 			if (hasBPs && g_breakpoints.IsAddressBreakPoint(mips->pc) && g_breakpoints.CheckSkipFirst() != mips->pc) {
-				auto cond = g_breakpoints.GetBreakPointCondition(mips->pc);
-				if (!cond || cond->Evaluate()) {
-					Core_Break(BreakReason::CpuBreakpoint, mips->pc);
+				g_breakpoints.ExecBreakPoint(mips->pc);
+				// If it tripped, bail without running - same convention as memchecks/reg
+				// breakpoints below.
+				if (coreState == CORE_STEPPING_CPU) {
 					if (g_breakpoints.IsTempBreakPoint(mips->pc))
 						g_breakpoints.RemoveBreakPoint(mips->pc);
 					break;

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1142,9 +1142,24 @@ static void RunUntilDowncountZeroFast(MIPSState *mips) {
 }
 
 #define _RS(op)   ((op>>21) & 0x1F)
+// Returns the 0-31 GPR index an instruction is about to write, or -1 if it doesn't write a GPR.
+// OUT_RA is always $ra (31) - jal/bltzal/bgezal/etc. have no encoded destination register field,
+// unlike jalr (which uses OUT_RD, since its destination is chosen via the rd field).
+static inline int GetGPRWriteTarget(const MIPSInstruction *instr, MIPSOpcode op) {
+	if (instr->flags & OUT_RT)
+		return (op >> 16) & 0x1F;
+	if (instr->flags & OUT_RD)
+		return (op >> 11) & 0x1F;
+	if (instr->flags & OUT_RA)
+		return 31;
+	return -1;
+}
+
 static void RunUntilDowncountZeroWithChecks(MIPSState *mips, u64 globalTicks) {
 	bool hasBPs = g_breakpoints.HasBreakPoints();
 	bool hasMCs = g_breakpoints.HasMemChecks();
+	// Bit i set means register i has an active GPR breakpoint - see GetGPRBreakpointMask().
+	u32 gprBPMask = g_breakpoints.GetGPRBreakpointMask();
 	while (mips->downcount >= 0 && coreState == CORE_RUNNING_CPU) {
 		// Don't stop in a delay slot! Well, unless we hit a memcheck in one, of course.
 		do {
@@ -1181,6 +1196,15 @@ static void RunUntilDowncountZeroWithChecks(MIPSState *mips, u64 globalTicks) {
 				if (coreState == CORE_STEPPING_CPU)
 					break;
 			}
+			if (gprBPMask != 0 && (instr->flags & (OUT_RT | OUT_RD | OUT_RA)) != 0 && g_breakpoints.CheckSkipFirst() != mips->pc) {
+				int gprTarget = GetGPRWriteTarget(instr, op);
+				if (gprTarget >= 0 && (gprBPMask & (1u << gprTarget)) != 0) {
+					g_breakpoints.ExecGPRBreakpoint(gprTarget, mips->pc);
+					// If it tripped, bail without running - same convention as memchecks above.
+					if (coreState == CORE_STEPPING_CPU)
+						break;
+				}
+			}
 
 			bool wasInDelaySlot = mips->inDelaySlot;
 			Interpret(mips, instr, op);
@@ -1204,7 +1228,7 @@ int MIPSInterpret_RunUntil(MIPSState *mips, u64 globalTicks) {
 		CoreTiming::Advance(mips);
 
 		uint64_t ticksLeft = globalTicks - CoreTiming::GetTicks(mips);
-		if (g_breakpoints.HasBreakPoints() || g_breakpoints.HasMemChecks() || ticksLeft <= mips->downcount) {
+		if (g_breakpoints.HasBreakPoints() || g_breakpoints.HasMemChecks() || g_breakpoints.HasGPRBreakpoints() || ticksLeft <= mips->downcount) {
 			RunUntilDowncountZeroWithChecks(mips, globalTicks);
 		} else {
 			RunUntilDowncountZeroFast(mips);

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1158,8 +1158,8 @@ static inline int GetGPRWriteTarget(const MIPSInstruction *instr, MIPSOpcode op)
 static void RunUntilDowncountZeroWithChecks(MIPSState *mips, u64 globalTicks) {
 	bool hasBPs = g_breakpoints.HasBreakPoints();
 	bool hasMCs = g_breakpoints.HasMemChecks();
-	// Bit i set means register i has an active GPR breakpoint - see GetGPRBreakpointMask().
-	u32 gprBPMask = g_breakpoints.GetGPRBreakpointMask();
+	// Bit i set means register i has an active register breakpoint - see GetRegBreakpointMask().
+	u32 regBPMask = g_breakpoints.GetRegBreakpointMask();
 	while (mips->downcount >= 0 && coreState == CORE_RUNNING_CPU) {
 		// Don't stop in a delay slot! Well, unless we hit a memcheck in one, of course.
 		do {
@@ -1196,10 +1196,10 @@ static void RunUntilDowncountZeroWithChecks(MIPSState *mips, u64 globalTicks) {
 				if (coreState == CORE_STEPPING_CPU)
 					break;
 			}
-			if (gprBPMask != 0 && (instr->flags & (OUT_RT | OUT_RD | OUT_RA)) != 0 && g_breakpoints.CheckSkipFirst() != mips->pc) {
-				int gprTarget = GetGPRWriteTarget(instr, op);
-				if (gprTarget >= 0 && (gprBPMask & (1u << gprTarget)) != 0) {
-					g_breakpoints.ExecGPRBreakpoint(gprTarget, mips->pc);
+			if (regBPMask != 0 && (instr->flags & (OUT_RT | OUT_RD | OUT_RA)) != 0 && g_breakpoints.CheckSkipFirst() != mips->pc) {
+				int regTarget = GetGPRWriteTarget(instr, op);
+				if (regTarget >= 0 && (regBPMask & (1u << regTarget)) != 0) {
+					g_breakpoints.ExecRegBreakpoint(regTarget, mips->pc);
 					// If it tripped, bail without running - same convention as memchecks above.
 					if (coreState == CORE_STEPPING_CPU)
 						break;
@@ -1228,7 +1228,7 @@ int MIPSInterpret_RunUntil(MIPSState *mips, u64 globalTicks) {
 		CoreTiming::Advance(mips);
 
 		uint64_t ticksLeft = globalTicks - CoreTiming::GetTicks(mips);
-		if (g_breakpoints.HasBreakPoints() || g_breakpoints.HasMemChecks() || g_breakpoints.HasGPRBreakpoints() || ticksLeft <= mips->downcount) {
+		if (g_breakpoints.HasBreakPoints() || g_breakpoints.HasMemChecks() || g_breakpoints.HasRegBreakpoints() || ticksLeft <= mips->downcount) {
 			RunUntilDowncountZeroWithChecks(mips, globalTicks);
 		} else {
 			RunUntilDowncountZeroFast(mips);

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -368,23 +368,27 @@ static const MIPSInstruction tableCop2BC2[4] = // 010010 01000 ...xx ...........
 
 static const MIPSInstruction tableCop0[32] = // 010000 xxxxx ..... ................
 {
-	INSTR("mfc0", JITFUNC(Comp_Generic), Dis_Generic, 0, OUT_RT),  // unused
+	// Dummy interpreter-only implementations (Int_Cop0, Interpreter.cpp) - real hardware
+	// semantics aren't modeled, just enough to not fault. Ordinary user-mode PSP code never
+	// executes these; kernel-mode boot code (flash0:/reboot.bin) does. See
+	// docs/VSHBootInvestigation.md.
+	INSTR("mfc0", JITFUNC(Comp_Generic), Dis_Generic, Int_Cop0, OUT_RT),
 	INVALID,
 	INVALID,
 	INVALID,
-	INSTR("mtc0", JITFUNC(Comp_Generic), Dis_Generic, 0, IN_RT),  // unused
+	INSTR("mtc0", JITFUNC(Comp_Generic), Dis_Generic, Int_Cop0, IN_RT),
 	INVALID,
 	INVALID,
 	INVALID,
 	//8
 	INVALID,
 	INVALID,
-	INSTR("rdpgpr", JITFUNC(Comp_Generic), Dis_Generic, 0, 0),
-	INSTR("mfmc0", JITFUNC(Comp_Generic), Dis_Generic, 0, 0),
+	INSTR("rdpgpr", JITFUNC(Comp_Generic), Dis_Generic, Int_Cop0, OUT_RT),
+	INSTR("mfmc0", JITFUNC(Comp_Generic), Dis_Generic, Int_Cop0, OUT_RT),
 
 	INVALID,
 	INVALID,
-	INSTR("wrpgpr", JITFUNC(Comp_Generic), Dis_Generic, 0, 0),
+	INSTR("wrpgpr", JITFUNC(Comp_Generic), Dis_Generic, Int_Cop0, IN_RT),
 	INVALID,
 	//16
 	ENCODING(Cop0CO), ENCODING(Cop0CO), ENCODING(Cop0CO), ENCODING(Cop0CO), ENCODING(Cop0CO), ENCODING(Cop0CO), ENCODING(Cop0CO), ENCODING(Cop0CO),

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -53,6 +53,8 @@ MemArena g_arena;
 u8 *m_pNullPage;
 u8 *m_pPhysicalScratchPad;
 u8 *m_pUncachedScratchPad;
+u8 *m_pKernelScratchPad;
+u8 *m_pUncachedKernelScratchPad;
 // 64-bit: Pointers to high-mem mirrors
 // 32-bit: Same as above
 u8 *m_pPhysicalRAM[3];
@@ -92,6 +94,12 @@ static MemoryView views[] = {
 	{&m_pNullPage,            0x00000000, 0x00010000, MV_NULL_PAGE}, // Null page, usually not enabled. Only used for working around some race condition bugs.
 	{&m_pPhysicalScratchPad,  0x00010000, SCRATCHPAD_SIZE, 0},
 	{&m_pUncachedScratchPad,  0x40010000, SCRATCHPAD_SIZE, MV_MIRROR_PREVIOUS},
+	// Kernel-mode code (e.g. flash0:/reboot.bin) sees the scratchpad through these mirrors -
+	// same two address bits as RAM below (0x80000000 = kernel, 0x40000000 = uncached,
+	// independently combinable), just missing here until this was noticed via a real SIGSEGV
+	// writing 0x80010000 (see docs/VSHBootInvestigation.md).
+	{&m_pKernelScratchPad,        0x80010000, SCRATCHPAD_SIZE, MV_MIRROR_PREVIOUS | MV_KERNEL},
+	{&m_pUncachedKernelScratchPad,0xC0010000, SCRATCHPAD_SIZE, MV_MIRROR_PREVIOUS | MV_KERNEL},
 	{&m_pPhysicalVRAM[0],     0x04000000, 0x00200000, 0},
 	{&m_pPhysicalVRAM[1],     0x04200000, 0x00200000, MV_MIRROR_PREVIOUS},
 	{&m_pPhysicalVRAM[2],     0x04400000, 0x00200000, MV_MIRROR_PREVIOUS},

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -305,7 +305,7 @@ inline bool IsValidAddress(const u32 address) {
 		return true;
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
-	} else if ((address & 0xBFFFC000) == 0x00010000) {
+	} else if ((address & 0x3FFFC000) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return true;
@@ -319,7 +319,7 @@ inline bool IsValid2AlignedAddress(const u32 address) {
 		return true;
 	} else if ((address & 0x3F800001) == 0x04000000) {
 		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
-	} else if ((address & 0xBFFFC001) == 0x00010000) {
+	} else if ((address & 0x3FFFC001) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return (address & 1) == 0;
@@ -333,7 +333,7 @@ inline bool IsValid4AlignedAddress(const u32 address) {
 		return true;
 	} else if ((address & 0x3F800003) == 0x04000000) {
 		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
-	} else if ((address & 0xBFFFC003) == 0x00010000) {
+	} else if ((address & 0x3FFFC003) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return (address & 3) == 0;
@@ -351,7 +351,7 @@ inline u32 MaxSizeAtAddress(const u32 address) {
 		} else {
 			return 0x04800000 - (address & 0x3FFFFFFF);
 		}
-	} else if ((address & 0xBFFFC000) == 0x00010000) {
+	} else if ((address & 0x3FFFC000) == 0x00010000) {
 		return 0x00014000 - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return 0x08000000 + g_MemorySize - (address & 0x3FFFFFFF);

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -30,7 +30,7 @@ namespace Memory {
 u8 *GetPointerWriteOrException(const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000 || // RAM
 		(address & 0xBF800000) == 0x04000000 || // VRAM
-		(address & 0xBFFFC000) == 0x00010000 || // Scratchpad
+		(address & 0x3FFFC000) == 0x00010000 || // Scratchpad
 		((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize)) { // More RAM (remasters, etc.)
 		return GetPointerWriteUnchecked(address);
 	} else {
@@ -43,7 +43,7 @@ u8 *GetPointerWriteOrException(const u32 address) {
 const u8 *GetPointerOrException(const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000 || // RAM
 		(address & 0xBF800000) == 0x04000000 || // VRAM
-		(address & 0xBFFFC000) == 0x00010000 || // Scratchpad
+		(address & 0x3FFFC000) == 0x00010000 || // Scratchpad
 		((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize)) { // More RAM (remasters, etc.)
 		return GetPointerUnchecked(address);
 	} else {
@@ -89,7 +89,7 @@ template <typename T>
 inline void ReadMemoryOrException(T &var, const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000 || // RAM
 		(address & 0xBF800000) == 0x04000000 || // VRAM
-		(address & 0xBFFFC000) == 0x00010000 || // Scratchpad
+		(address & 0x3FFFC000) == 0x00010000 || // Scratchpad
 		((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize)) { // More RAM (remasters, etc.)
 		var = *((const T*)GetPointerUnchecked(address));
 	} else {
@@ -102,7 +102,7 @@ template <typename T>
 inline void WriteMemoryOrException(u32 address, const T data) {
 	if ((address & 0x3E000000) == 0x08000000 || // RAM
 		(address & 0xBF800000) == 0x04000000 || // VRAM
-		(address & 0xBFFFC000) == 0x00010000 || // Scratchpad
+		(address & 0x3FFFC000) == 0x00010000 || // Scratchpad
 		((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize)) { // More RAM (remasters, etc.)
 		*(T*)GetPointerUnchecked(address) = data;
 	} else {
@@ -121,7 +121,9 @@ bool IsRAMAddress(const u32 address) {
 }
 
 bool IsScratchpadAddress(const u32 address) {
-	return (address & 0xBFFFC000) == 0x00010000;
+	// Ignore both the kernel bit (0x80000000) and the uncached bit (0x40000000) - the
+	// scratchpad is mirrored across all four combinations, same as RAM (see MemMap.cpp).
+	return (address & ~(0xC0000000 | (SCRATCHPAD_SIZE - 1))) == 0x00010000;
 }
 
 u8 ReadOrException_U8(const u32 address) {

--- a/Tools/wsdbg/Cargo.lock
+++ b/Tools/wsdbg/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +483,7 @@ name = "wsdbg"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "serde_json",
  "tungstenite",

--- a/Tools/wsdbg/Cargo.toml
+++ b/Tools/wsdbg/Cargo.toml
@@ -9,3 +9,4 @@ clap = { version = "4.5", features = ["derive"] }
 tungstenite = "0.24"
 serde_json = "1.0"
 anyhow = "1.0"
+base64 = "0.22"

--- a/Tools/wsdbg/README.md
+++ b/Tools/wsdbg/README.md
@@ -48,3 +48,23 @@ cargo run -- 12345 --raw '{"event":"cpu.evaluate","expression":"pc"}'
 ```
 
 Type `:help` in the REPL for a quick reminder, `:quit` to disconnect.
+
+## Scripting a multi-step sequence
+
+Piping several commands into the REPL (`(echo cmd1; echo cmd2; ...) | wsdbg PORT`) sends them all
+immediately by default - nothing waits for a response before moving to the next line, so scripts
+traditionally needed `sleep N` between commands to guess how long each one takes. Pass `--sync`
+to remove the guessing: each line blocks until its own response arrives (matched by ticket) before
+the next line is read, and for `cpu.resume`/`cpu.stepInto`/`cpu.stepOver`/`cpu.stepOut`/
+`cpu.runUntil`/`cpu.nextHLE` it also waits for the following `cpu.stepping` broadcast - the actual
+"the CPU stopped again" signal those commands imply. Everything still prints as it arrives; this
+only changes when the *next* line gets sent. A breakpoint that never trips would otherwise hang
+the script forever, so it gives up after `--sync-timeout` seconds (default 30) and moves on.
+
+```bash
+(
+  echo 'cpu.breakpoint.add address=134348800 enabled=true'
+  echo 'cpu.resume'
+  echo 'cpu.getAllRegs'
+) | cargo run -- 12345 --sync
+```

--- a/Tools/wsdbg/src/main.rs
+++ b/Tools/wsdbg/src/main.rs
@@ -93,6 +93,61 @@ fn next_ticket() -> u64 {
     TICKET.fetch_add(1, Ordering::Relaxed)
 }
 
+// A minimal shell-like tokenizer: splits on unquoted whitespace, and lets 'single' or "double"
+// quotes protect spaces (and each other) from being treated as a separator - e.g.
+// `logFormat="job func v0={v0} a0={a0}"` becomes one token, not four bogus ones that
+// build_event_json would silently misparse as extra, malformed key=value pairs (or fail on
+// outright). Quote characters are stripped from the resulting token, same as a normal shell; a
+// backslash escapes the very next character (including inside quotes), which is enough for this
+// tool's purposes without pulling in a full shell-parsing crate.
+fn split_shell_words(line: &str) -> Result<Vec<String>> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut in_word = false;
+    let mut quote: Option<char> = None;
+    let mut chars = line.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(q) => {
+                if c == '\\' && chars.peek().is_some() {
+                    current.push(chars.next().unwrap());
+                } else if c == q {
+                    quote = None;
+                } else {
+                    current.push(c);
+                }
+            }
+            None => {
+                if c == '\'' || c == '"' {
+                    quote = Some(c);
+                    in_word = true;
+                } else if c == '\\' && chars.peek().is_some() {
+                    current.push(chars.next().unwrap());
+                    in_word = true;
+                } else if c.is_whitespace() {
+                    if in_word {
+                        words.push(std::mem::take(&mut current));
+                        in_word = false;
+                    }
+                } else {
+                    current.push(c);
+                    in_word = true;
+                }
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return Err(anyhow!("Unterminated quote in command line"));
+    }
+    if in_word {
+        words.push(current);
+    }
+
+    Ok(words)
+}
+
 fn parse_value(raw: &str) -> serde_json::Value {
     // Accept numbers, true/false, null, and "quoted strings" as JSON; anything
     // else (including bare words and unescaped strings) is sent as a plain string.
@@ -200,14 +255,14 @@ fn handle_repl_line(socket: &mut WebSocket<TcpStream>, line: &str) -> Result<Opt
         return Ok(ticket.zip(event));
     }
 
-    let mut parts = line.split_whitespace();
+    let mut parts = split_shell_words(line)?.into_iter();
     let event = parts.next().ok_or_else(|| anyhow!("Empty command"))?;
-    let rest: Vec<String> = parts.map(|s| s.to_string()).collect();
+    let rest: Vec<String> = parts.collect();
     let ticket = next_ticket();
-    let json_text = build_event_json(event, &rest, Some(ticket))?;
+    let json_text = build_event_json(&event, &rest, Some(ticket))?;
     println!("-> (ticket {ticket}) {json_text}");
     socket.send(Message::Text(json_text.into()))?;
-    Ok(Some((ticket, event.to_string())))
+    Ok(Some((ticket, event)))
 }
 
 // --sync support: after sending a command, read (and print, same as the normal loop) incoming

--- a/Tools/wsdbg/src/main.rs
+++ b/Tools/wsdbg/src/main.rs
@@ -56,7 +56,36 @@ struct Args {
     /// Send this raw JSON text instead of building one from event/params (one-shot mode).
     #[arg(long)]
     raw: Option<String>,
+
+    /// REPL mode only: after sending a command, block until its ticketed response arrives
+    /// (and, for cpu.resume/cpu.step*/cpu.runUntil, until the following cpu.stepping broadcast
+    /// too) before reading the next input line. Turns a scripted sequence like
+    /// "(echo cmd1; sleep 1; echo cmd2; ...)" into "(echo cmd1; echo cmd2; ...)" - no more
+    /// guessing how long each step takes. All messages still print as they arrive; this only
+    /// changes when the *next* line gets read. Has no effect on one-shot mode (event/--raw),
+    /// which already waits up to --wait seconds for everything regardless.
+    #[arg(long)]
+    sync: bool,
+
+    /// With --sync, how long to wait for a command's response (and, for resume/step commands,
+    /// the following cpu.stepping) before giving up and reading the next line anyway, in
+    /// seconds. A breakpoint that never trips (bad condition, wrong address, etc.) would
+    /// otherwise hang the script forever.
+    #[arg(long, default_value_t = 30.0)]
+    sync_timeout: f64,
 }
+
+// Events that mean "let the CPU run" - after their own ticketed response comes back, --sync
+// also waits for the *next* cpu.stepping broadcast (which has no ticket of its own), since
+// that's the actual "it stopped again" signal any script issuing one of these actually wants.
+const RESUME_FAMILY: &[&str] = &[
+    "cpu.resume",
+    "cpu.stepInto",
+    "cpu.stepOver",
+    "cpu.stepOut",
+    "cpu.runUntil",
+    "cpu.nextHLE",
+];
 
 static TICKET: AtomicU64 = AtomicU64::new(1);
 
@@ -152,28 +181,90 @@ fn print_help() {
     println!(":help            show this message");
     println!(":quit / :q       disconnect and exit");
     println!("See docs/WebSocketDebugger.md in the ppsspp repo for the full event catalog.");
+    println!("Piping a script in? Pass --sync so each line waits for its response (and, for");
+    println!("cpu.resume/step*/runUntil, the following cpu.stepping) before the next line runs -");
+    println!("no more guessing sleep durations.");
 }
 
-fn handle_repl_line(socket: &mut WebSocket<TcpStream>, line: &str) -> Result<()> {
-    let json_text = if line.starts_with('{') {
-        line.to_string()
-    } else {
-        let mut parts = line.split_whitespace();
-        let event = parts.next().ok_or_else(|| anyhow!("Empty command"))?;
-        let rest: Vec<String> = parts.map(|s| s.to_string()).collect();
-        let ticket = next_ticket();
-        let json_text = build_event_json(event, &rest, Some(ticket))?;
-        println!("-> (ticket {ticket}) {json_text}");
-        socket.send(Message::Text(json_text.into()))?;
-        return Ok(());
-    };
+// Returns the (ticket, event name) sent, when known - used by --sync to know what response to
+// wait for. Both are recoverable for a plain "{...}" JSON paste too, as long as it includes
+// "ticket"/"event" fields itself; if it doesn't (or ticket isn't a plain integer), --sync has
+// nothing to wait on and just proceeds to the next line immediately, same as without --sync.
+fn handle_repl_line(socket: &mut WebSocket<TcpStream>, line: &str) -> Result<Option<(u64, String)>> {
+    if line.starts_with('{') {
+        println!("-> {line}");
+        socket.send(Message::Text(line.to_string().into()))?;
+        let parsed: serde_json::Value = serde_json::from_str(line).unwrap_or(serde_json::Value::Null);
+        let ticket = parsed.get("ticket").and_then(|t| t.as_u64());
+        let event = parsed.get("event").and_then(|e| e.as_str()).map(|s| s.to_string());
+        return Ok(ticket.zip(event));
+    }
 
-    println!("-> {json_text}");
+    let mut parts = line.split_whitespace();
+    let event = parts.next().ok_or_else(|| anyhow!("Empty command"))?;
+    let rest: Vec<String> = parts.map(|s| s.to_string()).collect();
+    let ticket = next_ticket();
+    let json_text = build_event_json(event, &rest, Some(ticket))?;
+    println!("-> (ticket {ticket}) {json_text}");
     socket.send(Message::Text(json_text.into()))?;
-    Ok(())
+    Ok(Some((ticket, event.to_string())))
 }
 
-fn run_repl(mut socket: WebSocket<TcpStream>) -> Result<()> {
+// --sync support: after sending a command, read (and print, same as the normal loop) incoming
+// messages until we've seen what that command actually completes with, or sync_timeout runs
+// out. Returns to the normal loop either way; a timeout just means the next line gets read
+// without having waited further.
+//
+// RESUME_FAMILY events (cpu.resume/step*/runUntil/nextHLE) are documented as having "no
+// immediate response" at all - their handlers never call req.Respond(), only req.Fail() on
+// error, so on success the *only* message that ever comes back is the unticketed cpu.stepping
+// broadcast once the CPU actually stops again. Waiting for a ticketed ack for these would hang
+// until the timeout every time, so don't - wait for cpu.stepping instead. Everything else uses
+// the normal ticketed request/response pair.
+fn wait_for_sync_response(socket: &mut WebSocket<TcpStream>, ticket: u64, event: &str, timeout_secs: f64) {
+    let wants_stepping = RESUME_FAMILY.contains(&event);
+    // wants_stepping: there's no ticketed response to wait for at all (see doc comment above),
+    // so treat "got_ticket" as trivially satisfied and only really wait on got_stepping. The
+    // reverse for every other event: no cpu.stepping is expected, only the ticketed response.
+    let mut got_ticket = wants_stepping;
+    let mut got_stepping = !wants_stepping;
+    let deadline = Instant::now() + Duration::from_secs_f64(timeout_secs.max(0.0));
+
+    while Instant::now() < deadline && !(got_ticket && got_stepping) {
+        match socket.read() {
+            Ok(Message::Text(text)) => {
+                print_incoming(&text);
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if !wants_stepping && v.get("ticket").and_then(|t| t.as_u64()) == Some(ticket) {
+                        got_ticket = true;
+                    }
+                    if wants_stepping && v.get("event").and_then(|e| e.as_str()) == Some("cpu.stepping") {
+                        got_stepping = true;
+                    }
+                }
+            }
+            Ok(Message::Close(frame)) => {
+                println!("\n[connection closed by PPSSPP: {frame:?}]");
+                return;
+            }
+            Ok(_) => {}
+            Err(ref e) if is_would_block(e) => {}
+            Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                println!("\n[connection closed]");
+                return;
+            }
+            Err(e) => {
+                eprintln!("\n[connection error: {e}]");
+                return;
+            }
+        }
+    }
+    if !(got_ticket && got_stepping) {
+        eprintln!("! --sync: timed out after {timeout_secs}s waiting for a response, continuing anyway");
+    }
+}
+
+fn run_repl(mut socket: WebSocket<TcpStream>, sync: bool, sync_timeout: f64) -> Result<()> {
     socket.get_ref().set_read_timeout(Some(Duration::from_millis(100)))?;
 
     // Politely say hello, per protocol convention (see WebSocket/GameSubscriber.cpp).
@@ -215,11 +306,13 @@ fn run_repl(mut socket: WebSocket<TcpStream>) -> Result<()> {
                     ":quit" | ":q" | ":exit" => return Ok(()),
                     ":help" | ":h" => print_help(),
                     "" => {}
-                    _ => {
-                        if let Err(e) = handle_repl_line(&mut socket, line) {
-                            eprintln!("! {e}");
+                    _ => match handle_repl_line(&mut socket, line) {
+                        Err(e) => eprintln!("! {e}"),
+                        Ok(Some((ticket, event))) if sync => {
+                            wait_for_sync_response(&mut socket, ticket, &event, sync_timeout);
                         }
-                    }
+                        Ok(_) => {}
+                    },
                 }
                 print!("> ");
                 io::stdout().flush().ok();
@@ -270,5 +363,5 @@ fn main() -> Result<()> {
         return run_one_shot(socket, json_text, args.wait);
     }
 
-    run_repl(socket)
+    run_repl(socket, args.sync, args.sync_timeout)
 }

--- a/Tools/wsdbg/src/main.rs
+++ b/Tools/wsdbg/src/main.rs
@@ -7,6 +7,7 @@
 //   wsdbg 12345 game.status            # one-shot: send an event, print responses, exit
 //   wsdbg 12345 cpu.setReg thread=0 name=0 value=42
 
+use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 use std::net::TcpStream;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -15,10 +16,14 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow};
+use base64::Engine as _;
 use clap::Parser;
 use tungstenite::client::IntoClientRequest;
 use tungstenite::http::HeaderValue;
 use tungstenite::{Message, WebSocket};
+
+// name -> (address, as the user typed it - not reparsed, just echoed back for display; bytes).
+type Snapshots = HashMap<String, (String, Vec<u8>)>;
 
 const SUBPROTOCOL: &str = "debugger.ppsspp.org";
 
@@ -233,8 +238,11 @@ fn print_help() {
     println!("    cpu.setReg thread=0 name=4 value=1000");
     println!("Or paste a full JSON message starting with '{{' to send it verbatim.");
     println!("A numeric 'ticket' is auto-assigned to shorthand commands so you can match up responses.");
-    println!(":help            show this message");
-    println!(":quit / :q       disconnect and exit");
+    println!(":help                              show this message");
+    println!(":quit / :q                         disconnect and exit");
+    println!(":snapshot <name> <addr> <size>     memory.read into a locally-named byte buffer");
+    println!(":snapshots                         list saved snapshots");
+    println!(":diff <name1> <name2>              byte-compare two snapshots");
     println!("See docs/WebSocketDebugger.md in the ppsspp repo for the full event catalog.");
     println!("Piping a script in? Pass --sync so each line waits for its response (and, for");
     println!("cpu.resume/step*/runUntil, the following cpu.stepping) before the next line runs -");
@@ -319,6 +327,160 @@ fn wait_for_sync_response(socket: &mut WebSocket<TcpStream>, ticket: u64, event:
     }
 }
 
+// Send a ticketed request and block until its response arrives (or timeout), returning the
+// parsed JSON. Unlike the normal REPL dispatch (fire-and-forget, or --sync's "wait but don't
+// look at the payload"), :snapshot needs the actual returned data before it can do anything -
+// there's no useful way to "move on to the next input line" first.
+fn send_and_wait(
+    socket: &mut WebSocket<TcpStream>,
+    event: &str,
+    params: &[String],
+    timeout_secs: f64,
+) -> Result<serde_json::Value> {
+    let ticket = next_ticket();
+    let json_text = build_event_json(event, params, Some(ticket))?;
+    println!("-> (ticket {ticket}) {json_text}");
+    socket.send(Message::Text(json_text.into()))?;
+
+    let deadline = Instant::now() + Duration::from_secs_f64(timeout_secs.max(0.0));
+    while Instant::now() < deadline {
+        match socket.read() {
+            Ok(Message::Text(text)) => {
+                print_incoming(&text);
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if v.get("ticket").and_then(|t| t.as_u64()) == Some(ticket) {
+                        return Ok(v);
+                    }
+                }
+            }
+            Ok(Message::Close(frame)) => return Err(anyhow!("connection closed by PPSSPP: {frame:?}")),
+            Ok(_) => {}
+            Err(ref e) if is_would_block(e) => {}
+            Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                return Err(anyhow!("connection closed"));
+            }
+            Err(e) => return Err(anyhow!("connection error: {e}")),
+        }
+    }
+    Err(anyhow!("timed out after {timeout_secs}s waiting for a response"))
+}
+
+// :snapshot <name> <address> <size> - reads memory.read once (blocking, unlike the rest of the
+// REPL) and stores the decoded bytes locally under <name>. address/size are passed through to
+// the server exactly as typed (same as any other event param - the server already accepts
+// "0x..." hex strings for address-like fields), not reparsed here.
+//
+// Kept entirely client-side rather than as a new PPSSPP-side memory.snapshot.* event: a
+// snapshot is a debugging-*session*-scoped concept (how long should the emulator hold onto one?
+// does it survive a savestate load or game restart? does it leak if a script forgets to clean
+// up?) with no real emulator-side meaning, and memory.read's existing base64 response is already
+// the only primitive actually needed - no new protocol surface required.
+fn cmd_snapshot(socket: &mut WebSocket<TcpStream>, snapshots: &mut Snapshots, args: &[&str], timeout_secs: f64) {
+    if args.len() != 3 {
+        eprintln!("! Usage: :snapshot <name> <address> <size>");
+        return;
+    }
+    let name = args[0];
+    let params = vec![format!("address={}", args[1]), format!("size={}", args[2])];
+    match send_and_wait(socket, "memory.read", &params, timeout_secs) {
+        Ok(resp) => {
+            if resp.get("event").and_then(|e| e.as_str()) == Some("error") {
+                let msg = resp.get("message").and_then(|m| m.as_str()).unwrap_or("unknown error");
+                eprintln!("! memory.read failed: {msg}");
+                return;
+            }
+            let b64 = match resp.get("base64").and_then(|b| b.as_str()) {
+                Some(b) => b,
+                None => {
+                    eprintln!("! Response had no 'base64' field: {resp}");
+                    return;
+                }
+            };
+            match base64::engine::general_purpose::STANDARD.decode(b64) {
+                Ok(bytes) => {
+                    let len = bytes.len();
+                    snapshots.insert(name.to_string(), (args[1].to_string(), bytes));
+                    println!("snapshot '{name}' saved: {len} bytes at {}", args[1]);
+                }
+                Err(e) => eprintln!("! Could not decode base64 response: {e}"),
+            }
+        }
+        Err(e) => eprintln!("! {e}"),
+    }
+}
+
+// :snapshots - list what's been captured so far in this session.
+fn cmd_list_snapshots(snapshots: &Snapshots) {
+    if snapshots.is_empty() {
+        println!("No snapshots saved. Use :snapshot <name> <address> <size> to take one.");
+        return;
+    }
+    let mut names: Vec<&String> = snapshots.keys().collect();
+    names.sort();
+    for name in names {
+        let (addr, bytes) = &snapshots[name];
+        println!("  {name}: {} bytes at {addr}", bytes.len());
+    }
+}
+
+// :diff <name1> <name2> - byte-compare two snapshots and print each differing run as
+// "+offset (N bytes): old_hex -> new_hex". Replaces the throwaway PowerShell/Bash diffing this
+// was needed for by hand at least twice during the VSH boot investigation (see
+// docs/VSHBootInvestigation.md) with one correct implementation.
+fn cmd_diff(snapshots: &Snapshots, args: &[&str]) {
+    if args.len() != 2 {
+        eprintln!("! Usage: :diff <name1> <name2>");
+        return;
+    }
+    let Some((addr1, bytes1)) = snapshots.get(args[0]) else {
+        eprintln!("! No snapshot named '{}' (see :snapshots)", args[0]);
+        return;
+    };
+    let Some((addr2, bytes2)) = snapshots.get(args[1]) else {
+        eprintln!("! No snapshot named '{}' (see :snapshots)", args[1]);
+        return;
+    };
+
+    let len = bytes1.len().min(bytes2.len());
+    if bytes1.len() != bytes2.len() {
+        println!(
+            "'{}' ({} bytes at {addr1}) and '{}' ({} bytes at {addr2}) differ in size - comparing the first {len} bytes",
+            args[0], bytes1.len(), args[1], bytes2.len()
+        );
+    }
+
+    const MAX_RUNS: usize = 50;
+    let mut runs = 0usize;
+    let mut i = 0usize;
+    while i < len {
+        if bytes1[i] == bytes2[i] {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < len && bytes1[i] != bytes2[i] {
+            i += 1;
+        }
+        runs += 1;
+        if runs <= MAX_RUNS {
+            let old_hex: Vec<String> = bytes1[start..i].iter().map(|b| format!("{b:02x}")).collect();
+            let new_hex: Vec<String> = bytes2[start..i].iter().map(|b| format!("{b:02x}")).collect();
+            let count = i - start;
+            println!(
+                "  +{start:#06x} ({count} byte{}): {} -> {}",
+                if count == 1 { "" } else { "s" },
+                old_hex.join(" "),
+                new_hex.join(" ")
+            );
+        }
+    }
+    if runs == 0 {
+        println!("'{}' and '{}' are identical (first {len} bytes)", args[0], args[1]);
+    } else if runs > MAX_RUNS {
+        println!("  ... and {} more differing run(s)", runs - MAX_RUNS);
+    }
+}
+
 fn run_repl(mut socket: WebSocket<TcpStream>, sync: bool, sync_timeout: f64) -> Result<()> {
     socket.get_ref().set_read_timeout(Some(Duration::from_millis(100)))?;
 
@@ -353,14 +515,26 @@ fn run_repl(mut socket: WebSocket<TcpStream>, sync: bool, sync_timeout: f64) -> 
     print!("> ");
     io::stdout().flush().ok();
 
+    let mut snapshots: Snapshots = Snapshots::new();
+
     loop {
         match rx.try_recv() {
             Ok(line) => {
                 let line = line.trim();
-                match line {
-                    ":quit" | ":q" | ":exit" => return Ok(()),
-                    ":help" | ":h" => print_help(),
-                    "" => {}
+                let mut words = line.split_whitespace();
+                match words.next() {
+                    Some(":quit") | Some(":q") | Some(":exit") => return Ok(()),
+                    Some(":help") | Some(":h") => print_help(),
+                    Some(":snapshot") => {
+                        let args: Vec<&str> = words.collect();
+                        cmd_snapshot(&mut socket, &mut snapshots, &args, sync_timeout);
+                    }
+                    Some(":snapshots") => cmd_list_snapshots(&snapshots),
+                    Some(":diff") => {
+                        let args: Vec<&str> = words.collect();
+                        cmd_diff(&snapshots, &args);
+                    }
+                    None => {}
                     _ => match handle_repl_line(&mut socket, line) {
                         Err(e) => eprintln!("! {e}"),
                         Ok(Some((ticket, event))) if sync => {

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -108,6 +108,7 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPUBufferSubscriber.h" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\GPUDisasmSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPURecordSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPUStatsSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\HLESubscriber.h" />
@@ -382,6 +383,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPUBufferSubscriber.cpp" />
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\GPUDisasmSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPURecordSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPUStatsSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\HLESubscriber.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -21,6 +21,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPUBufferSubscriber.cpp" />
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\GPUDisasmSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPURecordSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPUStatsSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\HLESubscriber.cpp" />
@@ -438,6 +439,7 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPUBufferSubscriber.h" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\GPUDisasmSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPURecordSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPUStatsSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\HLESubscriber.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -664,6 +664,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Debugger/WebSocket/GameBroadcaster.cpp \
   $(SRC)/Core/Debugger/WebSocket/GameSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/GPUBufferSubscriber.cpp \
+  $(SRC)/Core/Debugger/WebSocket/GPUDisasmSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/GPURecordSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/GPUStatsSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/HLESubscriber.cpp \

--- a/docs/WebSocketDebugger.md
+++ b/docs/WebSocketDebugger.md
@@ -105,7 +105,7 @@ file - this is just an index.
 | Game/version | `game.reset`, `game.status`, `version` | `GameSubscriber.cpp` |
 | CPU core | `cpu.stepping`, `cpu.resume`, `cpu.status`, `cpu.getAllRegs`, `cpu.getReg`, `cpu.setReg`, `cpu.evaluate` | `CPUCoreSubscriber.cpp` |
 | Stepping | `cpu.stepInto`, `cpu.stepOver`, `cpu.stepOut`, `cpu.runUntil`, `cpu.nextHLE` | `SteppingSubscriber.cpp` |
-| Breakpoints | `cpu.breakpoint.add/update/remove/list`, `memory.breakpoint.add/update/remove/list`, `cpu.gprBreakpoint.add/update/remove/list` (break when a GPR is written to, by any instruction anywhere - interpreter-only, no effect under a JIT backend) | `BreakpointSubscriber.cpp` |
+| Breakpoints | `cpu.breakpoint.add/update/remove/list`, `memory.breakpoint.add/update/remove/list`, `cpu.regBreakpoint.add/update/remove/list` (break when a register is written to, by any instruction anywhere - currently GPRs only; interpreter-only, no effect under a JIT backend) | `BreakpointSubscriber.cpp` |
 | Memory read/write | `memory.read_u8/u16/u32`, `memory.read`, `memory.readString`, `memory.write_u8/u16/u32`, `memory.write` | `MemorySubscriber.cpp` |
 | Memory search | `memory.search` - scan a range for a `u8`/`u16`/`u32`/`float` value or a `bytes` pattern (with an optional wildcard mask), for narrowing down where an unknown value lives (Cheat Engine style) | `MemorySubscriber.cpp` |
 | Memory info/annotations | `memory.mapping`, `memory.info.config/set/list/search` | `MemoryInfoSubscriber.cpp` |

--- a/docs/WebSocketDebugger.md
+++ b/docs/WebSocketDebugger.md
@@ -109,7 +109,8 @@ file - this is just an index.
 | Memory read/write | `memory.read_u8/u16/u32`, `memory.read`, `memory.readString`, `memory.write_u8/u16/u32`, `memory.write` | `MemorySubscriber.cpp` |
 | Memory search | `memory.search` - scan a range for a `u8`/`u16`/`u32`/`float` value or a `bytes` pattern (with an optional wildcard mask), for narrowing down where an unknown value lives (Cheat Engine style) | `MemorySubscriber.cpp` |
 | Memory info/annotations | `memory.mapping`, `memory.info.config/set/list/search` | `MemoryInfoSubscriber.cpp` |
-| Disassembly | `memory.base`, `memory.disasm`, `memory.searchDisasm`, `memory.assemble` | `DisasmSubscriber.cpp` |
+| Disassembly | `memory.base`, `memory.disasm` (add `compact=true` for plain-text lines instead of full per-field objects), `memory.searchDisasm` (add `findAll=true` for every match instead of just the first - e.g. "every caller of this address"), `memory.assemble` | `DisasmSubscriber.cpp` |
+| GE display list disassembly | `gpu.displaylist.disasm` - like `memory.disasm` but for GE command words (`CLEARMODE`, `PRIM`, etc.) instead of CPU instructions; also supports `compact=true` | `GPUDisasmSubscriber.cpp` |
 | HLE | `hle.thread.list/wake/stop`, `hle.func.list/add/remove/removeRange/rename/scan`, `hle.module.list`, `hle.backtrace` | `HLESubscriber.cpp` |
 | Data symbols | `hle.data.list/add/remove/rename` - label discovered data (structs, tables, buffers) with a name/type, same idea as `hle.func.*` but for `ST_DATA` symbols | `HLESubscriber.cpp` |
 | GPU stats | `gpu.stats.get`, `gpu.stats.feed` | `GPUStatsSubscriber.cpp` |

--- a/docs/WebSocketDebugger.md
+++ b/docs/WebSocketDebugger.md
@@ -105,7 +105,7 @@ file - this is just an index.
 | Game/version | `game.reset`, `game.status`, `version` | `GameSubscriber.cpp` |
 | CPU core | `cpu.stepping`, `cpu.resume`, `cpu.status`, `cpu.getAllRegs`, `cpu.getReg`, `cpu.setReg`, `cpu.evaluate` | `CPUCoreSubscriber.cpp` |
 | Stepping | `cpu.stepInto`, `cpu.stepOver`, `cpu.stepOut`, `cpu.runUntil`, `cpu.nextHLE` | `SteppingSubscriber.cpp` |
-| Breakpoints | `cpu.breakpoint.add/update/remove/list`, `memory.breakpoint.add/update/remove/list` | `BreakpointSubscriber.cpp` |
+| Breakpoints | `cpu.breakpoint.add/update/remove/list`, `memory.breakpoint.add/update/remove/list`, `cpu.gprBreakpoint.add/update/remove/list` (break when a GPR is written to, by any instruction anywhere - interpreter-only, no effect under a JIT backend) | `BreakpointSubscriber.cpp` |
 | Memory read/write | `memory.read_u8/u16/u32`, `memory.read`, `memory.readString`, `memory.write_u8/u16/u32`, `memory.write` | `MemorySubscriber.cpp` |
 | Memory search | `memory.search` - scan a range for a `u8`/`u16`/`u32`/`float` value or a `bytes` pattern (with an optional wildcard mask), for narrowing down where an unknown value lives (Cheat Engine style) | `MemorySubscriber.cpp` |
 | Memory info/annotations | `memory.mapping`, `memory.info.config/set/list/search` | `MemoryInfoSubscriber.cpp` |


### PR DESCRIPTION
This was added by claude to help investigate running reboot.bin and also HLE-boot of vsh.

Add register-write breakpoints. The register breakpoints can only be accessed from websockets for now, and only work in interpreter mode. More support coming later.

- Fixes a sync bug with step-out.
- Multiple improvements to wsdbg (the command line interface to websockets).
- Multiple other bugfixes in the debugger to make it more reliable.
- This also allows the scratchpad to be accessed from kernel mode code.