### PR TITLE
Validate infra DNS JSON responses

### DIFF
--- a/Common/Data/Format/JSONReader.h
+++ b/Common/Data/Format/JSONReader.h
@@ -19,7 +19,8 @@ struct JsonGet {
 		return get(child_name, JSON_ARRAY);
 	}
 	const JsonGet getDict(const char *child_name) const {
-		return JsonGet(get(child_name, JSON_OBJECT)->value);
+		const JsonNode *node = get(child_name, JSON_OBJECT);
+		return node ? JsonGet(node->value) : JsonGet(JSON_NULL);
 	}
 	const char *getStringOrNull(const char *child_name) const;
 	const char *getStringOr(const char *child_name, const char *default_value) const;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -218,6 +218,10 @@ bool LoadDNSForGameID(std::string_view gameID, std::string_view jsonStr, InfraDN
 
 	const JsonGet root = reader.root();
 	const JsonGet def = root.getDict("default");
+	if (!def) {
+		ERROR_LOG(Log::sceNet, "Infra DNS JSON is missing a default object");
+		return false;
+	}
 
 	// Load the default DNS.
 	if (def) {
@@ -233,6 +237,10 @@ bool LoadDNSForGameID(std::string_view gameID, std::string_view jsonStr, InfraDN
 	}
 
 	const JsonNode *games = root.getArray("games");
+	if (!games) {
+		ERROR_LOG(Log::sceNet, "Infra DNS JSON is missing a games array");
+		return false;
+	}
 	for (const JsonNode *iter : games->value) {
 		JsonGet game = iter->value;
 		// Goddamn I have to change the json reader we're using. So ugly.
@@ -374,7 +382,7 @@ bool LoadAutoDNS(std::string_view json) {
 
 std::shared_ptr<http::Request> g_infraDL;
 
-static const std::string_view jsonUrl = "http://metadata.ppsspp.org/infra-dns.json";
+static const std::string_view jsonUrl = "https://metadata.ppsspp.org/infra-dns.json";
 
 void DeleteAutoDNSCacheFile() {
 	File::Delete(g_DownloadManager.UrlToCachePath(jsonUrl));

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -31,6 +31,7 @@
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Serialize/SerializeMap.h"
 #include "Common/Data/Format/JSONReader.h"
+#include "Common/System/System.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/ErrorCodes.h"
 #include "Core/HLE/FunctionWrappers.h"
@@ -382,10 +383,15 @@ bool LoadAutoDNS(std::string_view json) {
 
 std::shared_ptr<http::Request> g_infraDL;
 
-static const std::string_view jsonUrl = "https://metadata.ppsspp.org/infra-dns.json";
+static constexpr std::string_view jsonUrlHttp = "http://metadata.ppsspp.org/infra-dns.json";
+static constexpr std::string_view jsonUrlHttps = "https://metadata.ppsspp.org/infra-dns.json";
+
+static std::string_view GetInfraDNSUrl() {
+	return System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS) ? jsonUrlHttps : jsonUrlHttp;
+}
 
 void DeleteAutoDNSCacheFile() {
-	File::Delete(g_DownloadManager.UrlToCachePath(jsonUrl));
+	File::Delete(g_DownloadManager.UrlToCachePath(GetInfraDNSUrl()));
 }
 
 void StartInfraJsonDownload() {
@@ -399,7 +405,7 @@ void StartInfraJsonDownload() {
 
 	if (!g_Config.bDontDownloadInfraJson) {
 		const char * const acceptMime = "application/json, text/*; q=0.9, */*; q=0.8";
-		g_infraDL = g_DownloadManager.StartDownload(jsonUrl, Path(), http::RequestFlags::Cached24H, acceptMime);
+		g_infraDL = g_DownloadManager.StartDownload(GetInfraDNSUrl(), Path(), http::RequestFlags::Cached24H, acceptMime);
 	}
 }
 
@@ -444,7 +450,7 @@ bool PollInfraJsonDownload(std::string *jsonOutput) {
 		// First, fall back to cache if it exists. Could build this functionality into the download manager
 		// but it would be a bit awkward.
 		std::string json;
-		if (File::ReadBinaryFileToString(g_DownloadManager.UrlToCachePath(jsonUrl), &json) && !json.empty()) {
+		if (File::ReadBinaryFileToString(g_DownloadManager.UrlToCachePath(GetInfraDNSUrl()), &json) && !json.empty()) {
 			WARN_LOG(Log::sceNet, "Failed to download infra-dns.json, falling back to cached file");
 			*jsonOutput = json;
 			LoadAutoDNS(*jsonOutput);


### PR DESCRIPTION
`LoadDNSForGameID()` parses `infra-dns.json` through `JsonGet`. `JsonGet::getDict()` dereferences the result of `get()` even when the `default` object is missing or has the wrong type, and `LoadDNSForGameID()` similarly iterates `root.getArray("games")` without checking for null. A malformed or truncated response can therefore crash the emulator while auto-DNS data is loaded. The download URL is also HTTP, allowing an on-path attacker to replace the response and redirect DNS configuration.

Make `getDict()` null-safe, validate the required `default` object and `games` array before use, and fetch the metadata over HTTPS.