### PR TITLE
Claude Code Review: DepthRaster: fix host buffer overflows in the depth raster queue

### DIFF
--- a/GPU/Common/DepthRaster.cpp
+++ b/GPU/Common/DepthRaster.cpp
@@ -370,14 +370,13 @@ int DepthRasterClipIndexedRectangles(int *tx, int *ty, float *tz, const float *t
 	return outCount;
 }
 
-int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor) {
+int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor, int maxOutCount) {
 	int outCount = 0;
 
 	int flipCull = 0;
 	if (draw.cullEnabled && draw.cullMode == GE_CULL_CW) {
 		flipCull = 3;
 	}
-	const bool cullEnabled = draw.cullEnabled;
 
 	static const float zerovec[4] = {0.0f, 0.0f, 0.0f, 1.0f};
 
@@ -449,6 +448,11 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 		}
 
 		collected -= 12;
+
+		if (outCount + 12 > maxOutCount) {
+			// Out of room. With culling off we emit two triangles per input triangle, so this is reachable.
+			break;
+		}
 
 		// These names are wrong .. until we transpose.
 		Vec4F32 x0 = Vec4F32::Load(verts[0]);
@@ -543,21 +547,6 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 #endif
 
 		outCount += 12;
-
-		if (!cullEnabled) {
-			// If culling is off, store the triangles again, with the first two vertices swapped.
-			(Vec4S32FromF32(x0) & inGuardBand).Store(tx + outCount);
-			(Vec4S32FromF32(x2) & inGuardBand).Store(tx + outCount + 4);
-			(Vec4S32FromF32(x1) & inGuardBand).Store(tx + outCount + 8);
-			Vec4S32FromF32(y0).Store(ty + outCount);
-			Vec4S32FromF32(y2).Store(ty + outCount + 4);
-			Vec4S32FromF32(y1).Store(ty + outCount + 8);
-			z0.Store(tz + outCount);
-			z2.Store(tz + outCount + 4);
-			z1.Store(tz + outCount + 8);
-
-			outCount += 12;
-		}
 	}
 
 	gpuStats.perFrame.numDepthRasterZCulled += planeCulled;

--- a/GPU/Common/DepthRaster.h
+++ b/GPU/Common/DepthRaster.h
@@ -51,7 +51,8 @@ struct DepthDraw {
 class VertexDecoder;
 struct TransformedVertex;
 
-int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor);
+// maxOutCount is the capacity of each of tx/ty/tz, in elements.
+int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor, int maxOutCount);
 int DepthRasterClipIndexedRectangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor);
 void DecodeAndTransformForDepthRaster(float *dest, const float *worldviewproj, const void *vertexData, int indexLowerBound, int indexUpperBound, const VertexDecoder *dec, u32 vertTypeID);
 void TransformPredecodedForDepthRaster(float *dest, const float *worldviewproj, const void *decodedVertexData, const VertexDecoder *dec, int count);

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -1010,7 +1010,8 @@ enum {
 	DEPTH_SCREENVERTS_COMPONENT_COUNT = VERTEX_BUFFER_MAX,
 	DEPTH_SCREENVERTS_COMPONENT_BYTES = DEPTH_SCREENVERTS_COMPONENT_COUNT * sizeof(int) + 384,
 	DEPTH_SCREENVERTS_TOTAL_BYTES = DEPTH_SCREENVERTS_COMPONENT_BYTES * 3,
-	DEPTH_INDEXBUFFER_BYTES = DEPTH_TRANSFORMED_MAX_VERTS * 3 * sizeof(uint16_t),  // hmmm
+	DEPTH_INDEXBUFFER_MAX_INDICES = DEPTH_TRANSFORMED_MAX_VERTS * 3,
+	DEPTH_INDEXBUFFER_BYTES = DEPTH_INDEXBUFFER_MAX_INDICES * sizeof(uint16_t),
 };
 
 // We process vertices for depth rendering in several stages:
@@ -1070,7 +1071,10 @@ Mat4F32 ComputeFinalProjMatrix() {
 	return m;
 }
 
