### PR TITLE
VSH: First preparations

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -327,6 +327,10 @@ void RegisterAllModules() {
 	Register_sceReg();
 	// Not ready to enable this due to apparent softlocks in Patapon 3.
 	// Register_sceNpMatching2();
+	Register_sceRtc_driver();
+	Register_scePower_driver();
+	Register_sceImpose_driver();
+	Register_sceHprm_driver();
 
 	// add new modules here.
 }

--- a/Core/HLE/sceHprm.cpp
+++ b/Core/HLE/sceHprm.cpp
@@ -53,6 +53,9 @@ static u32 sceHprmPeekLatch(u32 latchAddr) {
 }
 
 static u32 sceHprmReadLatch(u32 latchAddr) {
+	// Real hardware/JPCSP: 4 x u32 output struct, dummied out to all-zero (nothing held/pressed).
+	for (int i = 0; i < 4; i++)
+		Memory::WriteOrException_U32(0, latchAddr + i * 4);
 	return hleLogDebug(Log::HLE, 0, "latchAddr %08x", latchAddr);
 }
 
@@ -73,4 +76,17 @@ const HLEFunction sceHprm[] =
 void Register_sceHprm()
 {
 	RegisterHLEModule("sceHprm", ARRAY_SIZE(sceHprm), sceHprm);
+}
+
+// Kernel-mode variant library used by VSH modules (e.g. vshbridge). NID 0xE9B776BE is the
+// firmware 6.60+ alias of sceHprmReadLatch, listed as nid=0xE9B776BE version=660 alongside the
+// 0x40D2F9F0 version=150 NID in JPCSP's sceHprm.java - both resolve to the same function there.
+const HLEFunction sceHprm_driver[] =
+{
+	{0XE9B776BE, &WrapU_U<sceHprmReadLatch>, "sceHprmReadLatch", 'x', "x"},
+};
+
+void Register_sceHprm_driver()
+{
+	RegisterHLEModule("sceHprm_driver", ARRAY_SIZE(sceHprm_driver), sceHprm_driver);
 }

--- a/Core/HLE/sceHprm.h
+++ b/Core/HLE/sceHprm.h
@@ -18,3 +18,4 @@
 #pragma once
 
 void Register_sceHprm();
+void Register_sceHprm_driver();

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -127,3 +127,24 @@ const HLEFunction sceImpose[] = {
 void Register_sceImpose() {
 	RegisterHLEModule("sceImpose", ARRAY_SIZE(sceImpose), sceImpose);
 }
+
+// Real name/purpose unknown (jpcsp's sceImpose.java doesn't have one either - it's named
+// after its own NID, sceImpose_driver_B497314D). jpcsp's implementation just zeroes the
+// output pointer and returns 0; matched here rather than leaving it fully unresolved, since
+// an unresolved import leaves the caller's output buffer as PPSSPP's uninitialized-memory
+// poison instead of a real value. Kernel-only alias module some firmware-660+ code (e.g. the
+// VSH's sceVshBridge_Driver) imports from.
+static int sceImpose_driver_B497314D(int param, u32 resultAddr) {
+	auto result = PSPPointer<u64_le>::Create(resultAddr);
+	if (result.IsValid())
+		*result = 0;
+	return hleLogDebug(Log::sceUtility, 0, "UNTESTED");
+}
+
+const HLEFunction sceImpose_driver[] = {
+	{0XB497314D, &WrapI_IU<sceImpose_driver_B497314D>,     "sceImpose_driver_B497314D",     'i', "ix"},
+};
+
+void Register_sceImpose_driver() {
+	RegisterHLEModule("sceImpose_driver", ARRAY_SIZE(sceImpose_driver), sceImpose_driver);
+}

--- a/Core/HLE/sceImpose.h
+++ b/Core/HLE/sceImpose.h
@@ -20,5 +20,6 @@
 class PointerWrap;
 
 void Register_sceImpose();
+void Register_sceImpose_driver();
 void __ImposeInit();
 void __ImposeDoState(PointerWrap &p);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -947,6 +947,16 @@ const HLEFunction ThreadManForKernel[] =
 	{0x1D371B8A, &WrapI_IU<sceKernelCancelVpl>,                      "sceKernelCancelVpl",                        'i', "ix",     HLE_KERNEL_SYSCALL },
 	{0x39810265, &WrapI_IU<sceKernelReferVplStatus>,                 "sceKernelReferVplStatus",                   'i', "ip",     HLE_KERNEL_SYSCALL },
 	{0xBC31C1B9, nullptr, "sceKernelExtendKernelStack"},
+	// New entries must go here at the end, not inserted earlier in this table - the funcindex
+	// (this array position) gets baked directly into resolved-import syscall opcodes written
+	// into guest RAM (see GetSyscallOp() in HLE.cpp), which savestates capture verbatim. Inserting
+	// a new entry before an existing one shifts every later entry's index, silently corrupting
+	// any savestate taken after that entry was already resolved (see AGENTS.md).
+	{0x3AD58B8C, &WrapU_V<sceKernelSuspendDispatchThread>,           "sceKernelSuspendDispatchThread",            'x', "",       HLE_NOT_IN_INTERRUPT | HLE_KERNEL_SYSCALL },
+	{0x27E22EC2, &WrapU_U<sceKernelResumeDispatchThread>,            "sceKernelResumeDispatchThread",             'x', "x",      HLE_NOT_IN_INTERRUPT | HLE_KERNEL_SYSCALL },
+	{0xC11BA8C4, &WrapI_II<sceKernelNotifyCallback>,                 "sceKernelNotifyCallback",                   'i', "ii",     HLE_KERNEL_SYSCALL },
+	{0xF6427665, &WrapI_V<sceKernelGetUserLevel>,                    "sceKernelGetUserLevel",                     'i', "",       HLE_KERNEL_SYSCALL },
+	{0x85A2A5BF, &WrapI_V<sceKernelIsUserModeThread>,                "sceKernelIsUserModeThread",                 'i', "",       HLE_KERNEL_SYSCALL },
 };
 
 void Register_ThreadManForUser()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2121,6 +2121,23 @@ bool __KernelIsDispatchEnabled() {
 	return dispatchEnabled && __InterruptsEnabled();
 }
 
