### PR TITLE
Fix savestate loads slipping past hardcore mode during boot

### DIFF
--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -196,17 +196,15 @@ int g_screenshotFailures;
 		pspFileSystem.DoState(p);
 	}
 
-	// Hardcore mode bans loading savestates outright, and saving too unless the user opted
-	// back into that.
-	bool BannedInHardcoreMode(OperationType type) {
-		if (!Achievements::HardcoreModeActive()) {
-			return false;
-		}
-		return !(g_Config.bAchievementsSaveStateInHardcoreMode && type == OperationType::Save);
-	}
-
 	void Enqueue(const SaveState::Operation &op) {
-		if (!NetworkAllowSaveState() || BannedInHardcoreMode(op.type)) {
+		if (!NetworkAllowSaveState()) {
+			return;
+		}
+		// Hardcore mode bans loading savestates outright, and saving too unless the user opted
+		// back into that. Callers that ask WarnUserIfHardcoreModeActive themselves never get
+		// this far, so there's no double message - this is for the paths that go straight to
+		// the queue, like --state and auto-load.
+		if (Achievements::WarnUserIfHardcoreModeActive(op.type == OperationType::Save)) {
 			return;
 		}
 
@@ -816,9 +814,8 @@ int g_screenshotFailures;
 			// read as active yet. An operation queued in that window (a hotkey press, --state,
 			// auto-load) passed the check in Enqueue and would otherwise be applied here, after
 			// identification has finished and hardcore mode has come up.
-			if (BannedInHardcoreMode(op.type)) {
+			if (Achievements::WarnUserIfHardcoreModeActive(op.type == OperationType::Save)) {
 				WARN_LOG(Log::SaveState, "Dropping queued savestate operation - hardcore mode is active");
-				Achievements::WarnUserIfHardcoreModeActive(op.type == OperationType::Save);
 				continue;
 			}
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -197,13 +197,14 @@ int g_screenshotFailures;
 	}
 
 	void Enqueue(const SaveState::Operation &op) {
-		if (!NetworkAllowSaveState()) {
+		// These two both refuse the operation, and both say so - dropping it silently just
+		// looks like the hotkey didn't work. Callers that ask the same questions themselves
+		// return before getting here, so nothing shows a message twice.
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return;
 		}
 		// Hardcore mode bans loading savestates outright, and saving too unless the user opted
-		// back into that. Callers that ask WarnUserIfHardcoreModeActive themselves never get
-		// this far, so there's no double message - this is for the paths that go straight to
-		// the queue, like --state and auto-load.
+		// back into that.
 		if (Achievements::WarnUserIfHardcoreModeActive(op.type == OperationType::Save)) {
 			return;
 		}
@@ -217,7 +218,7 @@ int g_screenshotFailures;
 	}
 
 	void Load(const Path &filename, int slot, Callback callback) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return;
 		}
 
@@ -228,7 +229,7 @@ int g_screenshotFailures;
 	}
 
 	void Save(const Path &filename, int slot, Callback callback) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return;
 		}
 
@@ -398,7 +399,7 @@ int g_screenshotFailures;
 	}
 
 	void LoadSlot(std::string_view gamePrefix, int slot, Callback callback) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return;
 		}
 
@@ -439,7 +440,7 @@ int g_screenshotFailures;
 	}
 
 	bool UndoLoad(std::string_view gamePrefix, Callback callback) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return false;
 		}
 
@@ -465,7 +466,7 @@ int g_screenshotFailures;
 	}
 
 	void SaveSlot(std::string_view gamePrefix, int slot, Callback callback) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return;
 		}
 
@@ -510,7 +511,7 @@ int g_screenshotFailures;
 	}
 
 	bool UndoSaveSlot(std::string_view gamePrefix, int slot) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return false;
 		}
 
