### PR TITLE
Use selected flags when starting the web server

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -835,7 +835,7 @@ void NativeInit(int argc, const char *argv[], const CommandLineOptions &cmdLineO
 		flags |= WebServerFlags::DEBUGGER;
 	}
 	if (flags != WebServerFlags::NONE) {
-		StartWebServer(WebServerFlags::ALL);
+		StartWebServer(flags);
 	}
 
 	std::string sysName = System_GetProperty(SYSPROP_NAME);


### PR DESCRIPTION
NativeInit computes a bitmask from the independent remote-sharing and remote-debugger settings, but starts the server with `WebServerFlags::ALL`. Enabling only remote disc sharing therefore exposes the unauthenticated debugger WebSocket, including memory/register writes and CPU execution control.

Pass the selected bitmask to `StartWebServer` so the services remain independently controlled. Remote disc sharing no longer enables debugger access implicitly.