### PR TITLE
Fix savestate breakage related to file system mounts

### DIFF
--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -644,20 +644,29 @@ void MetaFileSystem::DoState(PointerWrap &p) {
 
 	u32 n = (u32) fileSystems.size();
 	Do(p, n);
-	bool skipPfat0 = false;
-	if (n != (u32) fileSystems.size()) {
-		if (n == (u32) fileSystems.size() - 1) {
-			skipPfat0 = true;
-		} else {
-			p.SetError(p.ERROR_FAILURE);
-			ERROR_LOG(Log::FileSystem, "Savestate failure: number of filesystems doesn't match.");
-			return;
-		}
+
+	// The mounts are serialized positionally, one section each and no length to skip by, so a
+	// savestate from an older build is simply missing the sections for mounts that didn't exist
+	// yet - and we have to leave out exactly those to stay lined up. Most recently added first.
+	static const char * const mountsAddedOverTime[] = { "flash1:", "pfat0:" };
+
+	const size_t missing = n < (u32)fileSystems.size() ? fileSystems.size() - n : 0;
+	if (n > (u32)fileSystems.size() || missing > ARRAY_SIZE(mountsAddedOverTime)) {
+		p.SetError(p.ERROR_FAILURE);
+		ERROR_LOG(Log::FileSystem, "Savestate failure: number of filesystems doesn't match (%d in state, %d mounted).", (int)n, (int)fileSystems.size());
+		return;
 	}
 
-	for (u32 i = 0; i < n; ++i) {
-		if (!skipPfat0 || fileSystems[i].prefix != "pfat0:") {
-			fileSystems[i].system->DoState(p);
+	for (const MountPoint &mount : fileSystems) {
+		bool skip = false;
+		for (size_t i = 0; i < missing; i++) {
+			if (mount.prefix == mountsAddedOverTime[i]) {
+				skip = true;
+				break;
+			}
+		}
+		if (!skip) {
+			mount.system->DoState(p);
 		}
 	}
 }

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -645,9 +645,19 @@ void MetaFileSystem::DoState(PointerWrap &p) {
 	u32 n = (u32) fileSystems.size();
 	Do(p, n);
 
-	// The mounts are serialized positionally, one section each and no length to skip by, so a
-	// savestate from an older build is simply missing the sections for mounts that didn't exist
-	// yet - and we have to leave out exactly those to stay lined up. Most recently added first.
+	// The mounts are serialized positionally: one section per mount, in mount order, with no
+	// length to skip by. So a savestate from an older build simply lacks the sections for mounts
+	// that didn't exist yet, and we have to leave out exactly those to stay lined up. We only know
+	// how many are missing (n), not which, so the list below says which ones came last.
+	//
+	// ADDING A NEW MOUNT: prepend its prefix here, or every existing savestate stops loading with
+	// "Failure at <whatever section follows>". The list is newest first, because a state that is
+	// missing k mounts is missing the k most recently added ones. Where in the mount order the new
+	// mount goes doesn't matter - removing it by prefix restores the old relative order either way.
+	//
+	// RENAMING OR REMOVING A MOUNT is not covered by any of this: a section in the state that we
+	// have no mount for can't be skipped, since we can't know how long it is. That would need a
+	// format change - storing the prefixes, or a length per section.
 	static const char * const mountsAddedOverTime[] = { "flash1:", "pfat0:" };
 
 	const size_t missing = n < (u32)fileSystems.size() ? fileSystems.size() - n : 0;

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -645,18 +645,24 @@ void MetaFileSystem::DoState(PointerWrap &p) {
 	u32 n = (u32) fileSystems.size();
 	Do(p, n);
 
-	// The mounts are serialized positionally: one section per mount, in mount order, with no
-	// length to skip by. So a savestate from an older build simply lacks the sections for mounts
-	// that didn't exist yet, and we have to leave out exactly those to stay lined up. We only know
-	// how many are missing (n), not which, so the list below says which ones came last.
+	// The mounts are serialized positionally: one section per mount, in fileSystems order, with no
+	// length to skip by. That order is the order Mount() first saw each prefix during boot, which
+	// spans more than MountFileSystems() - booting an ISO, MountGameISO() has already added umd0:,
+	// umd1:, umd: and disc0: by the time we get there. An older build's savestate simply lacks the
+	// sections for mounts that didn't exist yet, and we have to leave out exactly those to stay
+	// lined up. We only know how many are missing (n), not which, hence the list below.
 	//
 	// ADDING A NEW MOUNT: prepend its prefix here, or every existing savestate stops loading with
-	// "Failure at <whatever section follows>". The list is newest first, because a state that is
-	// missing k mounts is missing the k most recently added ones. Where in the mount order the new
-	// mount goes doesn't matter - removing it by prefix restores the old relative order either way.
+	// "Failure at <whatever section follows>". Newest first, because a state missing k mounts is
+	// missing the k most recently added ones. Where the new mount falls in the order doesn't
+	// matter - skipping it by prefix leaves the relative order of all the others unchanged.
 	//
-	// RENAMING OR REMOVING A MOUNT is not covered by any of this: a section in the state that we
-	// have no mount for can't be skipped, since we can't know how long it is. That would need a
+	// DO NOT REORDER EXISTING MOUNTS. Sections are paired with filesystems purely by position, so
+	// swapping two Mount() calls feeds every old savestate's sections to the wrong filesystems,
+	// silently and with no version to catch it.
+	//
+	// RENAMING OR REMOVING A MOUNT isn't handled here either: a section in the state we have no
+	// mount for can't be skipped, because we can't know how long it is. Either of those needs a
 	// format change - storing the prefixes, or a length per section.
 	static const char * const mountsAddedOverTime[] = { "flash1:", "pfat0:" };
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -82,6 +82,8 @@ static bool g_screenshotFailed = false;
 static std::string g_debugOutputBuffer;
 static bool g_writeFailureScreenshot = true;
 static bool g_writeDebugOutput = true;
+// Set from the savestate callback on the emu thread, read after it has been joined.
+static bool g_stateLoadFailed = false;
 
 #if PPSSPP_PLATFORM(ANDROID)
 JNIEnv *getEnv() {
@@ -339,6 +341,10 @@ static bool RunAutoTest(GraphicsContext *graphicsContext, CoreParameter &corePar
 	double deadline = time_now_d() + opt.timeout;
 	coreState = coreParameter.startBreak ? CORE_STEPPING_CPU : CORE_RUNNING_CPU;
 	while (coreState == CORE_RUNNING_CPU || coreState == CORE_STEPPING_CPU) {
+		// Savestate loads/saves are queued and applied here, same as EmuScreen::render does in the
+		// app. Without this, --state silently did nothing at all.
+		SaveState::Process();
+
 		int blockTicks = (int)usToCycles(1000000 / 10);
 		PSP_RunLoopFor(blockTicks);
 
@@ -873,7 +879,14 @@ int main(int argc, const char* argv[]) {
 	}
 
 	if (stateToLoad) {
-		SaveState::Load(Path(stateToLoad), -1);
+		// Queued now, actually applied by SaveState::Process() once the game is up and running.
+		SaveState::Load(Path(stateToLoad), -1, [](SaveState::Status status, std::string_view message, std::string_view) {
+			// The message already reads as a full sentence, e.g. "Failed to load state: <reason>".
+			fprintf(stderr, "%.*s\n", (int)message.size(), message.data());
+			if (status == SaveState::Status::FAILURE) {
+				g_stateLoadFailed = true;
+			}
+		});
 	}
 
 	std::string errorMessage;
@@ -890,6 +903,11 @@ int main(int argc, const char* argv[]) {
 	}, &errorMessage)) {
 		// No fallbacks in headless - if we can't run it, we can't. Let's not get confusing.
 		fprintf(stderr, "Failed to initialize graphics surface: %s\n", errorMessage.c_str());
+		retval = 1;
+	}
+
+	if (g_stateLoadFailed && retval == 0) {
+		// Whatever the run itself reported, the state we were told to load never got applied.
 		retval = 1;
 	}
 


### PR DESCRIPTION
Fixes a savestate breakage I detected manually.

Broke in 78ef1eae829dc153b5e5c54770455bddaedfb748

Some clauding involved but it went completely the wrong direction at first. The end result is fine though.