### PR TITLE
Bound replacement PNG dimensions safely

### DIFF
--- a/Common/Data/Format/PNGLoad.cpp
+++ b/Common/Data/Format/PNGLoad.cpp
@@ -148,8 +148,12 @@ bool PNGHeaderPeek::IsValidPNGHeader() const {
 	if (magic != 0x474e5089 || ihdrTag != 0x52444849) {
 		return false;
 	}
-	// Reject crazy sized images, too.
-	if (Width() > 32768 && Height() > 32768) {
+	// Keep the peeker's limit consistent with pngLoadPtr(). A replacement
+	// texture is decoded into an uncompressed RGBA buffer, so accepting one
+	// oversized dimension would still allow a decompression bomb.
+	const int width = Width();
+	const int height = Height();
+	if (width <= 0 || height <= 0 || width > 8192 || height > 8192) {
 		return false;
 	}
 	return true;

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <algorithm>
+#include <limits>
 
 #include "ppsspp_config.h"
 
@@ -721,8 +722,15 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 		png.format = PNG_FORMAT_RGBA;
 
 		std::vector<uint8_t> &out = data_[mipLevel];
-		// TODO: Should probably try to handle out-of-memory gracefully here.
-		out.resize(level.w * level.h * 4);
+		const size_t width = (size_t)level.w;
+		const size_t height = (size_t)level.h;
+		if (level.w <= 0 || level.h <= 0 ||
+			width > std::numeric_limits<size_t>::max() / height ||
+			width * height > std::numeric_limits<size_t>::max() / 4) {
+			ERROR_LOG(Log::TexReplacement, "PNG replacement dimensions are too large: %s (%dx%d)", filename.c_str(), level.w, level.h);
+			return LoadLevelResult::LOAD_ERROR;
+		}
+		out.resize(width * height * 4);
 		if (!png_image_finish_read(&png, nullptr, &out[0], level.w * 4, nullptr)) {
 			ERROR_LOG(Log::TexReplacement, "Could not load texture replacement: %s - %s", filename.c_str(), png.message);
 			out.resize(0);

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -16,7 +16,6 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <algorithm>
-#include <limits>
 
 #include "ppsspp_config.h"
 
@@ -722,15 +721,7 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 		png.format = PNG_FORMAT_RGBA;
 
 		std::vector<uint8_t> &out = data_[mipLevel];
-		const size_t width = (size_t)level.w;
-		const size_t height = (size_t)level.h;
-		if (level.w <= 0 || level.h <= 0 ||
-			width > std::numeric_limits<size_t>::max() / height ||
-			width * height > std::numeric_limits<size_t>::max() / 4) {
-			ERROR_LOG(Log::TexReplacement, "PNG replacement dimensions are too large: %s (%dx%d)", filename.c_str(), level.w, level.h);
-			return LoadLevelResult::LOAD_ERROR;
-		}
-		out.resize(width * height * 4);
+		out.resize(level.w * level.h * 4);
 		if (!png_image_finish_read(&png, nullptr, &out[0], level.w * 4, nullptr)) {
 			ERROR_LOG(Log::TexReplacement, "Could not load texture replacement: %s - %s", filename.c_str(), png.message);
 			out.resize(0);


### PR DESCRIPTION
Replacement texture loading checks PNG header dimensions with an AND, so a file with only one oversized dimension can pass the initial check. `ReplacedTexture::Load` then computes `level.w * level.h * 4` before resizing the pixel buffer. Crafted replacement PNG metadata can therefore bypass the header check and produce an invalid or enormous allocation size.

Apply the existing 8192-per-dimension limit with OR semantics, reject non-positive dimensions, and check the `size_t` multiplication before `out.resize`. This prevents malformed PNG dimensions from overflowing the replacement-texture allocation.