### PR TITLE
Support PSPAR/TempAR folder and comment codes in cheat files

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -101,6 +101,9 @@ void CheatFileParser::Flush() {
 		cheats_.push_back(CheatCode{lastCheatInfo_.name, pendingLines_});
 		FlushCheatInfo();
 		pendingLines_.clear();
+	} else if (lastCheatInfo_.structure != CheatStructure::None) {
+		// Folders and comments have no cheat lines of their own, but still belong in the list.
+		FlushCheatInfo();
 	}
 }
 
@@ -172,10 +175,26 @@ void CheatFileParser::ParseLine(const std::string &line, int lineNumber) {
 		ParseDataLine(line.substr(2), lineNumber);
 		return;
 
-	case 'M':
-		// TempAR data line.
+	case 'M': {
+		// TempAR/PSPAR data line. We don't run these, but the folder and comment codes only
+		// organize the list, so those we can honor. See the "Folder/Comment Codes" section of
+		// https://github.com/raing3/psp-cheat-documentation/blob/master/cheat-devices/pspar.md
+		u32 part1 = 0, part2 = 0;
+		if (sscanf(line.c_str() + 2, "%x %x", &part1, &part2) == 2 && (part1 & 0xFFFFFFF0) == 0xCF000000) {
+			switch (part1 & 0xF) {
+			case 0: lastCheatInfo_.structure = CheatStructure::SingleSelectFolder; break;
+			case 1: lastCheatInfo_.structure = CheatStructure::Comment; break;
+			case 2: lastCheatInfo_.structure = CheatStructure::MultiSelectFolder; break;
+			default:
+				AddError("unknown folder/comment code", lineNumber);
+				return;
+			}
+			lastCheatInfo_.subItems = (int)part2;
+			return;
+		}
 		AddError("TempAR codes not supported", lineNumber);
 		return;
+	}
 
 	default:
 		AddError("unknown line type", lineNumber);

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -33,10 +33,21 @@ struct CheatCode {
 	std::vector<CheatLine> lines;
 };
 
+// Organizational codes from PSPAR/TempAR (the _M 0xCF00000n lines). These carry no memory
+// operations - they just group the entries that follow them in the list.
+enum class CheatStructure {
+	None,
+	Comment,
+	SingleSelectFolder,
+	MultiSelectFolder,
+};
+
 struct CheatFileInfo {
 	int lineNum;
 	std::string name;
 	bool enabled;
+	CheatStructure structure = CheatStructure::None;
+	int subItems = 0;  // How many of the entries that follow belong to this folder or comment.
 
 	bool IsTitle(std::string_view *title) const {
 		return DetectCheatTitle(name, title);

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -288,13 +288,18 @@ void CwCheatScreen::CreateContentViews(UI::ViewGroup *parent) {
 
 	rightColumn->Add(new ItemHeader(cw->T("Cheats")));
 
+	ComputeCheatLayout();
+
 	bool prevIsTitle = false;
 	View *prev = nullptr;
 	for (size_t i = 0; i < fileInfo_.size(); ++i) {
+		const CheatLayout &layout = layout_[i];
+		// Folders indent what's inside them.
+		const float indent = 24.0f * layout.depth;
 		std::string_view text;
 		if (fileInfo_[i].IsTitle(&text)) {
 			// Title.
-			TextView *titleView = rightColumn->Add(new TextView(text, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8, 8, 8, 0))));
+			TextView *titleView = rightColumn->Add(new TextView(text, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8 + (int)indent, 8, 8, 0))));
 			titleView->SetTextSize(UI::TextSize::Big);
 			titleView->SetAlwaysVisibleInSearch(true);
 			prevIsTitle = true;
@@ -302,17 +307,81 @@ void CwCheatScreen::CreateContentViews(UI::ViewGroup *parent) {
 		} else if (fileInfo_[i].IsPostComment(&text)) {
 			rightColumn->Add(new SettingHint(text, prev));
 			prevIsTitle = false;
+		} else if (layout.isFolder) {
+			// A folder from the structure codes. Same look as a title, so the two kinds of
+			// grouping in the wild don't end up looking unrelated.
+			TextView *folderView = rightColumn->Add(new TextView(fileInfo_[i].name, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8 + (int)indent, 8, 8, 0))));
+			folderView->SetTextSize(UI::TextSize::Big);
+			folderView->SetAlwaysVisibleInSearch(true);
+			prevIsTitle = true;
+			prev = nullptr;
+		} else if (layout.isComment) {
+			// Comments aren't cheats you can turn on, they're just text.
+			rightColumn->Add(new TextView(fileInfo_[i].name, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, UI::Margins(8 + (int)indent, 4, 8, 0))));
+			prevIsTitle = false;
+			prev = nullptr;
 		} else {
 			// Regular cheat code.
 			if (!prevIsTitle) {
 				rightColumn->Add(new Spacer(8.0f));
 			}
-			CheckBox *checkBox = rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name));
+			CheckBox *checkBox = rightColumn->Add(new CheckBox(&fileInfo_[i].enabled, fileInfo_[i].name, "", new LinearLayoutParams(UI::Margins((int)indent, 0, 0, 0))));
 			checkBox->OnClick.Add([=](UI::EventParams &) {
 				OnCheckBox((int)i);
 			});
 			prev = checkBox;
 			prevIsTitle = false;
