### PR TITLE
Add madden 06 to infra-dns.json

### DIFF
--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -217,6 +217,24 @@
 			]
 		},
 		{
+			"name": "Madden NFL 06",
+			"comment": {
+				"en_US": "Works but there are incompatibilities between platforms. Requires a patch!"
+			},
+			"revival_credits": {
+				"group": "EA Nation Hub",
+				"url": "https://discord.gg/fwrQHHxrQQ"
+			},
+			"dns": "eahub.eu",
+			"domains": {
+				"pspmadden06.ea.com": "eahub.eu"
+			},
+			"score": 4,
+			"known_working_ids": [
+				"ULUS10024"
+			]
+		},
+		{
 			"name": "Madden NFL 07",
 			"comment": {
 				"en_US": "Works but there are incompatibilities between platforms"


### PR DESCRIPTION
The game requires a patch so its port don't overlap with madden 09.

Note: I was unable to test the configuration despite everything looking fine to me (falls back to default dns), maybe a regression on "DontDownloadInfraJson" ?