@@ -543,7 +544,7 @@ int g_screenshotFailures;
 	}
 
 	bool UndoLastSave(std::string_view gamePrefix) {
-		if (!NetworkAllowSaveState()) {
+		if (NetworkWarnUserIfOnlineAndCantSavestate()) {
 			return false;
 		}
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -196,17 +196,18 @@ int g_screenshotFailures;
 		pspFileSystem.DoState(p);
 	}
 
-	void Enqueue(const SaveState::Operation &op) {
-		if (!NetworkAllowSaveState()) {
-			return;
+	// Hardcore mode bans loading savestates outright, and saving too unless the user opted
+	// back into that.
+	bool BannedInHardcoreMode(OperationType type) {
+		if (!Achievements::HardcoreModeActive()) {
+			return false;
 		}
-		if (Achievements::HardcoreModeActive()) {
-			if (g_Config.bAchievementsSaveStateInHardcoreMode && ((op.type == SaveState::OperationType::Save))) {
-				// We allow saving in hardcore mode if this setting is on.
-			} else {
-				// Operation not allowed
-				return;
-			}
+		return !(g_Config.bAchievementsSaveStateInHardcoreMode && type == OperationType::Save);
+	}
+
+	void Enqueue(const SaveState::Operation &op) {
+		if (!NetworkAllowSaveState() || BannedInHardcoreMode(op.type)) {
+			return;
 		}
 
 		std::lock_guard<std::mutex> guard(mutex);
@@ -810,6 +811,17 @@ int g_screenshotFailures;
 		SaveStart state;
 
 		for (const auto &op : operations) {
+			// Re-check here, and not just in Enqueue: during boot, RetroAchievements is still
+			// identifying the game asynchronously, and until it's done hardcore mode doesn't
+			// read as active yet. An operation queued in that window (a hotkey press, --state,
+			// auto-load) passed the check in Enqueue and would otherwise be applied here, after
+			// identification has finished and hardcore mode has come up.
+			if (BannedInHardcoreMode(op.type)) {
+				WARN_LOG(Log::SaveState, "Dropping queued savestate operation - hardcore mode is active");
+				Achievements::WarnUserIfHardcoreModeActive(op.type == OperationType::Save);
+				continue;
+			}
+
 			CChunkFileReader::Error result;
 			Status callbackResult;
 			std::string callbackMessage;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -58,6 +58,7 @@
 #include "Core/ConfigValues.h"
 #include "Core/System.h"
 #include "Core/Reporting.h"
+#include "Core/RetroAchievements.h"
 #include "Core/CoreParameter.h"
 #include "Core/HLE/sceKernel.h"  // GPI/GPO
 #include "Core/MIPS/MIPSTables.h"
@@ -187,6 +188,10 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	});
 
 	items->Add(new Choice(dev->T("Toggle Freeze")))->OnClick.Add([](UI::EventParams &e) {
+		// Freezing restores a savestate every frame, so it's not allowed in hardcore mode.
+		if (Achievements::WarnUserIfHardcoreModeActive(false)) {
+			return;
+		}
 		if (PSP_CoreParameter().frozen) {
 			PSP_CoreParameter().frozen = false;
 		} else {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1709,8 +1709,14 @@ ScreenRenderFlags EmuScreen::RunEmulation(bool skipBufferEffects) {
 			gpu->BeginHostFrame(displayLayoutConfig);
 		}
 
-		// Freeze-frame functionality (loads a savestate on every frame).
-		if (PSP_CoreParameter().freezeNext) {
+		// Freeze-frame functionality (loads a savestate on every frame). It's a savestate load
+		// like any other, so it's banned in hardcore mode - and checked here rather than only
+		// where it's toggled, since hardcore mode can come up after the fact, once the game
+		// has been identified.
+		if (Achievements::HardcoreModeActive()) {
+			PSP_CoreParameter().freezeNext = false;
+			PSP_CoreParameter().frozen = false;
+		} else if (PSP_CoreParameter().freezeNext) {
 			PSP_CoreParameter().frozen = true;
 			PSP_CoreParameter().freezeNext = false;
 			SaveState::SaveToRam(freezeState_);


### PR DESCRIPTION
## Claude says

Fixes a reported race where a savestate could be loaded during boot even with RetroAchievements hardcore mode active.

### The race

`SaveState::Enqueue()` was the only place the hardcore check happened, but operations don't run there - they're queued and applied later by `Process()`. During boot, `Achievements::HardcoreModeActive()` reads **false** even when hardcore is on, because it requires `rc_client_is_processing_required()`, which only becomes true once RetroAchievements has finished identifying the game asynchronously. Anything queued in that window passed the check, sat in the queue, and was applied by `Process()` after identification completed and hardcore came up.

Three ways in, and one of them isn't even a race:

- **Auto-load was a guaranteed bypass.** `EmuScreen::bootComplete()` calls `Achievements::SetGame()`, which starts the identify, and then checks `HardcoreModeActive()` a few lines below - always false at that point. So "Auto load savestate" quietly worked in hardcore mode, every time.
- `--state FILE` is enqueued before a game is even booted.
- A load-state hotkey or pause-menu load while the game is still identifying.

The queue is *not* drained during that window (`EmuScreen` gates `SaveState::Process()` on `!Achievements::IsBlockingExecution()`), which is exactly why the operation survived to be applied on the far side of it.

**Fix:** re-check per operation in `Process()`, immediately before the state is applied. That's the last gate before it lands, and by then identification has finished so the answer is authoritative. One check covers every entry point - hotkey, `--state`, auto-load, pause menu, WebSocket debugger, rewind - rather than patching each caller. `Core_ProcessStepping()` also calls `Process()` without the `IsBlockingExecution` gate, and is covered too.

### Freeze-frame

Freeze-frame restores a savestate every frame straight through `SaveState::LoadFromRam()`, never touching the operation queue, so neither hardcore check ever saw it. Now blocked at the dev-menu toggle (with a message), and again in the render loop, since hardcore can come up after the fact once the game is identified.

### Silent refusals

Both `Enqueue()` and the eight `NetworkAllowSaveState()` guards in `SaveState.cpp` simply returned when they refused an operation, so a load that arrived through a path with no check of its own did nothing with no explanation. They now go through `WarnUserIfHardcoreModeActive()` / `NetworkWarnUserIfOnlineAndCantSavestate()`, which are the same predicates plus the standard message.

No duplicate messages: every caller that shows one of these warnings uses it as a *gate* and returns before reaching `SaveState`, and `PauseScreen`/`ImDebugger` hide or disable the savestate UI outright instead. The only things reaching `Enqueue` in hardcore mode are the paths that had no check at all. The caller-side gates are kept deliberately, not redundantly - `ID_FILE_LOADSTATEFILE` opens a file browser before enqueueing, and you want the refusal before the dialog rather than after.

Using `WarnUserIfHardcoreModeActive()` in both places also let the local helper go: it *is* the predicate plus the message, so there's now one statement of the rule instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgACRqkQNpfJQ4fjwyoEup
