### PR TITLE
Fix PPSSPP libretro startup auto-load savestate restoration

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1797,6 +1797,7 @@ bool retro_unserialize(const void *data, size_t size) {
    if (!gpu) {
       unserialize_data = malloc(size);
       memcpy(unserialize_data, data, size);
+      unserialize_size = size;
       return true;
    }
 


### PR DESCRIPTION
## Summary

Fixes an issue in the PPSSPP libretro core where savestates configured to auto-load at startup were not restored correctly.

## Problem

When a frontend requests a savestate load during early core startup, `retro_unserialize()` can be called before the GPU is initialized.

PPSSPP intentionally defers applying the savestate until initialization is complete. That deferred behavior is expected and is not the bug.

The issue was that PPSSPP copied the savestate data for later use but did not retain its corresponding `size`. As a result, the deferred restore later used `unserialize_size == 0`, so the savestate was not restored.

Manual savestate loading after core initialization was unaffected because it did not use this early-startup deferred path.

## Fix

Preserve the savestate size together with the deferred savestate data so the startup auto-loaded state can be restored correctly after initialization completes.

## Verification

With startup savestate auto-load enabled, the frontend reported that the state had been loaded, but before this fix the PPSSPP core started the game normally instead of restoring the saved state.

After the fix, the automatically loaded savestate is restored correctly at startup.

Manual savestate loading continues to work as before.