### PR TITLE
Add mpeg small delay compat by Gemini

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -123,6 +123,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ShaderColorBitmask", &flags_.ShaderColorBitmask);
 	CheckSetting(iniFile, gameID, "DisableFirstFrameReadback", &flags_.DisableFirstFrameReadback);
 	CheckSetting(iniFile, gameID, "MpegAvcWarmUp", &flags_.MpegAvcWarmUp);
+	CheckSetting(iniFile, gameID, "MpegSmallDelay", &flags_.MpegSmallDelay);
 	CheckSetting(iniFile, gameID, "BlueToAlpha", &flags_.BlueToAlpha);
 	CheckSetting(iniFile, gameID, "CenteredLines", &flags_.CenteredLines);
 	CheckSetting(iniFile, gameID, "ZZT3SelectHack", &flags_.ZZT3SelectHack);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -78,6 +78,7 @@ struct CompatFlags {
 	bool ShaderColorBitmask;
 	bool DisableFirstFrameReadback;
 	bool MpegAvcWarmUp;
+	bool MpegSmallDelay;
 	bool BlueToAlpha;
 	bool CenteredLines;
 	bool ZZT3SelectHack;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -79,10 +79,10 @@ static const u32 MPEG_MEMSIZE_0105 = 0x10000;     // 64k.
 static const int MPEG_AVC_DECODE_SUCCESS = 1;     // Internal value.
 static const int MPEG_WARMUP_FRAMES = 1;
 
-static const int atracDecodeDelayMs = 3000;
+static int atracDecodeDelayMs = 3000;
 static const int avcFirstDelayMs = 3600;
-static const int avcCscDelayMs = 4000;
-static const int avcDecodeDelayMs = 5400;         // Varies between 4700 and 6000.
+static int avcCscDelayMs = 4000;
+static int avcDecodeDelayMs = 5400;         // Varies between 4700 and 6000.
 static const int avcEmptyDelayMs = 320;
 static const int mpegDecodeErrorDelayMs = 100;
 static const int mpegTimestampPerSecond = 90000;  // How many MPEG Timestamp units in a second.
@@ -422,6 +422,11 @@ static u32 sceMpegInit() {
 		//return SCE_MPEG_ERROR_ALREADY_INIT;
 	} else {
 		INFO_LOG(Log::Mpeg, "sceMpegInit(), mpegLibVersion 0x%0x, mpegLibcrc %x", mpegLibVersion, mpegLibCrc);
+	}
+	if (PSP_CoreParameter().compat.flags().MpegSmallDelay) {
+		atracDecodeDelayMs = 100;		
+		avcCscDelayMs = 100;
+		avcDecodeDelayMs = 100;
 	}
 	isMpegInit = true;
 	return hleDelayResult(hleNoLog(0), "mpeg init", 750);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2204,3 +2204,7 @@ UCJS10100 = true
 UCKS45127 = true
 UCJS18055 = true
 NPJG00027 = true
+
+[MpegSmallDelay]
+Tenshin Ranman Happy Go Lucky need small mpeg delay to avoid video flickering #issue 7367
+ULJM05634 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -2206,5 +2206,16 @@ UCJS18055 = true
 NPJG00027 = true
 
 [MpegSmallDelay]
-Tenshin Ranman Happy Go Lucky need small mpeg delay to avoid video flickering #issue 7367
+#Squirrel engine'S PSP games need small mpeg delay to avoid video flickering
+#Tenshin Ranman Happy Go Lucky #issue 7367
+ULJM05633 = true
 ULJM05634 = true
+NPJH50297 = true
+
+#GA: Geijutsuka Art Design Class: Slapstick Wonderland
+ULJM05671 = true
+ULJM05672 = true
+
+#Fight Ippatsu! Juden-Chan!! CC
+ULJM05667 = true
+ULJM05668 = true


### PR DESCRIPTION
fix #7637
Avoid Squirrel-based video decoder like Tenshin Ranman Happy Go Lucky  video flickering.

Here is the breakdown of why the standard emulator delays cause the game to break, and why the 100 microsecond delay fixes it:

1. How PPSSPP Normally Emulates Video On a real PSP, video decoding isn't handled by the main CPU. It is offloaded to a dedicated hardware chip called the Media Engine (ME). When a game wants to play a video, it asks the ME to decode a frame. The ME takes physical time to do this—typically around 5400 microseconds (us) for a standard-resolution frame. To mimic this physical hardware, PPSSPP intentionally puts the game's decoding thread to "sleep" for 5400us using hleDelayResult. For 99% of PSP games, this works perfectly. The games wait patiently, receive the decoded frame, and draw it to the screen.

2. The Squirrel Engine's Impatience Tenshin Ranman runs on a visual novel framework called the Squirrel Engine. This engine has notoriously strict and poorly optimized internal frame-pacing. Instead of asking the Media Engine for a full frame and waiting patiently, the Squirrel engine decodes the video in tiny slices and constantly polls the hardware, asking, "Is it done yet? Is it done yet?" Worse, it sets a very strict, hardcoded internal timer for how long this process should take. It expects the ME hardware to return the decoded slices almost instantaneously.

3. The Desync (Why it Flickers) If PPSSPP applies the realistic, standard delay of 5400us, the Squirrel engine's strict timer runs out. Because the engine is impatient, it assumes the Media Engine failed or is lagging. Instead of waiting for the rest of the video slice to finish decoding, the game engine panics. It skips the rest of the frame, assumes the video buffer is empty, and forces the graphics pipeline to swap to the next display buffer anyway. This is why you saw the violent flickering and black screens: the game was continually drawing half-finished frames to the screen and throwing the rest of the data in the garbage.

4. Why the 100 Delay Fixes It By overriding the sceMpeg delays down to 100, you are essentially giving the game a "fast-pass." You are lying to the Squirrel engine, telling it that the virtual Media Engine decoded the video almost instantly. Because the engine gets its data back exponentially faster than normal, its strict internal timers are satisfied. It doesn't panic, it doesn't drop the buffer, and it allows the graphics pipeline to draw the entire frame perfectly in sync.

In short: you are dealing with a bug inside the game's original engine. On real PSP silicon, the hardware responded just fast enough to avoid triggering the engine's strict timeout. In an emulator, the only way to satisfy that poorly written logic is to artificially feed the data back to it as fast as possible!