### PR TITLE
Fix the restart-into-a-screen arguments, broken by the cmdline refactor

### DIFF
--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -894,7 +894,7 @@ void TouchTestScreen::OnImmersiveModeChange(UI::EventParams &e) {
 
 void TouchTestScreen::OnRenderingBackend(UI::EventParams &e) {
 	g_Config.Save("GameSettingsScreen::RenderingBackend");
-	System_RestartApp("--touchscreentest");
+	System_RestartApp("--start-screen=touchscreentest");
 }
 
 void TouchTestScreen::OnRecreateActivity(UI::EventParams &e) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1723,7 +1723,7 @@ void TriggerRestart(const char *why, bool editThenRestore, const Path &gamePath)
 	// Extra save here to make sure the choice really gets saved even if there are shutdown bugs in
 	// the GPU backend code.
 	g_Config.Save(why);
-	std::string param = "--gamesettings";
+	std::string param = "--start-screen=gamesettings";
 	if (editThenRestore) {
 		// We won't pass the gameID, so don't resume back into settings.
 		param.clear();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -807,8 +807,8 @@ void NativeInit(int argc, const char *argv[], const CommandLineOptions &cmdLineO
 		// Launch into specified start screen. This is useful for testing UI, more screens can be easily added here.
 		if (equals(cmdLineOptions.startScreen.value(), "touchscreentest")) {
 			g_screenManager->switchScreen(new MainScreen());
+			g_screenManager->push(new TouchTestScreen(Path()));
 		}
-		g_screenManager->push(new TouchTestScreen(Path()));
 		if (equals(cmdLineOptions.startScreen.value(), "gamesettings")) {
 			g_screenManager->switchScreen(new LogoScreen(AfterLogoScreen::TO_GAME_SETTINGS));
 		} else if (equals(cmdLineOptions.startScreen.value(), "developertools")) {


### PR DESCRIPTION
### Claude says

Centralizing command line parsing replaced the hand-rolled --gamesettings and
--touchscreentest argv checks in NativeInit with a single --start-screen=<name>
option, and made an unrecognized "--" argument a hard parse error. The two
System_RestartApp callers still passed the old flags.

So changing the graphics backend killed PPSSPP for good: the new process starts,
fails to parse --gamesettings, and returns 1 from WinMain before a window ever
exists. The error goes to stderr, which nobody sees in a GUI build, so it just
looks like the app quit instead of restarting.

Restarts that pass no arguments (the memstick screen, and the edit-then-restore
path) were unaffected, since an empty argument string makes ExitAndRestart reuse
the original command line.

Also move the TouchTestScreen push inside the touchscreentest branch - it looks
like a brace that didn't move during the refactor, and it would otherwise push a
touch test screen for every --start-screen value.
