### PR TITLE
[POC] Start aemu_postoffice relay along side with built-in adhocctl server

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -726,7 +726,7 @@ endif()
 list(APPEND CoreExtraLibs armips)
 
 target_link_libraries(Core GPU Common chdr kirk cityhash sfmt19937 xbrz xxhash rcheevos minimp3 at3_standalone lua
-	aemu_postoffice_client ${CoreExtraLibs} ${CMAKE_DL_LIBS})
+	aemu_postoffice_client aemu_postoffice_server ${CoreExtraLibs} ${CMAKE_DL_LIBS})
 
 # Winsock
 if(WIN32)

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1948,6 +1948,10 @@ void __NetAdhocInit() {
 
 			aemu_postoffice_server::Server relay_server(config);
 
+			UPnP_Add(IP_PROTOCOL_TCP, AEMU_POSTOFFICE_PORT);
+
+			INFO_LOG(Log::sceNet, "RelayServer: Listening for Connections on TCP Port %u", AEMU_POSTOFFICE_PORT);
+
 			while (adhocServerRunning) {
 				auto now = std::chrono::high_resolution_clock::now();
 				auto pump_status = relay_server.pump();
@@ -1963,6 +1967,10 @@ void __NetAdhocInit() {
 					std::this_thread::sleep_for(wait_time - time_taken);
 				}
 			}
+
+			INFO_LOG(Log::sceNet, "RelayServer: Shutdown complete");
+
+			UPnP_Remove(IP_PROTOCOL_TCP, AEMU_POSTOFFICE_PORT);
 		});
 	}
 }

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -60,6 +60,8 @@
 #include "Core/HLE/NetAdhocCommon.h"
 
 #include "ext/aemu_postoffice/client/postoffice_client.h"
+#include "ext/aemu_postoffice/server_cpp/server.h"
+#include "ext/aemu_postoffice/server_cpp/log.h"
 
 #ifdef _WIN32
 #undef errno
@@ -96,6 +98,7 @@ bool trackingRelayFailure = false;
 bool relayDisabled = false;
 bool relayFirstConnect = true;
 bool g_serverListLoaded = false;
+std::thread relayThread;
 
 int gameModeNotifyEvent = -1;
 
