### PR TITLE
Netconf utility param reading fix

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -66,7 +66,7 @@ int PSPNetconfDialog::Init(u32 paramAddr) {
 	StartInfraJsonDownload();
 
 	requestAddr = paramAddr;
-	if (!ReadVariableSizedStruct(paramAddr, &request.common)) {
+	if (!ReadVariableSizedStruct(paramAddr, &request)) {
 		return SCE_KERNEL_ERROR_BAD_ARGUMENT;  // untested
 	}
 


### PR DESCRIPTION
The `&request.common` part made the function deduce the wrong template, so it both kept triggering an assert for the struct being "too big" and kept reading only the common part to `request`. So the net action wasn't copied from the PSP memory and stayed `0`, which is `NETCONF_CONNECT_APNET`. This made the adhoc code trigger the AP dialog.