### PR TITLE
Misc shutdown fixes on Windows

### DIFF
--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -40,6 +40,10 @@
 
 DisassemblyManager g_disassemblyManager;
 
+void ClearDisassemblyCache() {
+	g_disassemblyManager.clear();
+}
+
 bool isInInterval(u32 start, u32 size, u32 value) {
 	return start <= value && value <= (start+size-1);
 }

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -204,6 +204,15 @@ private:
 
 extern DisassemblyManager g_disassemblyManager;
 
+// Drops the cached disassembly. Call this when what it describes - emulated memory and the symbol
+// map - goes away. DisassemblyManager.cpp isn't built for libretro (see libretro/Makefile.common),
+// so there it's a no-op, the same way the WebSocket debugger entry points are.
+#ifdef __LIBRETRO__
+inline void ClearDisassemblyCache() {}
+#else
+void ClearDisassemblyCache();
+#endif
+
 bool isInInterval(u32 start, u32 size, u32 value);
 bool IsLikelyStringAt(uint32_t addr);
 

--- a/Core/Debugger/WebSocket/DisasmSubscriber.cpp
+++ b/Core/Debugger/WebSocket/DisasmSubscriber.cpp
@@ -37,9 +37,6 @@ public:
 	WebSocketDisasmState() {
 		g_disassemblyManager.setCpu(currentDebugMIPS);
 	}
-	~WebSocketDisasmState() {
-		g_disassemblyManager.clear();
-	}
 
 	void Base(DebuggerRequest &req);
 	void Disasm(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -33,9 +33,6 @@ struct WebSocketSteppingState : public DebuggerSubscriber {
 	WebSocketSteppingState() {
 		g_disassemblyManager.setCpu(currentDebugMIPS);
 	}
-	~WebSocketSteppingState() {
-		g_disassemblyManager.clear();
-	}
 
 	void Into(DebuggerRequest &req);
 	void Over(DebuggerRequest &req);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -50,6 +50,7 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSVFPUUtils.h"
+#include "Core/Debugger/DisassemblyManager.h"
 #include "Core/Debugger/LineInfo.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/System.h"
@@ -615,6 +616,10 @@ void CPU_Shutdown(bool success) {
 	DisplayHWShutdown();
 
 	pspFileSystem.Shutdown();  // This unmounts all filesystems.
+
+	// Everything the disassembly cache describes - emulated memory and the symbol map - is about
+	// to go away, so drop it here rather than leaving it to whichever debugger UI closes last.
+	ClearDisassemblyCache();
 
 	mipsr4k.Shutdown();
 	Memory::Shutdown();

--- a/UI/ImDebugger/ImDisasmView.cpp
+++ b/UI/ImDebugger/ImDisasmView.cpp
@@ -38,10 +38,6 @@ ImDisasmView::ImDisasmView() {
 	displaySymbols_ = true;
 }
 
-ImDisasmView::~ImDisasmView() {
-	g_disassemblyManager.clear();
-}
-
 void ImDisasmView::ScanVisibleFunctions() {
 	g_disassemblyManager.analyze(windowStart_, g_disassemblyManager.getNthNextAddress(windowStart_, visibleRows_) - windowStart_);
 }

--- a/UI/ImDebugger/ImDisasmView.h
+++ b/UI/ImDebugger/ImDisasmView.h
@@ -23,7 +23,6 @@ class MIPSState;
 class ImDisasmView {
 public:
 	ImDisasmView();
-	~ImDisasmView();
 
 	// Public variables bounds to imgui checkboxes
 	bool followPC_ = true;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1046,7 +1046,13 @@ void NativeShutdownGraphics(GraphicsContext *graphicsContext) {
 		}
 		ImGui_ImplThin3d_DestroyDeviceObjects();
 		ImGui_ImplThin3d_Shutdown();
+		// Destroy the debugger here, while the things it refers to are still alive. If left to
+		// static destruction, ~ImDisasmView runs after Core's globals are gone and its
+		// g_disassemblyManager.clear() walks a destroyed map (and locks a destroyed mutex).
+		imDebugger_.reset();
 		ImGui::DestroyContext(ctx_);
+		ctx_ = nullptr;
+		imguiInited_ = false;
 	}
 
 #if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -209,7 +209,6 @@ CtrlDisAsmView::~CtrlDisAsmView()
 {
 	DeleteObject(font);
 	DeleteObject(boldfont);
-	g_disassemblyManager.clear();
 }
 
 static COLORREF scaleColor(COLORREF color, float factor)

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -1312,15 +1312,17 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	_dbg_assert_(mainThread.joinable());
 	mainThread.join();
 
+	// The debugger windows reach into core state as they go away (CtrlDisAsmView touches
+	// g_disassemblyManager, for example), so tear them down while the core is still around.
+	MainWindow::DestroyDebugWindows();
+	DialogManager::DestroyAll();
+
 	// It's safe to call NativeShutdown, we've joined the main thread.
 	NativeShutdown();
 
 	g_VFS.Clear();
 
 	// g_InputManager.StopPolling() is called in WM_DESTROY
-
-	MainWindow::DestroyDebugWindows();
-	DialogManager::DestroyAll();
 
 	TimeShutdown();
 


### PR DESCRIPTION
* Destroy the ImGui debugger explicitly, not at static destruction time

* Windows: destroy the debugger windows before NativeShutdown()

* Clear the disassembly cache where it goes stale, not in view destructors