+		}
+	}
+}
+
+void CwCheatScreen::ComputeCheatLayout() {
+	layout_.assign(fileInfo_.size(), CheatLayout());
+
+	// A folder or comment claims the entries that follow it, so keep a stack of the ones we're
+	// still inside. Every entry counts against all the groups enclosing it, nesting included.
+	struct OpenGroup {
+		CheatStructure structure;
+		int remaining;
+		int index;
+	};
+	std::vector<OpenGroup> groups;
+
+	for (size_t i = 0; i < fileInfo_.size(); ++i) {
+		while (!groups.empty() && groups.back().remaining <= 0) {
+			groups.pop_back();
+		}
+
+		CheatLayout &layout = layout_[i];
+		for (const auto &group : groups) {
+			if (group.structure == CheatStructure::Comment) {
+				layout.isComment = true;
+			} else {
+				layout.depth++;
+				if (group.structure == CheatStructure::SingleSelectFolder) {
+					layout.singleSelectParent = group.index;
+				}
+			}
+		}
+		for (auto &group : groups) {
+			group.remaining--;
+		}
+
+		switch (fileInfo_[i].structure) {
+		case CheatStructure::Comment:
+			layout.isComment = true;
+			break;
+		case CheatStructure::SingleSelectFolder:
+		case CheatStructure::MultiSelectFolder:
+			// A folder nested in a comment is just more comment text.
+			layout.isFolder = !layout.isComment;
+			break;
+		case CheatStructure::None:
+			break;
+		}
+
+		if (fileInfo_[i].structure != CheatStructure::None && fileInfo_[i].subItems > 0) {
+			groups.push_back(OpenGroup{fileInfo_[i].structure, fileInfo_[i].subItems, (int)i});
 		}
 	}
 }
