### PR TITLE
Allow disabling dithering when using software rendering

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -692,6 +692,7 @@ static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("SkipBufferEffects", SETTING(g_Config, bSkipBufferEffects), false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("DepthRasterMode", SETTING(g_Config, iDepthRasterMode), &DefaultDepthRaster, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("SoftwareRenderer", SETTING(g_Config, bSoftwareRendering), false, CfgFlag::PER_GAME),
+	ConfigSetting("SoftwareDisableDithering", SETTING(g_Config, bSoftwareDisableDithering), false, CfgFlag::PER_GAME),
 	ConfigSetting("SoftwareRendererJit", SETTING(g_Config, bSoftwareRenderingJit), true, CfgFlag::PER_GAME),
 	ConfigSetting("HardwareTransform", SETTING(g_Config, bHardwareTransform), true, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("TextureFiltering", SETTING(g_Config, iTexFiltering), 1, CfgFlag::PER_GAME | CfgFlag::REPORT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -294,6 +294,7 @@ public:
 
 	bool bSoftwareRendering;
 	bool bSoftwareRenderingJit;
+	bool bSoftwareDisableDithering;
 	bool bHardwareTransform;
 	bool bVendorBugChecksEnabled;
 

--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/StringUtils.h"
+#include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/GPUState.h"
@@ -54,7 +55,7 @@ void ComputePixelFuncID(PixelFuncID *id) {
 	// TODO: Could this be minz > 0x0000 || maxz < 0xFFFF?  Maybe unsafe, depending on verts...
 	id->applyDepthRange = !gstate.isModeThrough();
 	// Dither happens even in clear mode.
-	id->dithering = gstate.isDitherEnabled();
+	id->dithering = gstate.isDitherEnabled() && !g_Config.bSoftwareDisableDithering;
 	id->fbFormat = gstate.FrameBufFormat();
 	id->useStandardStride = gstate.FrameBufStride() == 512;
 	id->applyColorWriteMask = gstate.getColorMask() != 0;


### PR DESCRIPTION
Adds an option (not exposed in the UI, must be set via global/per-game `ppsspp.ini`) to disable dithering when using Software Rendering.

Primary motivation was to have a faithful rendition of games (Silent Hill titles are still broken on HW) without dithering getting in the way; including for analysis and comparison against HW rendering. Dithering obviously destroys metrics/diffs and only introduces noise when given to AI models to compare.

I know that it was stated in the past that SW should remain as close to actual PSP rendering as possible, but this is single-digit-LoC change adding just one config option, invisible to the user, and could help some people (at least me lol) so I'd like to see this be included.

---

*Disclaimer*

Research and implementation was done via Codex as I have no clue about cpp. This was **not** "vibe-coded" in the "add a dithering toggle, make no mistakes" style, I deliberately separated this into a research pass and an implementation task so I can actually understand the code. I can provide transcripts on request.

Patching produced mixed line endings which were normalized to CRLF. I did a successful Windows build (msbuild) with no new warnings and tested the result.

---

**Comparison**

<img width="860" height="272" alt="image" src="https://github.com/user-attachments/assets/093a106b-d126-4df0-a646-a2b155e231ac" />

<img width="800" height="400" alt="image" src="https://github.com/user-attachments/assets/549cb3f6-e15f-47cb-ba6d-9aac8c17cf2a" />