@@ -326,6 +329,10 @@ void __NetAdhocShutdown() {
 	adhocServerRunning = false;
 	if (adhocServerThread.joinable()) {
 		adhocServerThread.join();
+	}
+
+	if (relayThread.joinable()) {
+		relayThread.join();
 	}
 
 	NetAdhocctl_Term();
@@ -1900,6 +1907,18 @@ void __AdhocNotifInit() {
 	sendTargetPeers.clear();
 }
 
+static void aemu_postoffice_server_log(const char *format, ...){
+	char log_buf[1024] = {0};
+	va_list args;
+	va_start(args, format);
+	int len = vsnprintf(log_buf, sizeof(log_buf), format, args);
+	va_end(args);
+	if (len < 1024 && log_buf[len - 1] == '\n'){
+		log_buf[len - 1] = '\0';
+	}
+	INFO_LOG(Log::sceNet, "%s", log_buf);
+}
+
 void __NetAdhocInit() {
 	friendFinderRunning = false;
 	netAdhocInited = false;
@@ -1912,6 +1931,39 @@ void __NetAdhocInit() {
 	adhocServerRunning = false;
 	if (g_Config.bEnableWlan && g_Config.bEnableAdhocServer) {
 		adhocServerThread = std::thread(proAdhocServerThread, SERVER_PORT);
+
+		// relay thread
+		relayThread = std::thread([] () {
+			SetCurrentThreadName("AEMUPostoffice");
+
+			aemu_postoffice_server::LOG = aemu_postoffice_server_log;
+
+			struct aemu_postoffice_server::config config;
+			/*
+			 * strict mode requires adhocctl data to be fed into the relay, either from
+			 * aemu_postoffice's implementation of adhocctl, or by constructing the snapshot
+			 * from ppsspp's adhocctl server
+			 */
+			config.strict_mode = false;
+
+			aemu_postoffice_server::Server relay_server(config);
+
+			while (adhocServerRunning) {
+				auto now = std::chrono::high_resolution_clock::now();
+				auto pump_status = relay_server.pump();
+				auto wait_time = std::chrono::milliseconds(8);
+				if (pump_status == aemu_postoffice_server::ServerPumpStatus::LISTEN_SOCK_DEAD) {
+					break;
+				}
+				if (pump_status == aemu_postoffice_server::ServerPumpStatus::IDLE){
+					wait_time = std::chrono::milliseconds(100);
+				}
+				auto time_taken = now - std::chrono::high_resolution_clock::now();
+				if (time_taken < wait_time){
+					std::this_thread::sleep_for(wait_time - time_taken);
+				}
+			}
+		});
 	}
 }
 

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1907,13 +1907,13 @@ void __AdhocNotifInit() {
 	sendTargetPeers.clear();
 }
 
-static void aemu_postoffice_server_log(const char *format, ...){
+static void aemu_postoffice_server_log(const char *format, ...) {
 	char log_buf[1024] = {0};
 	va_list args;
 	va_start(args, format);
 	int len = vsnprintf(log_buf, sizeof(log_buf), format, args);
 	va_end(args);
-	if (len < 1024 && log_buf[len - 1] == '\n'){
+	if (len < 1024 && log_buf[len - 1] == '\n') {
 		log_buf[len - 1] = '\0';
 	}
 	INFO_LOG(Log::sceNet, "%s", log_buf);
@@ -1959,11 +1959,11 @@ void __NetAdhocInit() {
 				if (pump_status == aemu_postoffice_server::ServerPumpStatus::LISTEN_SOCK_DEAD) {
 					break;
 				}
-				if (pump_status == aemu_postoffice_server::ServerPumpStatus::IDLE){
+				if (pump_status == aemu_postoffice_server::ServerPumpStatus::IDLE) {
 					wait_time = std::chrono::milliseconds(100);
 				}
 				auto time_taken = now - std::chrono::high_resolution_clock::now();
-				if (time_taken < wait_time){
+				if (time_taken < wait_time) {
 					std::this_thread::sleep_for(wait_time - time_taken);
 				}
 			}

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1937,6 +1937,7 @@ void __NetAdhocInit() {
 			SetCurrentThreadName("AEMUPostoffice");
 
 			aemu_postoffice_server::LOG = aemu_postoffice_server_log;
+			aemu_postoffice_server::LOG_TS = aemu_postoffice_server_log;
 
 			struct aemu_postoffice_server::config config;
 			/*

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -75,6 +75,34 @@ add_library(aemu_postoffice_client STATIC
 	${aemu_postoffice_client_obj}
 )
 
+set(aemu_postoffice_server_obj
+	aemu_postoffice/server_cpp/server.cpp
+	aemu_postoffice/server_cpp/session.cpp
+	aemu_postoffice/server_cpp/semaphore.cpp
+	aemu_postoffice/server_cpp/log.cpp
+)
+
+if(WIN32)
+	list(APPEND aemu_postoffice_server_obj
+		aemu_postoffice/server_cpp/native_socket_windows.cpp
+	)
+endif()
+
+if(LINUX OR ANDROID OR MACOSX OR IOS OR BSD)
+	list(APPEND aemu_postoffice_server_obj
+		aemu_postoffice/server_cpp/native_socket_linux.cpp
+	)
+endif()
+
+add_library(aemu_postoffice_server STATIC
+	${aemu_postoffice_server_obj}
+)
+
+set_target_properties(aemu_postoffice_server
+	PROPERTIES
+	CXX_STANDARD 20
+)
+
 set(FT_REQUIRE_ZLIB OFF CACHE BOOL "" FORCE)
 set(FT_REQUIRE_BZIP2 OFF CACHE BOOL "" FORCE)
 set(FT_REQUIRE_PNG OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
The new cpp server was namespaced for easy integration with other projects, tho I'm unsure if this is desirable, nor am I sure if starting the relay along side with the built-in adhocctl server is good UX

This currently only builds with CMake, and if this becomes a desirable feature, I'll likely need help with the msvc project files