@@ -553,6 +622,25 @@ bool CwCheatScreen::ImportCheats(const Path &cheatFile, int *cheatsFound) {
 }
 
 void CwCheatScreen::OnCheckBox(int index) {
+	// In a single select folder, turning one on turns the others off.
+	const int parent = index >= 0 && index < (int)layout_.size() ? layout_[index].singleSelectParent : -1;
+	if (parent != -1 && fileInfo_[index].enabled) {
+		bool changedOthers = false;
+		for (size_t i = 0; i < fileInfo_.size(); ++i) {
+			if ((int)i != index && layout_[i].singleSelectParent == parent && fileInfo_[i].enabled) {
+				fileInfo_[i].enabled = false;
+				changedOthers = true;
+			}
+		}
+		if (changedOthers) {
+			if (!RebuildCheatFile(INDEX_ALL)) {
+				RecreateViews();
+			}
+			RecreateViews();
+			return;
+		}
+	}
+
 	if (!RebuildCheatFile(index)) {
 		// TODO: Report error.  Let's reload the file, presumably it changed.
 		RecreateViews();

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -71,6 +71,17 @@ private:
 	bool HasCheatWithName(const std::string &name);
 	bool RebuildCheatFile(int index);
 
+	// Works out the folder/comment nesting from the PSPAR structure codes in fileInfo_.
+	void ComputeCheatLayout();
+
+	struct CheatLayout {
+		int depth = 0;                 // How deep in folders, for indentation.
+		bool isComment = false;        // Show as text rather than a checkbox.
+		bool isFolder = false;         // This entry is a folder header.
+		int singleSelectParent = -1;   // Enclosing single-select folder, if any.
+	};
+	std::vector<CheatLayout> layout_;
+
 	CWCheatEngine *engine_ = nullptr;
 	std::vector<CheatFileInfo> fileInfo_;
 	std::string gameID_;

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -106,6 +106,7 @@
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/MemMap.h"
 #include "Core/KeyMap.h"
+#include "Core/CwCheat.h"
 #include "Core/Util/PathUtil.h"
 #include "Core/MIPS/MIPSVFPUUtils.h"
 #include "GPU/Common/TextureDecoder.h"
@@ -2446,6 +2447,55 @@ bool TestInputMapping() {
 	return true;
 }
 
+// The PSPAR/TempAR folder and comment codes (_M 0xCF00000n) organize the cheat list. See #21257.
+bool TestCheatStructureCodes() {
+	Path tempRoot = Path("unittest_cheat_test");
+	File::DeleteDirRecursively(tempRoot);
+	EXPECT_TRUE(File::CreateDir(tempRoot));
+	Path cheatFile = tempRoot / "cheats.db";
+
+	const char *contents =
+		"_S ULUS-10000\n"
+		"_G Test Game\n"
+		"_C0 Speed\n"
+		"_M 0xCF000000 0x00000002\n"   // single select folder, next two entries are inside it
+		"_C1 Double\n"
+		"_L 0x20000000 0x00000002\n"
+		"_C1 Quadruple\n"
+		"_L 0x20000000 0x00000004\n"
+		"_C0 Read me\n"
+		"_M 0xCF000001 0x00000001\n"   // comment, and so is the entry after it
+		"_C0 Turning both speeds on is a bad idea\n"
+		"_L 0x20000000 0x00000000\n"
+		"_C1 Infinite health\n"
+		"_L 0x20000000 0x00000063\n";
+	EXPECT_TRUE(File::WriteStringToFile(false, contents, cheatFile));
+
+	CheatFileParser parser(cheatFile, "ULUS10000");
+	// The structure codes must not be reported as unsupported TempAR codes.
+	EXPECT_TRUE(parser.Parse());
+	EXPECT_EQ_INT((int)parser.GetErrors().size(), 0);
+
+	const std::vector<CheatFileInfo> &info = parser.GetFileInfo();
+	EXPECT_EQ_INT((int)info.size(), 6);
+	EXPECT_EQ_INT((int)info[0].structure, (int)CheatStructure::SingleSelectFolder);
+	EXPECT_EQ_INT(info[0].subItems, 2);
+	EXPECT_EQ_INT((int)info[1].structure, (int)CheatStructure::None);
+	EXPECT_EQ_INT((int)info[2].structure, (int)CheatStructure::None);
+	EXPECT_EQ_INT((int)info[3].structure, (int)CheatStructure::Comment);
+	EXPECT_EQ_INT(info[3].subItems, 1);
+	EXPECT_EQ_INT((int)info[5].structure, (int)CheatStructure::None);
+
+	// A folder carries no cheat lines of its own, so it can't turn into a runnable cheat.
+	for (const auto &cheat : parser.GetCheats()) {
+		EXPECT_FALSE(cheat.name == "Speed");
+		EXPECT_FALSE(cheat.name == "Read me");
+	}
+
+	File::DeleteDirRecursively(tempRoot);
+	return true;
+}
+
 bool TestEscapeMenuString() {
 	char c;
 	std::string temp = UnescapeMenuString("&File", &c);
@@ -3010,6 +3060,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(FastVec),
 	TEST_ITEM(SmallDataConvert),
 	TEST_ITEM(InputMapping),
+	TEST_ITEM(CheatStructureCodes),
 	TEST_ITEM(EscapeMenuString),
 	TEST_ITEM(VFS),
 	TEST_ITEM(Substitutions),


### PR DESCRIPTION
EDIT: Unfortunately this needs more work.


### Claude says

These _M 0xCF00000n lines carry no memory operations - they group the entries that follow them into folders, or turn them into comments. We used to reject them as unsupported TempAR codes, so files using them showed parse errors and listed the folder headings as toggleable cheats that did nothing.

Folders now render like the existing cheat titles with their contents indented, comments render as plain text, and enabling an entry in a single select folder turns off its siblings.

Fixes #21257


Claude-Session: https://claude.ai/code/session_01JvJR8oJNSCimCM9KXVLjfq