### PR TITLE
libretro: restore emu-thread pause handshake so retro_serialize can't deadlock

### DIFF
--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -100,6 +100,7 @@ extern retro_hw_context_type backend;
 enum class EmuThreadState {
 	DISABLED,
 	RUNNING,
+	PAUSE_REQUESTED,
 	PAUSED,
 	QUIT_REQUESTED,
 	STOPPED,

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1392,6 +1392,9 @@ namespace Libretro {
             case EmuThreadState::RUNNING:
                EmuFrame();
                break;
+            case EmuThreadState::PAUSE_REQUESTED:
+               emuThreadState = EmuThreadState::PAUSED;
+               [[fallthrough]];
             case EmuThreadState::PAUSED:
                sleep_ms(1, "libretro-paused");
                break;
@@ -1441,7 +1444,7 @@ namespace Libretro {
       if (emuThreadState != EmuThreadState::RUNNING)
          return;
 
-      emuThreadState = EmuThreadState::PAUSED;
+      emuThreadState = EmuThreadState::PAUSE_REQUESTED;
 
       // Is this safe?
       ctx->ThreadFrame(); // Eat 1 frame
@@ -1715,7 +1718,8 @@ void retro_run(void) {
 
    // Handle thread pumping.
    if (useEmuThread) {
-      if (emuThreadState == EmuThreadState::PAUSED) {
+      if (emuThreadState == EmuThreadState::PAUSED ||
+          emuThreadState == EmuThreadState::PAUSE_REQUESTED) {
          VsyncSwapIntervalDetect();
          ctx->SwapBuffers();
          return;


### PR DESCRIPTION
### Intro
Hey! I'm working on some kind of internal libretro core player and I was adding periodic save states. During that work, I realized that sometimes the emulator would hang, and it seemed to happen only with save states. I'm also using OpenGL instead of Vulkan as I'm working with somewhat old hardware.

The issue seems to be (all below generated by Claude, obviously 😅) that the emulation thread is missing a handshake after it's being told to be paused. From Claude's analysis it seems this code was removed to optimize some calls to avoid wasting cycles, but this handshake is necessary so the emulation thread does not hang while waiting for a save state to be generated, or something like that. 

The emulator state needs to be stopped so the state can be generated, or so I've figured out. My background isn't emulators although I've done gamedev in the past, but hopefully all of this makes sense. I was able to grab a gdb stack of the hang and use it to create the patch.

**Per the PPSSPP AI policy:** the root-cause investigation (gdb analysis) and this three-hunk patch were developed with AI assistance (Claude). I have reviewed and fully understand the change; the diagnosis and diff were verified by hand against the code and on real hardware.

Thanks for reading!

### Problem
On the OpenGL backend with the emu thread enabled (`useEmuThread`, GLES core), `retro_serialize` / `retro_unserialize` can deadlock the emu thread under repeated save/load — reproducible when a frontend takes periodic save-state snapshots.

### Root cause
`EmuThreadPause()` no longer waits for the emu thread to acknowledge the pause:

```cpp
emuThreadState = EmuThreadState::PAUSED;   // main thread sets PAUSED itself
ctx->ThreadFrame();                         // eat 1 frame
while (emuThreadState != EmuThreadState::PAUSED)   // already PAUSED -> never loops
    sleep_ms(1, "libretro-pause-poll");
```

The poll loop is dead code, so `EmuThreadPause()` returns while the emu thread may still be mid-`EmuFrame()`. `retro_serialize` then reads emulator state and drives the GL `ThreadFrame` handshake concurrently with the emu thread, and both sides can wedge in `ctx->ThreadFrame()`.

This regressed in c42a3f070a ("Implement the new shutdown path for libretro too"), which removed the `PAUSE_REQUESTED` intermediate state. Without it the emu thread never sets `PAUSED` at a frame boundary, so the wait above has nothing to wait for.

### Fix
Restore only the pause acknowledge handshake:
- `EmuThreadPause()` sets `PAUSE_REQUESTED` and waits for the emu thread to reach `PAUSED`.
- The emu thread loop transitions `PAUSE_REQUESTED -> PAUSED` at its own frame boundary.
- `retro_run` treats `PAUSE_REQUESTED` like `PAUSED` (swap + return) so it doesn't pump a frame mid-pause.

`START_REQUESTED` stays removed and the new shutdown path (`QUIT_REQUESTED -> NotifyEmuThreadExit -> drain loop`) is untouched.

### Testing
Built the GL libretro core on Debian stable and ran a frontend taking periodic save-state snapshots (~1 per 5s). Before: the emu thread wedges on the first serialize after a pause — confirmed via gdb, main thread parked in `GLRenderManager::ThreadFrame` (`cond_wait`, 0% CPU), EmuThread parked, only audio alive. After: ~200s / ~40 snapshots under sustained load, render thread steady, no freeze.
