### PR TITLE
Add CI for libretro's MSYS2-based Windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,52 @@ jobs:
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: msbuild /m /p:TrackFileAccess=false /p:Configuration=${{ env.BUILD_CONFIGURATION }} /p:Platform=x64 /p:AppxPackageSigningEnabled=false UWP/PPSSPP_UWP.sln
 
+  # Mirrors the two Windows jobs in libretro's own GitLab CI (see .gitlab-ci.yml). The libretro core
+  # is built by GNU make driving cl.exe/link.exe from an MSYS2 shell, not by the VS solution, so it
+  # catches MSVC-specific errors that neither build-windows nor the Linux/Android libretro builds do
+  # - duplicate symbols in particular, since MSVC emits inline functions that gcc/clang inline away.
+  build-libretro-windows:
+    name: build-libretro-windows (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: x64
+          platform: windows_msvc2019_desktop_x64
+          msystem: MINGW64
+        - arch: x86
+          platform: windows_msvc2019_desktop_x86
+          msystem: MINGW32
+
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: recursive
+
+    # Needs a real MSYS2 (make, bash, cygpath) - the one preinstalled on the runner image isn't on
+    # PATH and has no make. path-type: inherit keeps the Windows PATH, which the Makefile needs for
+    # reg.exe (Windows SDK lookup) and git.
+    - name: Setup MSYS2
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
+      with:
+        msystem: ${{ matrix.msystem }}
+        path-type: inherit
+        install: make
+
+    # The Makefile can locate Visual Studio by itself, but only through "cmd //c bash VSWhere.sh",
+    # which depends on COMSPEC and ProgramFiles(x86) surviving into the MSYS2 shell. Resolving it
+    # here and passing VsInstallRoot= on the command line (a command-line variable overrides the
+    # Makefile's own := assignment) fails loudly rather than silently misconfiguring the build.
+    - name: Build libretro core
+      shell: msys2 {0}
+      run: |
+        VS_PATH=$(sh libretro/VSWhere.sh -latest -property installationPath)
+        test -n "$VS_PATH" || { echo "vswhere found no Visual Studio installation"; exit 1; }
+        echo "Visual Studio: $VS_PATH"
+        make -C libretro -f Makefile -j4 platform=${{ matrix.platform }} VsInstallRoot="$(cygpath -u "$VS_PATH")"
+
   test-windows:
     runs-on: windows-latest
     needs: build-windows

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1984,11 +1984,6 @@ void System_PostUIMessage(UIMessage message, std::string_view param) {}
 void System_RunOnMainThread(std::function<void()>) {}
 void NativeFrame(GraphicsContext *graphicsContext) {}
 void NativeResized() {}
-// Stubs to let things link - libretro builds Core.cpp and Breakpoints.cpp, which call into the
-// WebSocket debugger, but doesn't build Core/Debugger/WebSocket.cpp itself.
-void WebSocketDebuggerTick() {}
-bool WebSocketDebuggerHasClients() { return false; }
-void WebSocketNotifyBreakpointHit(const BreakpointHit &hit) {}
 void System_Toast(std::string_view str) {}
 
 inline int16_t Clamp16(int32_t sample) {


### PR DESCRIPTION
Clauding again, mirroring the official libretro build servers, should hopefully fix #22129 and avoid any reappearance of similar issues. Another thing that would have taken me hours and hours to get right. Well, hopefully it works first try :)