### PR TITLE
Reject invalid ISO metadata extents

### DIFF
--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -296,10 +296,17 @@ void ISOFileSystem::ReadDirectory(TreeEntry *root) const {
 			entry->recordTime = UnixTimeFromDirectoryEntry(dir);
 			VERBOSE_LOG(Log::FileSystem, "%s: %s %08x %08x %d", entry->isDirectory ? "D" : "F", entry->name.c_str(), (u32)dir.firstDataSector, entry->startingPosition, entry->startingPosition);
 
-			// Round down to avoid any false reports.
-			if (isFile && dir.firstDataSector + (dir.dataLength / 2048) > blockDevice->GetNumBlocks()) {
+			// Validate the complete extent before exposing it through GetFileInfo.
+			// The directory record is untrusted, and retaining an out-of-range
+			// length lets callers resize host buffers from a bogus file size.
+			const u64 firstSector = dir.firstDataSector;
+			const u64 dataSectors = ((u64)dir.dataLength + sectorSize - 1) / sectorSize;
+			const u64 numBlocks = blockDevice->GetNumBlocks();
+			if (firstSector > numBlocks || dataSectors > numBlocks - firstSector) {
 				blockDevice->NotifyReadError();
 				ERROR_LOG(Log::FileSystem, "File '%s' starts or ends outside ISO. firstDataSector: %d len: %d", entry->BuildPath().c_str(), (int)dir.firstDataSector, (int)dir.dataLength);
+				delete entry;
+				continue;
 			}
 
 			if (entry->isDirectory && !relative) {

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -549,6 +549,7 @@ std::string GameManager::GetPBPGameID(FileLoader *loader) const {
 }
 
 std::string GameManager::GetISOGameID(FileLoader *loader) const {
+	static constexpr s64 MAX_PARAM_SFO_SIZE = 1024 * 1024;
 	SequentialHandleAllocator handles;
 	std::string errorString;
 	std::shared_ptr<BlockDevice> bd(ConstructBlockDevice(loader, &errorString));
@@ -566,10 +567,16 @@ std::string GameManager::GetISOGameID(FileLoader *loader) const {
 	if (handle < 0) {
 		return "";
 	}
+	if (info.size < 0 || info.size > MAX_PARAM_SFO_SIZE) {
+		WARN_LOG(Log::Loader, "Ignoring implausibly large PARAM.SFO (%lld bytes)", (long long)info.size);
+		umd.CloseFile(handle);
+		return "";
+	}
 
 	std::string sfoData;
-	sfoData.resize(info.size);
-	umd.ReadFile(handle, (u8 *)&sfoData[0], info.size);
+	sfoData.resize((size_t)info.size);
+	if (info.size > 0)
+		umd.ReadFile(handle, (u8 *)sfoData.data(), info.size);
 	umd.CloseFile(handle);
 
 	ParamSFOData sfo;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -450,9 +450,14 @@ void GameInfo::SetupTexture(Draw::DrawContext *thin3d, GameInfoTex &tex, int max
 
 // Will clear contents on failure.
 static bool ReadFileToString(IFileSystem *fs, std::string_view filename, std::string *contents, std::mutex *mtx) {
+	static constexpr s64 MAX_GAME_INFO_FILE_SIZE = 64 * 1024 * 1024;
 	std::string fn(filename);
 	PSPFileInfo info = fs->GetFileInfo(fn);
 	if (!info.exists) {
+		return false;
+	}
+	if (info.size < 0 || info.size > MAX_GAME_INFO_FILE_SIZE) {
+		WARN_LOG(Log::UI, "Ignoring implausibly large game metadata file %s (%lld bytes)", fn.c_str(), (long long)info.size);
 		return false;
 	}
 


### PR DESCRIPTION
`ISOFileSystem::ReadDirectory()` converts ISO directory records into `FileInfo` entries without checking that each extent remains within the image. `GameManager::GetISOGameID()` and `GameInfoCache::ReadFileToString()` then trust reported file sizes when reading metadata and resizing host buffers.

A crafted ISO can advertise out-of-range extents or oversized metadata files, causing excessive allocations, invalid reads, or process termination when the image is mounted or inspected.

Validate directory extents against the image size and reject oversized metadata before allocation or reading. Invalid entries are skipped safely.