### PR TITLE
Avoid validating unused savedata name lists

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1540,7 +1540,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param) {
 
 	SceUtilitySavedataSaveName *saveNameListData;
 	bool hasMultipleFileName = false;
-	if (param->saveNameList.IsValid()) {
+	if (param->saveNameList.IsValid() && WouldHaveMultiSaveName(param)) {
 		Clear();
 
 		saveNameListData = param->saveNameList;
@@ -1558,7 +1558,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param) {
 			saveDataListCount++;
 		}
 
-		if (saveDataListCount > 0 && WouldHaveMultiSaveName(param)) {
+		if (saveDataListCount > 0) {
 			hasMultipleFileName = true;
 			saveDataList = new SaveFileInfo[saveDataListCount];
 			


### PR DESCRIPTION
## Summary

Avoids validating `saveNameList` for savedata modes that do not use it.

## Problem

Some savedata modes use the direct `saveName` field rather than `saveNameList`.

`SavedataParam::SetPspParam()` currently scans and validates `saveNameList` whenever its pointer is valid, before checking whether the current mode actually uses a multi-name list.

FINAL FANTASY I (ULJM05241) exposes this behavior because its `saveNameList` points to guest stack memory that is later reused. On a subsequent savedata call, the unused list can contain stale data. The current validation may then reject that stale entry with `SCE_ERROR_UTILITY_INVALID_PARAM_SIZE` before the direct `saveName` path is reached.

## Fix

Only scan and validate `saveNameList` when `WouldHaveMultiSaveName(param)` indicates that the current savedata mode actually uses the list.

Modes that use `saveNameList` continue to perform the existing path traversal validation unchanged.

## Verification

Verified that FINAL FANTASY I can load existing saved data, enter its in-game save flow, save successfully, and reload the saved data after this change.

The fix does not add any title-specific behavior.

This also aligns with the historical handling discussed in #1017, where direct save names are preferred for the affected savedata modes.