+// PPSSPP doesn't track a real per-module "user level" (set via the owning module's
+// PSP_MODULE_INFO attribute on real firmware, e.g. 0 for kernel-mode modules like the VSH's
+// bridge driver, 4 for a regular user-mode game). Approximate it from the calling thread's
+// kernel/user attr instead - the two levels VSH code actually seems to check for are "kernel"
+// vs "not kernel", so this is enough to avoid it treating itself as an ordinary user thread.
+int sceKernelGetUserLevel() {
+	PSPThread *t = __GetCurrentThread();
+	int level = (t && (t->nt.attr & PSP_THREAD_ATTR_KERNEL)) ? 0 : 4;
+	return hleLogDebug(Log::sceKernel, level);
+}
+
+int sceKernelIsUserModeThread() {
+	PSPThread *t = __GetCurrentThread();
+	int isUser = (t && (t->nt.attr & PSP_THREAD_ATTR_KERNEL)) ? 0 : 1;
+	return hleLogDebug(Log::sceKernel, isUser);
+}
+
 int KernelRotateThreadReadyQueue(int priority) {
 	PSPThread *cur = __GetCurrentThread();
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -59,6 +59,8 @@ int __KernelGetThreadExitStatus(SceUID threadID);
 int sceKernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr);
 u32 sceKernelSuspendDispatchThread();
 u32 sceKernelResumeDispatchThread(u32 suspended);
+int sceKernelGetUserLevel();
+int sceKernelIsUserModeThread();
 int sceKernelWaitThreadEnd(SceUID threadID, u32 timeoutPtr);
 u32 sceKernelReferThreadStatus(u32 uid, u32 statusPtr);
 u32 sceKernelReferThreadRunStatus(u32 uid, u32 statusPtr);

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -635,6 +635,21 @@ void Register_scePower() {
 	RegisterHLEModule("scePower",ARRAY_SIZE(scePower),scePower);
 }
 
+// Real name unknown (jpcsp's scePower.java doesn't have one either - it's named after its
+// own NID, scePower_driver_5F5006D2, and just returns 0 unconditionally). Kernel-only alias
+// module some firmware-660+ code (e.g. the VSH's sceVshBridge_Driver) imports from.
+static int scePower_driver_5F5006D2() {
+	return hleLogDebug(Log::HLE, 0, "UNTESTED");
+}
+
+const HLEFunction scePower_driver[] = {
+	{0X5F5006D2, &WrapI_V<scePower_driver_5F5006D2>,          "scePower_driver_5F5006D2",          'i', ""   },
+};
+
+void Register_scePower_driver() {
+	RegisterHLEModule("scePower_driver", ARRAY_SIZE(scePower_driver), scePower_driver);
+}
+
 void Register_sceSuspendForUser() {
 	RegisterHLEModule("sceSuspendForUser", ARRAY_SIZE(sceSuspendForUser), sceSuspendForUser);
 }

--- a/Core/HLE/scePower.h
+++ b/Core/HLE/scePower.h
@@ -23,6 +23,7 @@ void __PowerInit();
 void __PowerDoState(PointerWrap &p);
 
 void Register_scePower();
+void Register_scePower_driver();
 void Register_sceSuspendForUser();
 
 int KernelVolatileMemLock(int type, u32 paddr, u32 psize);

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -945,7 +945,23 @@ static int sceRtcGetLastReincarnatedTime(u32 tickPtr)
 static int sceRtcSetAlarmTick(u32 unknown1, u32 unknown2)
 {
 	ERROR_LOG_REPORT(Log::sceRtc, "UNIMPL sceRtcSetAlarmTick(%x, %x)", unknown1, unknown2);
-	return 0; 
+	return 0;
+}
+
+// Real signature per uofw (sceRtc_C2DDBEB5, src/kd/rtc/rtc.c): s32 sceRtcGetAlarmTick(u64 *tick).
+// PPSSPP doesn't track a real hardware RTC alarm, so there's nothing meaningful to report -
+// but leaving this fully unimplemented (nullptr in the function table) meant callers got back
+// PPSSPP's uninitialized-memory poison in *tick instead of a real value. On the VSH boot path
+// (see docs/VSHBootInvestigation.md) that poisoned tick was later dereferenced as a pointer by
+// vsh_module's own code, causing a wild-address SIGSEGV. Write a real (zero) tick instead, same
+// as if no alarm were currently set - matches sceRtcSetAlarmTick() above also being a no-op.
+static int sceRtcGetAlarmTick(u32 tickPtr) {
+	auto tick = PSPPointer<u64_le>::Create(tickPtr);
+	if (!tick.IsValid())
+		return hleLogError(Log::sceRtc, 0, "bad address");
+
+	*tick = 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 // Caller must check outPtr and srcTickPtr.
@@ -1132,10 +1148,25 @@ const HLEFunction sceRtc[] =
 	{0X81FCDA34, nullptr,                                  "sceRtcIsAlarmed",                '?', ""   },
 	{0XFB3B18CD, nullptr,                                  "sceRtcRegisterCallback",         '?', ""   },
 	{0X6A676D2D, nullptr,                                  "sceRtcUnregisterCallback",       '?', ""   },
-	{0XC2DDBEB5, nullptr,                                  "sceRtcGetAlarmTick",             '?', ""   },
+	{0XC2DDBEB5, &WrapI_U<sceRtcGetAlarmTick>,             "sceRtcGetAlarmTick",             'i', "x"  },
 };
 
 void Register_sceRtc()
 {
 	RegisterHLEModule("sceRtc", ARRAY_SIZE(sceRtc), sceRtc);
+}
+
+// sceRtc_driver is the kernel-only alias some firmware-660+ modules (e.g. the VSH's
+// sceVshBridge_Driver) import from instead of plain sceRtc - same underlying functions,
+// just also exported under a second, kernel-suffixed module name. Confirmed by cross-
+// checking jpcsp's sceRtc.java, which registers 0xE09880CF as an alternate NID on the exact
+// same sceRtcSetAlarmTick() method (JPCSP doesn't distinguish import module names the way
+// PPSSPP's HLE dispatch does, but the NID->function mapping is the same either way).
+const HLEFunction sceRtc_driver[] = {
+	{0XE09880CF, &WrapI_UU<sceRtcSetAlarmTick>,            "sceRtcSetAlarmTick",             'i', "xx" },
+};
+
+void Register_sceRtc_driver()
+{
+	RegisterHLEModule("sceRtc_driver", ARRAY_SIZE(sceRtc_driver), sceRtc_driver);
 }

