### PR TITLE
cleanup cmake aemu_postoffice building, allow connecting to 127.0.0.1 adhoc server outside of PPSSPP process

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -1,23 +1,4 @@
 set(CoreExtra)
-set(aemu_postoffice
-	${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/postoffice.c
-	${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/postoffice_mem_stdc.c
-	${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/mutex_impl_cpp.cpp
-	${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/delay_impl_cpp.cpp
-	${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/log_impl_ppsspp.cpp
-)
-
-if(WIN32)
-	list(APPEND aemu_postoffice
-		${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/sock_impl_windows.c
-	)
-endif()
-
-if(LINUX OR ANDROID OR MACOSX OR IOS OR BSD)
-	list(APPEND aemu_postoffice
-		${CMAKE_SOURCE_DIR}/ext/aemu_postoffice/client/sock_impl_linux.c
-	)
-endif()
 
 list(APPEND CoreExtra
 	MIPS/IR/IRAnalysis.cpp
@@ -523,7 +504,6 @@ add_library(Core STATIC
 	HLE/NetAdhocCommon.h
 	HLE/sceNetAdhoc.cpp
 	HLE/sceNetAdhoc.h
-	${aemu_postoffice}
 	HLE/sceNetAdhocMatching.cpp
 	HLE/sceNetAdhocMatching.h
 	HLE/sceNetInet.cpp
@@ -746,7 +726,7 @@ endif()
 list(APPEND CoreExtraLibs armips)
 
 target_link_libraries(Core GPU Common chdr kirk cityhash sfmt19937 xbrz xxhash rcheevos minimp3 at3_standalone lua
-	${CoreExtraLibs} ${CMAKE_DL_LIBS})
+	aemu_postoffice_client ${CoreExtraLibs} ${CMAKE_DL_LIBS})
 
 # Winsock
 if(WIN32)

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -2237,10 +2237,6 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 	if (g_adhocServerIP.in.sin_addr.s_addr == INADDR_NONE)
 		return SOCKET_ERROR;
 
-	// Don't need to connect if AdhocServer IP is the same with this instance localhost IP and having AdhocServer disabled
-	if (g_adhocServerIP.in.sin_addr.s_addr == g_localhostIP.in.sin_addr.s_addr && !g_Config.bEnableAdhocServer)
-		return SOCKET_ERROR;
-
 	// Connect to Adhoc Server
 	int errorcode = 0;
 	int cnt = 0;

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -51,6 +51,30 @@ add_library(xxhash STATIC
 	xxhash.h
 )
 
+set(aemu_postoffice_client_obj
+	aemu_postoffice/client/postoffice.c
+	aemu_postoffice/client/postoffice_mem_stdc.c
+	aemu_postoffice/client/mutex_impl_cpp.cpp
+	aemu_postoffice/client/delay_impl_cpp.cpp
+	aemu_postoffice/client/log_impl_ppsspp.cpp
+)
+
+if(WIN32)
+	list(APPEND aemu_postoffice_client_obj
+		aemu_postoffice/client/sock_impl_windows.c
+	)
+endif()
+
+if(LINUX OR ANDROID OR MACOSX OR IOS OR BSD)
+	list(APPEND aemu_postoffice_client_obj
+		aemu_postoffice/client/sock_impl_linux.c
+	)
+endif()
+
+add_library(aemu_postoffice_client STATIC
+	${aemu_postoffice_client_obj}
+)
+
 set(FT_REQUIRE_ZLIB OFF CACHE BOOL "" FORCE)
 set(FT_REQUIRE_BZIP2 OFF CACHE BOOL "" FORCE)
 set(FT_REQUIRE_PNG OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
- cleanup cmake aemu_postoffice building, I made a mess during the initial integration
- allow connecting to 127.0.0.1 adhoc server outside of PPSSPP process, some server hosts are confused as to why they cannot connect to their own server