### PR TITLE
Strip spaces of the disc ID

### DIFF
--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -105,7 +105,8 @@ std::vector<std::string> ParamSFOData::GetKeys() const {
 }
 
 std::string ParamSFOData::GetDiscID() {
-	const std::string discID = GetValueString("DISC_ID");
+	const std::string rawDiscID = GetValueString("DISC_ID");
+	const std::string discID(StripSpaces(rawDiscID));
 	if (discID.empty()) {
 		std::string fakeID = GenerateFakeID(Path());
 		WARN_LOG(Log::Loader, "No DiscID found - generating a fake one: '%s' (from %s)", fakeID.c_str(), PSP_CoreParameter().fileToStart.c_str());


### PR DESCRIPTION
As said in #22143 in rare cases the disc ID contains a space, which leads to a mismatch with the `infra-dns.json` file (especially for madden 06) and creates game-related files (cheats, save states, etc.) with spaces (e.g. `ULUS10024 .ini`).  

Confirmed to fix madden 06 online and no regression observed in another game tested.