--- a/Core/HLE/sceRtc.h
+++ b/Core/HLE/sceRtc.h
@@ -35,6 +35,7 @@ void RtcSetBaseTime(int32_t seconds, int32_t micro = 0);
 u64 __RtcGetCurrentTick();
 
 void Register_sceRtc();
+void Register_sceRtc_driver();
 void __RtcInit();
 void __RtcDoState(PointerWrap &p);
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -297,8 +297,8 @@ inline bool AddressesEqualAfterMask(const u32 address1, const u32 address2) {
 inline bool IsValidAddress(const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000) {
 		return true;
-	} else if ((address & 0x3F800000) == 0x04000000) {
-		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
+	} else if ((address & 0xBF800000) == 0x04000000) {
+		return true;  // 0xBxx above: Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
 	} else if ((address & 0x3FFFC000) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -311,8 +311,8 @@ inline bool IsValidAddress(const u32 address) {
 inline bool IsValid2AlignedAddress(const u32 address) {
 	if ((address & 0x3E000001) == 0x08000000) {
 		return true;
-	} else if ((address & 0x3F800001) == 0x04000000) {
-		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
+	} else if ((address & 0xBF800001) == 0x04000000) {
+		return true;  // 0xBxx above: Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
 	} else if ((address & 0x3FFFC001) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -325,8 +325,8 @@ inline bool IsValid2AlignedAddress(const u32 address) {
 inline bool IsValid4AlignedAddress(const u32 address) {
 	if ((address & 0x3E000003) == 0x08000000) {
 		return true;
-	} else if ((address & 0x3F800003) == 0x04000000) {
-		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
+	} else if ((address & 0xBF800003) == 0x04000000) {
+		return true;  // 0xBxx above: Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
 	} else if ((address & 0x3FFFC003) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -340,8 +340,8 @@ template<int A>
 inline bool IsValidNAlignedAddress(const u32 address) {
 	if ((address & (0x3E000000 | (A - 1))) == 0x08000000) {
 		return true;
-	} else if ((address & (0x3F800000 | (A - 1))) == 0x04000000) {
-		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
+	} else if ((address & (0xBF800000 | (A - 1))) == 0x04000000) {
+		return true;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
 	} else if ((address & (0x3FFFC000 | (A - 1))) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -354,12 +354,8 @@ inline bool IsValidNAlignedAddress(const u32 address) {
 inline u32 MaxSizeAtAddress(const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000) {
 		return 0x08000000 + g_MemorySize - (address & 0x3FFFFFFF);
-	} else if ((address & 0x3F800000) == 0x04000000) {
-		if (address & 0x80000000) {
-			return 0;
-		} else {
-			return 0x04800000 - (address & 0x3FFFFFFF);
-		}
+	} else if ((address & 0xBF800000) == 0x04000000) {
+		return 0x04800000 - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3FFFC000) == 0x00010000) {
 		return 0x00014000 - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -371,6 +367,25 @@ inline u32 MaxSizeAtAddress(const u32 address) {
 
 inline const char *GetCharPointerUnchecked(const u32 address) {
 	return (const char *)GetPointerUnchecked(address);
+}
+
+// Differences from the above functions: Check for 16-byte alignment, disallow scratchpad (can't texture from there, I don't think).
+inline bool IsValidTextureAddress(const u32 address) {
+	if ((address & 0x3E00000F) == 0x08000000) {
+		return true;  // Can texture from RAM (not sure if kernel RAM too, but let's allow it).
+	} else if ((address & 0xBF80000F) == 0x04000000) {  // 0xB makes sure we don't allow kernel-flagged VRAM.
+		return true;
+	} else if ((address & 0x3E00000F) == 0x08000000 && (address & 0x3F000000) >= 0x08000000 && ((address & 0x3F000000) < 0x08000000 + g_MemorySize)) {
+		return true;  // Extended RAM.
+	} else {
+		// Can't texture from scratchpad or other kinds of memory.
+		return false;
+	}
+}
+
+// I believe this is the same, but let's keep a separate function.
+inline bool IsValidCLUTAddress(const u32 address) {
+	return IsValidTextureAddress(address);
 }
 
 // NOTE: Unlike the similar IsValidRange/IsValidAddress functions, this one is linear cost vs the size of the string,

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -42,6 +42,24 @@
 // Global declarations
 class PointerWrap;
 
+// The PPGe font atlas doesn't live in emulated RAM, but the GE still needs an address to texture
+// from, so we hand it this fake one and translate it back to a host pointer where it's used.
+// NOTE: The top 4 bits must be zero due to how the address is stored in the gstate.
+constexpr u32 PPGE_ATLAS_FAKE_ADDRESS = 0x03000000;
+// The size of the atlas, or 0 when PPGe isn't initialized. Set up by PPGeDraw.cpp.
+extern u32 g_ppgeAtlasFakeSize;
+
+inline bool IsPPGEAtlasFakeAddress(u32 addr, u32 *offset) {
+	if (addr >= PPGE_ATLAS_FAKE_ADDRESS && addr < PPGE_ATLAS_FAKE_ADDRESS + g_ppgeAtlasFakeSize) {
+		if (offset) {
+			*offset = addr - PPGE_ATLAS_FAKE_ADDRESS;
+		}
+		return true;
+	} else {
+		return false;
+	}
+}
+
 typedef void (*writeFn8 )(const u8, const u32);
 typedef void (*writeFn16)(const u16,const u32);
 typedef void (*writeFn32)(const u32,const u32);
@@ -377,6 +395,8 @@ inline bool IsValidTextureAddress(const u32 address) {
 		return true;
 	} else if ((address & 0x3E00000F) == 0x08000000 && (address & 0x3F000000) >= 0x08000000 && ((address & 0x3F000000) < 0x08000000 + g_MemorySize)) {
 		return true;  // Extended RAM.
+	} else if (IsPPGEAtlasFakeAddress(address, nullptr)) {
+		return true;  // PPGe atlas texture
 	} else {
 		// Can't texture from scratchpad or other kinds of memory.
 		return false;

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -48,11 +48,11 @@
 static Atlas g_ppge_atlas;
 static Draw::DrawContext *g_draw = nullptr;
 
-static u32 atlasPtr;
 static int atlasWidth;
 static int atlasHeight;
-static uint64_t atlasHash;
-static bool atlasRequiresReset;
+
+// The size of the atlas as seen through PPGE_ATLAS_FAKE_ADDRESS, see MemMap.h. 0 until initialized.
+u32 g_ppgeAtlasFakeSize;
 
 struct PPGeVertex {
 	u16_le u, v;
@@ -67,43 +67,43 @@ struct PPGeRemasterVertex {
 };
 
 static PSPPointer<PspGeListArgs> listArgs;
-static u32 listArgsSize = sizeof(PspGeListArgs);
+constexpr u32 listArgsSize = sizeof(PspGeListArgs);
 static u32 savedContextPtr;
-static u32 savedContextSize = 512 * 4;
+constexpr u32 savedContextSize = 512 * 4;
 
 // Display list writer
 static u32 dlPtr;
 static u32 dlWritePtr;
-static u32 dlSize = 0x10000; // should be enough for a frame of gui...
+constexpr u32 dlSize = 0x10000; // should be enough for a frame of gui...
 
 static u32 dataPtr;
 static u32 dataWritePtr;
-static u32 dataSize = 0x10000; // should be enough for a frame of gui...
+constexpr u32 dataSize = 0x10000; // should be enough for a frame of gui...
+
+static u8 *g_atlasImageData = nullptr;
 
 static PSPPointer<u16_le> palette;
-static u32 paletteSize = sizeof(u16) * 16;
+constexpr u32 paletteSize = sizeof(u16) * 16;
+static constexpr u16_le paletteData[16] = { 0x0FFF, 0x1FFF, 0x2FFF, 0x3FFF, 0x4FFF, 0x5FFF, 0x6FFF, 0x7FFF, 0x8FFF, 0x9FFF, 0xAFFF, 0xBFFF, 0xCFFF, 0xDFFF, 0xEFFF, 0xFFFF };
 
 // Vertex collector
 static u32 vertexStart;
 static u32 vertexCount;
 
 // Used for formatting text
-struct AtlasCharVertex
-{
+struct AtlasCharVertex {
 	float x;
 	float y;
 	const AtlasChar *c;
 };
 
-struct AtlasTextMetrics
-{
+struct AtlasTextMetrics {
 	float x;
 	float y;
 	float maxWidth;
 	float lineHeight;
 	float scale;
 	int numLines;
-
 };
 
 typedef std::vector<AtlasCharVertex> AtlasCharLine;
@@ -129,9 +129,8 @@ struct PPGeTextDrawerCacheKey {
 };
 
 struct PPGeTextDrawerImage {
-	PPGeTextDrawerImage() : entry(0) {}
-	TextStringEntry entry;
-	u32 ptr;
+	TextStringEntry entry = 0;
+	u32 ptr = 0;
 };
 
 static std::map<PPGeTextDrawerCacheKey, PPGeTextDrawerImage> textDrawerImages;
@@ -154,7 +153,7 @@ static void PPGeDecimateTextImages(int age = 97);
 
 void PPGeSetTexture(u32 dataAddr, int width, int height);
 
-//only 0xFFFFFF of data is used
+// only 0xFFFFFF of data is used
 static void WriteCmd(u8 cmd, u32 data) {
 	Memory::WriteUnchecked_U32((cmd << 24) | (data & 0xFFFFFF), dlWritePtr);
 	dlWritePtr += 4;
@@ -209,18 +208,15 @@ static void EndVertexDataAndDraw(int prim) {
 	vertexStart = 0;
 }
 
-bool PPGeIsFontTextureAddress(u32 addr) {
-	return addr == atlasPtr;
-}
+static u32 __PPGeDoAlloc(u32 size, bool fromTop, const char *name) {
+	u32 sizeRounded = size;
 
-static u32 __PPGeDoAlloc(u32 &size, bool fromTop, const char *name) {
-	u32 ptr = kernelMemory.Alloc(size, fromTop, name);
+	u32 ptr = kernelMemory.Alloc(sizeRounded, fromTop, name);
 	// Didn't get it, try again after decimating images.
 	if (ptr == (u32)-1) {
 		PPGeDecimateTextImages(4);
 		PPGeImage::Decimate(4);
-
-		ptr = kernelMemory.Alloc(size, fromTop, name);
+		ptr = kernelMemory.Alloc(sizeRounded, fromTop, name);
 		if (ptr == (u32)-1) {
 			return 0;
 		}
@@ -228,8 +224,7 @@ static u32 __PPGeDoAlloc(u32 &size, bool fromTop, const char *name) {
 	return ptr;
 }
 
-void __PPGeSetupListArgs()
-{
+void __PPGeSetupListArgs() {
 	if (listArgs.IsValid())
 		return;
 
@@ -243,9 +238,9 @@ void __PPGeSetupListArgs()
 }
 
 void __PPGeInit() {
-	// PPGe isn't really important for headless, and LoadZIM takes a long time.
-	// TODO: Load it lazily, and not into kernel memory.
-	bool skipZIM = System_GetPropertyBool(SYSPROP_IS_HEADLESS);
+	// PPGe isn't really important for headless, and LoadZIM takes a long time (well not that long, but unnecessary).
+	// TODO: Load it lazily.
+	const bool skipZIM = System_GetPropertyBool(SYSPROP_IS_HEADLESS);
 
 	u8 *imageData[12]{};
 	int width[12]{};
@@ -275,35 +270,28 @@ void __PPGeInit() {
 	dlPtr = __PPGeDoAlloc(dlSize, false, "PPGe Display List");
 	dataPtr = __PPGeDoAlloc(dataSize, false, "PPGe Vertex Data");
 	__PPGeSetupListArgs();
-	atlasPtr = atlasSize == 0 ? 0 : __PPGeDoAlloc(atlasSize, false, "PPGe Atlas Texture");
 	palette = __PPGeDoAlloc(paletteSize, false, "PPGe Texture Palette");
+	Memory::Memcpy(palette.ptr, (const void *)paletteData, paletteSize, "PPGe Palette");
 
-	// Generate 16-greyscale palette. All PPGe graphics are greyscale so we can use a tiny paletted texture.
-	for (int i = 0; i < 16; i++) {
-		int val = i;
-		palette[i] = (val << 12) | 0xFFF;
+	if (loadedZIM) {
+		const u32_le *imagePtr = (u32_le *)imageData[0];
+		_dbg_assert_(!g_atlasImageData);
+		g_atlasImageData = new u8[atlasSize];
+		g_ppgeAtlasFakeSize = atlasSize;
+
+		// Palettize to 4-bit, the easy way.
+		for (int i = 0; i < width[0] * height[0] / 2; i++) {
+			// Each pixel is 16 bits, so this loads two pixels.
+			const u32 c = imagePtr[i];
+			// It's white anyway, so we only look at one channel of each pixel.
+			const int a1 = (c & 0x0000000F) >> 0;
+			const int a2 = (c & 0x000F0000) >> 16;
+			const u8 cval = (a2 << 4) | a1;
+			g_atlasImageData[i] = cval;
+		}
+
+		free(imageData[0]);
 	}
-	NotifyMemInfo(MemBlockFlags::WRITE, palette.ptr, 16 * sizeof(u16_le), "PPGe Palette");
-
-	const u32_le *imagePtr = (u32_le *)imageData[0];
-	u8 *ramPtr = atlasPtr == 0 ? nullptr : (u8 *)Memory::GetPointerRangeOrException(atlasPtr, atlasSize);
-
-	// Palettize to 4-bit, the easy way.
-	for (int i = 0; i < width[0] * height[0] / 2; i++) {
-		// Each pixel is 16 bits, so this loads two pixels.
-		u32 c = imagePtr[i];
-		// It's white anyway, so we only look at one channel of each pixel.
-		int a1 = (c & 0x0000000F) >> 0;
-		int a2 = (c & 0x000F0000) >> 16;
-		u8 cval = (a2 << 4) | a1;
-		ramPtr[i] = cval;
-	}
-	if (atlasPtr != 0) {
-		atlasHash = XXH3_64bits(ramPtr, atlasSize);
-		NotifyMemInfo(MemBlockFlags::WRITE, atlasPtr, atlasSize, "PPGe Atlas");
-	}
-
-	free(imageData[0]);
 
 	// We can't create it here, because Android needs it on the right thread.
 	// Avoid creating ever on headless just to be safe.
@@ -311,10 +299,7 @@ void __PPGeInit() {
 	textDrawer = nullptr;
 	textDrawerImages.clear();
 
-	atlasRequiresReset = false;
-
-	INFO_LOG(Log::sceGe, "PPGe drawing library initialized. DL: %08x Data: %08x Atlas: %08x (%i) Args: %08x",
-		dlPtr, dataPtr, atlasPtr, atlasSize, listArgs.ptr);
+	INFO_LOG(Log::sceGe, "PPGe drawing library initialized. DL: %08x Data: %08x Atlas (%i) Args: %08x", dlPtr, dataPtr, atlasSize, listArgs.ptr);
 }
 
 void __PPGeDoState(PointerWrap &p)
@@ -323,27 +308,35 @@ void __PPGeDoState(PointerWrap &p)
 	if (!s)
 		return;
 
+	// Old format: the atlas lived in emulated kernel RAM. We just dummy those fields out, and free
+	// the memory if the state we're loading has some. Note that these must stay initialized - they're
+	// read (not just written) when saving, and uninitialized memory in a savestate is not acceptable.
+	u32 atlasPtr = 0;
+	int dummyAtlasWidth = 0;
+	int dummyAtlasHeight = 0;
 	Do(p, atlasPtr);
-	Do(p, atlasWidth);
-	Do(p, atlasHeight);
+	Do(p, dummyAtlasWidth);
+	Do(p, dummyAtlasHeight);
 	Do(p, palette);
 
-	// If the atlas the save state was created with differs from the current one, reload.
-	uint64_t savedHash = atlasHash;
-	if (s >= 4) {
-		Do(p, savedHash);
-	} else {
-		// Memory was already updated by this point, so check directly.
-		if (atlasPtr != 0) {
-			savedHash = XXH3_64bits(Memory::GetPointerRangeOrException(atlasPtr, atlasWidth * atlasHeight / 2), atlasWidth * atlasHeight / 2);
-		} else {
-			savedHash ^= 1;
-		}
+	if (p.mode == PointerWrap::MODE_READ && atlasPtr) {
+		// We don't store the atlas in emulated RAM anymore, so free the old allocation. This is safe
+		// here - __KernelMemoryDoState() runs before us, so the block allocator is already restored.
+		kernelMemory.Free(atlasPtr);
 	}
-	atlasRequiresReset = savedHash != atlasHash;
 
+	// Used to be the hash of the atlas the state was created with, to detect a changed atlas.
+	// The atlas is host-side now and gets rebuilt on load anyway, so it's meaningless.
+	uint64_t dummySavedHash = 0;
+	if (s >= 4) {
+		Do(p, dummySavedHash);
+	}
+
+	// These are compile-time constants now, so a savestate can't be allowed to change them.
+	// Note that old states hold the size *rounded up* to the allocator grain, which we no longer use.
+	u32 dummySavedContextSize = savedContextSize;
 	Do(p, savedContextPtr);
-	Do(p, savedContextSize);
+	Do(p, dummySavedContextSize);
 
 	if (s == 1) {
 		listArgs = 0;
@@ -375,13 +368,15 @@ void __PPGeDoState(PointerWrap &p)
 		textDrawerImages.clear();
 	}
 
+	u32 dummyDlSize = dlSize;
 	Do(p, dlPtr);
 	Do(p, dlWritePtr);
-	Do(p, dlSize);
+	Do(p, dummyDlSize);
 
+	u32 dummyDataSize = dataSize;
 	Do(p, dataPtr);
 	Do(p, dataWritePtr);
-	Do(p, dataSize);
+	Do(p, dummyDataSize);
 
 	Do(p, vertexStart);
 	Do(p, vertexCount);
@@ -390,10 +385,13 @@ void __PPGeDoState(PointerWrap &p)
 	Do(p, char_lines_metrics);
 }
 
-void __PPGeShutdown()
-{
-	if (atlasPtr)
-		kernelMemory.Free(atlasPtr);
+void __PPGeShutdown() {
+	if (g_atlasImageData) {
+		delete[] g_atlasImageData;
+		g_atlasImageData = nullptr;
+	}
+	g_ppgeAtlasFakeSize = 0;
+
 	if (dataPtr)
 		kernelMemory.Free(dataPtr);
 	if (dlPtr)
@@ -405,22 +403,25 @@ void __PPGeShutdown()
 	if (palette)
 		kernelMemory.Free(palette.ptr);
 
-	atlasPtr = 0;
 	dataPtr = 0;
 	dlPtr = 0;
 	savedContextPtr = 0;
 	listArgs = 0;
+	palette = 0;
 
 	delete textDrawer;
 	textDrawer = nullptr;
 
-	for (auto im : textDrawerImages)
+	for (auto &im : textDrawerImages)
 		kernelMemory.Free(im.second.ptr);
 	textDrawerImages.clear();
 }
 
-void PPGeBegin()
-{
+const u8 *PPGeAtlasGetData() {
+	return g_atlasImageData;
+}
+
+void PPGeBegin() {
 	if (!dlPtr)
 		return;
 
@@ -852,6 +853,8 @@ void PPGeDrawCurrentText(u32 color) {
 			WriteCmd(GE_CMD_TEXSIZE0, 9 | (9 << 8));
 		}
 
+		WriteCmd(GE_CMD_TEXBUFWIDTH0, atlasWidth | ((PPGE_ATLAS_FAKE_ADDRESS & 0x0F000000) >> 8));
+
 		BeginVertexData();
 		for (auto i = char_lines.begin(); i != char_lines.end(); ++i) {
 			for (auto j = i->begin(); j != i->end(); ++j) {
@@ -863,7 +866,9 @@ void PPGeDrawCurrentText(u32 color) {
 					EndVertexDataAndDraw(GE_PRIM_RECTANGLES);
 
 					uint32_t offset = atlasWidth * wantedPosY * 256 + wantedPosX * 256;
-					WriteCmd(GE_CMD_TEXADDR0, (atlasPtr & 0xFFFFF0) + offset / 2);
+					_dbg_assert_(offset / 2 < g_ppgeAtlasFakeSize);
+					// The base ptr is already set.
+					WriteCmd(GE_CMD_TEXADDR0, (PPGE_ATLAS_FAKE_ADDRESS & 0xFFFFF0) + offset / 2);
 					texturePosX = wantedPosX;
 					texturePosY = wantedPosY;
 
@@ -1316,8 +1321,8 @@ void PPGeSetDefaultTexture()
 	WriteCmd(GE_CMD_TEXFILTER, (1 << 8) | 1);   // mag = LINEAR min = LINEAR
 	WriteCmd(GE_CMD_TEXWRAP, (1 << 8) | 1);  // clamp texture wrapping
 	WriteCmd(GE_CMD_TEXFUNC, (0 << 16) | (1 << 8) | 0);  // RGBA texture reads, modulate, no color doubling
-	WriteCmd(GE_CMD_TEXADDR0, atlasPtr & 0xFFFFF0);
-	WriteCmd(GE_CMD_TEXBUFWIDTH0, atlasWidth | ((atlasPtr & 0xFF000000) >> 8));
+	WriteCmd(GE_CMD_TEXADDR0, PPGE_ATLAS_FAKE_ADDRESS & 0xFFFFF0);
+	WriteCmd(GE_CMD_TEXBUFWIDTH0, atlasWidth | ((PPGE_ATLAS_FAKE_ADDRESS & 0x0F000000) >> 8));
 	WriteCmd(GE_CMD_TEXFLUSH, 0);
 }
 
@@ -1499,9 +1504,4 @@ void PPGeNotifyFrame() {
 
 	PPGeDecimateTextImages();
 	PPGeImage::Decimate();
-
-	if (atlasRequiresReset) {
-		__PPGeShutdown();
-		__PPGeInit();
-	}
 }

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -108,9 +108,7 @@ void PPGeScissor(int x1, int y1, int x2, int y2);
 void PPGeScissorReset();
 
 void PPGeNotifyFrame();
-
-// Could have returned the address directly I guess, but nothing out side of PPGe should actually use it so..
-bool PPGeIsFontTextureAddress(u32 addr);
+const u8 *PPGeAtlasGetData();
 
 class PPGeImage {
 public:

--- a/Core/Util/PortManager.cpp
+++ b/Core/Util/PortManager.cpp
@@ -526,7 +526,7 @@ int upnpService(const unsigned int timeout) {
 		g_PortManager.Shutdown();
 	}
 
-	// Should we ingore any leftover UPnP requests? instead of processing it on the next game start
+	// Should we ignore any leftover UPnP requests? instead of processing it on the next game start
 	{
 		std::unique_lock<std::mutex> lock(g_upnpLock);
 		g_upnpReqs.clear();
@@ -550,9 +550,11 @@ void __UPnPShutdown() {
 		g_upnpCond.notify_one();
 	}
 
+	INFO_LOG(Log::HTTP, "Waiting for upnp thread to shut down...");
 	if (g_upnpServiceThread.joinable()) {
 		g_upnpServiceThread.join();
 	}
+	INFO_LOG(Log::HTTP, "upnp thread shut down.");
 }
 
 void UPnP_Add(const char* protocol, unsigned short port, unsigned short intport) {

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -844,6 +844,7 @@ static void WebServerThread() {
 	delete http;
 
 	UpdateStatus(ServerStatus::FINISHED);
+	INFO_LOG(Log::HTTP, "Left web server loop.");
 }
 
 // Only adds flags.

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -517,7 +517,7 @@ TextureApplyResult TextureCacheCommon::ApplyTexture(bool doBind) {
 		level = std::max(0, gstate.getTexLevelOffset16() / 16);
 	}
 	const u32 texaddr = gstate.getTextureAddress(level);
-	if (!Memory::IsValidAddress(texaddr)) {
+	if (!Memory::IsValidTextureAddress(texaddr)) {
 		// Bind a null texture and return.
 		Unbind();
 		gstate_c.SetTextureIsVideo(false);
@@ -1496,7 +1496,7 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes, GPURecord::Record
 	clutTotalBytes_ = loadBytes;
 	clutRenderAddress_ = 0xFFFFFFFF;
 
-	if (!Memory::IsValidAddress(clutAddr)) {
+	if (!Memory::IsValidCLUTAddress(clutAddr)) {
 		memset(clutBufRaw_, 0x00, loadBytes);
 		// Reload the clut next time (should we really do it in this case?)
 		clutLastFormat_ = 0xFFFFFFFF;
@@ -1505,6 +1505,8 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes, GPURecord::Record
 	}
 
 	if (Memory::IsVRAMAddress(clutAddr)) {
+		// If we're loading the CLUT from VRAM, it might be directly from a framebuffer. This is used for some fancy effects.
+
 		// Clear the uncached and mirror bits, etc. to match framebuffers.
 		const u32 clutLoadAddr = clutAddr & 0x041FFFFF;
 		const u32 clutLoadEnd = clutLoadAddr + loadBytes;
@@ -2758,7 +2760,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	for (int i = 0; i < plan.levelsToLoad; i++) {
 		// If encountering levels pointing to nothing, adjust max level.
 		u32 levelTexaddr = gstate.getTextureAddress(i);
-		if (!Memory::IsValidAddress(levelTexaddr)) {
+		if (!Memory::IsValidTextureAddress(levelTexaddr)) {
 			plan.levelsToLoad = i;
 			break;
 		}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -409,6 +409,7 @@ static u32 ComputeTextureHash(TextureReplacer &replacer, u32 addr, int bufw, int
 	}
 	const u32 *checkp = (const u32 *)Memory::GetPointerOrException(addr);
 
+	// NOTE: I'm not sure we want to align-check the end, so can't use IsValidTextureAddress here.
 	if (Memory::IsValidAddress(addr + sizeInRAM)) {
 		gpuStats.perFrame.numTextureDataBytesHashed += sizeInRAM;
 
@@ -517,6 +518,7 @@ TextureApplyResult TextureCacheCommon::ApplyTexture(bool doBind) {
 		level = std::max(0, gstate.getTexLevelOffset16() / 16);
 	}
 	const u32 texaddr = gstate.getTextureAddress(level);
+	_dbg_assert_(texaddr != 0);
 	if (!Memory::IsValidTextureAddress(texaddr)) {
 		// Bind a null texture and return.
 		Unbind();
@@ -570,7 +572,6 @@ TextureApplyResult TextureCacheCommon::ApplyTexture(bool doBind) {
 		cluthash = 0;
 	}
 	const u64 cachekey = TexCacheEntry::CacheKey(texaddr, texFormat, dim, cluthash);
-
 	int bufw = GetTextureBufw(0, texaddr, texFormat);
 	u8 maxLevel = gstate.getTextureMaxLevel();
 	const bool swizzled = gstate.isTextureSwizzled();
@@ -820,8 +821,10 @@ TextureApplyResult TextureCacheCommon::ApplyTexture(bool doBind) {
 	def.format = texFormat;
 	def.bufw = bufw;
 
+	const bool isPPGE = IsPPGEAtlasFakeAddress(texaddr, nullptr);
+
 	AttachCandidate bestCandidate;
-	if (GetBestFramebufferCandidate(framebufferManager_, def, 0, &bestCandidate, "texture")) {
+	if (!isPPGE && GetBestFramebufferCandidate(framebufferManager_, def, 0, &bestCandidate, "texture")) {
 		RasterChannel channel;
 		VirtualFramebuffer *framebuffer = SetTextureFramebuffer(bestCandidate, &channel);  // sets curTexture3D
 		TextureApplyResult result;
@@ -852,9 +855,9 @@ TextureApplyResult TextureCacheCommon::ApplyTexture(bool doBind) {
 	TexCacheEntry *entry = new TexCacheEntry{};
 	cache_[cachekey].reset(entry);
 	entry->status = {};
-	if (PPGeIsFontTextureAddress(texaddr)) {
+	if (isPPGE) {
 		// It's the builtin font texture.
-		entry->status |= TexStatus::RELIABLE;
+		entry->status |= TexStatus::RELIABLE | TexStatus::IS_PPGE_ATLAS;
 	}
 
 	if (hasClutGPU) {
@@ -897,7 +900,11 @@ TextureApplyResult TextureCacheCommon::ApplyTexture(bool doBind) {
 	gstate_c.curTextureWidth = w;
 	gstate_c.curTextureHeight = h;
 	UpdateMaxSeenV(entry, gstate.isModeThrough());  // Critical to update this before hashing! As it's used to decide the hash range.
-	entry->fullhash = ComputeTextureHash(replacer_, entry->addr, entry->bufw, w, h, swizzled, entry);
+
+	// TODO: Avoid hashing known video textures.
+	if (!(entry->status & TexStatus::IS_PPGE_ATLAS)) {
+		entry->fullhash = ComputeTextureHash(replacer_, entry->addr, entry->bufw, w, h, swizzled, entry);
+	}
 
 	VERBOSE_LOG(Log::TexCache, "%08x: Creating new texture, hash %08x (maxSeenV=%d), w: %d h: %d, creating", texaddr, entry->fullhash, entry->maxSeenV, w, h);
 
@@ -1958,7 +1965,11 @@ TextureAlpha TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETex
 
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
-	const u8 *texptr = Memory::GetPointerOrException(texaddr);
+
+	u32 ppgeOffset;
+	const bool isPPGE = IsPPGEAtlasFakeAddress(texaddr, &ppgeOffset);
+
+	const u8 *texptr = isPPGE ? (PPGeAtlasGetData() + ppgeOffset) : Memory::GetPointerOrException(texaddr);
 	const uint32_t byteSize = (textureBitsPerPixel[format] * bufw * h) / 8;
 
 	// Validate the texture data fits in mapped RAM, like the DXT path does.
@@ -1968,7 +1979,7 @@ TextureAlpha TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETex
 	// Swizzled textures are read in 8-row blocks, rounding the height up.
 	const uint32_t rows = swizzled ? ((h + 7) & ~7) : h;
 	const uint32_t neededBytes = bytesPerRow * rows;
-	if (bytesPerRow > 0 && !Memory::IsValidRange(texaddr, neededBytes)) {
+	if (bytesPerRow > 0 && !isPPGE && !Memory::IsValidRange(texaddr, neededBytes)) {
 		ERROR_LOG_REPORT(Log::G3D, "Texture extends beyond valid RAM: %08x + %d x %d", texaddr, bufw, h);
 		uint32_t limited = Memory::ClampValidSizeAt(texaddr, neededBytes);
 		h = limited / bytesPerRow;
@@ -1976,9 +1987,11 @@ TextureAlpha TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETex
 			h &= ~7;
 	}
 
-	char buf[128];
-	size_t len = snprintf(buf, sizeof(buf), "Tex_%08x_%dx%d_%s", texaddr, w, h, GeTextureFormatToString(format, clutformat));
-	NotifyMemInfo(MemBlockFlags::TEXTURE, texaddr, byteSize, buf, len);
+	if (!isPPGE) {
+		char buf[128];
+		size_t len = snprintf(buf, sizeof(buf), "Tex_%08x_%dx%d_%s", texaddr, w, h, GeTextureFormatToString(format, clutformat));
+		NotifyMemInfo(MemBlockFlags::TEXTURE, texaddr, byteSize, buf, len);
+	}
 
 	switch (format) {
 	case GE_TFMT_CLUT4:
@@ -3092,5 +3105,12 @@ std::string TexStatusToString(TexStatus status) {
 	if (status & TexStatus::VIDEO) {
 		result += "VIDEO ";
 	}
+	if (status & TexStatus::RELIABLE) {
+		result += "RELIABLE ";
+	}
+	if (status & TexStatus::IS_PPGE_ATLAS) {
+		result += "IS_PPGE_ATLAS ";
+	}
+
 	return result.empty() ? "None" : result;
 }

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -150,7 +150,7 @@ enum class TexStatus : u16 {
 	IS_3D = (1 << 10),
 	NO_MIPS = (1 << 11),      // Has bad or unusable mipmap levels.
 	FRAMEBUFFER_OVERLAP = (1 << 12),
-	// Free bit 13
+	IS_PPGE_ATLAS = (1 << 13),
 	CLUT8_INDEXED = (1 << 14),  // Decoded as plain CLUT8 indices instead of all the way to colors.
 	CLUT_GPU = (1 << 15),
 };

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -244,8 +244,10 @@ static const u32 textureAlignMask16[16] = {
 
 u32 GetTextureBufw(int level, u32 texaddr, GETextureFormat format) {
 	// This is a hack to allow for us to draw the huge PPGe texture, which is always in kernel ram.
-	if (texaddr >= PSP_GetKernelMemoryBase() && texaddr < PSP_GetKernelMemoryEnd())
+	// Without this, the bufwidth gets masked away improperly.
+	if (IsPPGEAtlasFakeAddress(texaddr, nullptr)) {
 		return gstate.texbufwidth[level] & 0x1FFF;
+	}
 
 	u32 bufw = gstate.texbufwidth[level] & textureAlignMask16[format];
 	if (bufw == 0 && format <= GE_TFMT_DXT5) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -26,6 +26,7 @@
 #include "Core/Config.h"
 #include "Core/Debugger/MemBlockInfo.h"
 #include "Core/MemMap.h"
+#include "Core/Util/PPGeDraw.h"
 #include "GPU/GPUState.h"
 
 #include "GPU/Common/TextureDecoder.h"
@@ -133,10 +134,16 @@ void ComputeRasterizerState(RasterizerState *state, BinManager *binner) {
 			u32 texaddr = gstate.getTextureAddress(i);
 			state->texaddr[i] = texaddr;
 			state->texbufw[i] = (uint16_t)GetTextureBufw(i, texaddr, texfmt);
-			if (Memory::IsValidAddress(texaddr))
-				state->texptr[i] = Memory::GetPointerUnchecked(texaddr);
-			else
+			if (Memory::IsValidTextureAddress(texaddr)) {
+				u32 offset;
+				if (IsPPGEAtlasFakeAddress(texaddr, &offset)) {
+					state->texptr[i] = PPGeAtlasGetData() + offset;
+				} else {
+					state->texptr[i] = Memory::GetPointerUnchecked(texaddr);
+				}
+			} else {
 				state->texptr[i] = nullptr;
+			}
 		}
 
 		state->textureLodSlope = gstate.getTextureLodSlope();


### PR DESCRIPTION
I've gotten the VSH running, well, or stumbling at least, see https://www.ppsspp.org/docs/getting-started/how-to-run-the-vsh/ .

I did this through trial-and-error mainly, accelerated by Claude to automate some of the job.

Time to start getting the code in, this is just some minor safe commits, plus an important refactor: Previously we stored the font atlas for sceUtility dialogs (which uses an internal graphics library I call PPGe) in PSP kernel memory, but that will not fly in this case as the VSH loads kernel modules that need the space.