-bool DrawEngineCommon::CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim, int vertexCount) {
+// numDecoded is how many vertices this draw will write to depthTransformed_, which is not the
+// same thing as vertexCount (the number of indices) - an indexed draw can decode far more
+// vertices than it has indices, or far fewer.
+bool DrawEngineCommon::CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim, int vertexCount, int numDecoded) {
 	switch (prim) {
 	case GE_PRIM_INVALID:
 	case GE_PRIM_KEEP_PREVIOUS:
@@ -1116,8 +1120,11 @@ bool DrawEngineCommon::CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim,
 		_dbg_assert_(gstate.isDepthWriteEnabled());
 	}
 
-	if (depthVertexCount_ + vertexCount >= DEPTH_TRANSFORMED_MAX_VERTS) {
+	if (depthVertexCount_ + numDecoded > DEPTH_TRANSFORMED_MAX_VERTS) {
 		// Can't add more. We need to flush.
+		return false;
+	}
+	if (depthIndexCount_ + vertexCount > DEPTH_INDEXBUFFER_MAX_INDICES) {
 		return false;
 	}
 
@@ -1150,8 +1157,14 @@ void DrawEngineCommon::DepthRasterSubmitRaw(GEPrimitiveType prim, const VertexDe
 	float worldviewproj[16];
 	ComputeFinalProjMatrix().Store(worldviewproj);
 
+	// How many vertices the decode loop below will write.
+	int willDecode = 0;
+	for (int i = 0; i < numDrawVerts_; i++) {
+		willDecode += drawVerts_[i].indexUpperBound + 1 - drawVerts_[i].indexLowerBound;
+	}
+
 	DepthDraw draw;
-	if (!CalculateDepthDraw(&draw, prim, vertexCount)) {
+	if (!CalculateDepthDraw(&draw, prim, vertexCount, willDecode)) {
 		return;
 	}
 
@@ -1161,7 +1174,7 @@ void DrawEngineCommon::DepthRasterSubmitRaw(GEPrimitiveType prim, const VertexDe
 	int numDecoded = 0;
 	for (int i = 0; i < numDrawVerts_; i++) {
 		const DeferredVerts &dv = drawVerts_[i];
-		if (dv.indexUpperBound + 1 - dv.indexLowerBound + numDecoded >= DEPTH_TRANSFORMED_MAX_VERTS) {
+		if (draw.vertexOffset + numDecoded + (dv.indexUpperBound + 1 - dv.indexLowerBound) > DEPTH_TRANSFORMED_MAX_VERTS) {
 			// Hit our limit! Stop decoding in this draw.
 			// We should have already broken out in CalculateDepthDraw.
 			break;
@@ -1193,7 +1206,7 @@ void DrawEngineCommon::DepthRasterPredecoded(GEPrimitiveType prim, const void *i
 	}
 
 	DepthDraw draw;
-	if (!CalculateDepthDraw(&draw, prim, vertexCount)) {
+	if (!CalculateDepthDraw(&draw, prim, vertexCount, numDecoded)) {
 		return;
 	}
 
@@ -1255,7 +1268,7 @@ void DrawEngineCommon::FlushQueuedDepth() {
 				outVertCount = DepthRasterClipIndexedRectangles(tx, ty, tz, vertices, indices, draw, tileScissor);
 				break;
 			case GE_PRIM_TRIANGLES:
-				outVertCount = DepthRasterClipIndexedTriangles(tx, ty, tz, vertices, indices, draw, tileScissor);
+				outVertCount = DepthRasterClipIndexedTriangles(tx, ty, tz, vertices, indices, draw, tileScissor, DEPTH_SCREENVERTS_COMPONENT_COUNT);
 				break;
 			default:
 				_dbg_assert_(false);

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -169,7 +169,7 @@ protected:
 	void ShutdownDepthRaster();
 	void DepthRasterSubmitRaw(GEPrimitiveType prim, const VertexDecoder *dec, uint32_t vertTypeID, int vertexCount);
 	void DepthRasterPredecoded(GEPrimitiveType prim, const void *inVerts, int numDecoded, const VertexDecoder *dec, int vertexCount);
-	bool CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim, int vertexCount);
+	bool CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim, int vertexCount, int numDecoded);
 
 	static inline int IndexSize(u32 vtype) {
 		const u32 indexType = (vtype & GE_VTYPE_IDX_MASK);


### PR DESCRIPTION
More stuff, including a possible performance fix (that will mainly affect Syphon Filter).

## Claude says

CalculateDepthDraw guarded depthVertexCount_ with vertexCount, which is the index count - but depthVertexCount_ grows by the number of decoded vertices, which for an indexed draw can be far larger. Two draws with 6 indices spanning 40000 vertices each therefore passed the check and wrote ~700KB past the end of depthTransformed_. It also never bounded depthIndexCount_ against depthIndices_ at all, which only has room for 3 indices per vertex slot while draws routinely produce more. Pass the decoded count in separately and check both.

DepthRasterClipIndexedTriangles duplicated culling-disabled triangles twice: once in the collect loop (added for Syphon Filter, #21498) and again in the output stage, which was the older code and should have been removed then. So it emitted four triangles per input triangle into buffers sized for one, and did twice the rasterization work it needed to in that mode. Removed the output-stage copy, and gave the function the output capacity so it stops when full - even at 2x, a culling-disabled draw over ~32k indices doesn't fit.


Claude-Session: https://claude.ai/code/session_01DCPmm7FoQUoqrbMdhfqhQ2