### PR TITLE
sceKernelThread: actually accumulate runForClocks

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -477,6 +477,9 @@ static int g_inCbCount = 0;
 static SceUID currentCallbackThreadID = 0;
 static int readyCallbacksCount = 0;
 static SceUID currentThread;
+// When the running thread last changed, so each thread can be billed for the time it actually ran
+// (nt.runForClocks). Not serialized - it's re-based on load, which only skews the very first slice.
+static u64 lastContextSwitchUs = 0;
 static PSPThread *currentThreadPtr;
 static u32 idleThreadHackAddr;
 static u32 threadReturnHackAddr;
@@ -774,6 +777,7 @@ void __KernelThreadingInit() {
 	currentCallbackThreadID = 0;
 	readyCallbacksCount = 0;
 	lastSwitchCycles = 0;
+	lastContextSwitchUs = 0;
 	idleThreadHackAddr = kernelMemory.Alloc(blockSize, false, "threadrethack");
 
 	Memory::Memcpy(idleThreadHackAddr, idleThreadCode, sizeof(idleThreadCode), "ThreadMIPS");
@@ -856,6 +860,15 @@ void __KernelThreadingDoState(PointerWrap &p)
 		Do(p, threadEventHandlers);
 	if (s >= 3)
 		Do(p, pendingDeleteThreads);
+
+	if (p.mode == p.MODE_READ) {
+		// Re-base rather than serialize, so a state saved before this existed doesn't bill one
+		// thread for the entire emulated time up to the save. Only on load: saving runs a measure
+		// pass and then a write pass, and re-basing in either would throw away the time the
+		// running thread had accumulated since the last switch - a save must not change what the
+		// game can observe.
+		lastContextSwitchUs = CoreTiming::GetGlobalTimeUs();
+	}
 }
 
 void __KernelThreadingDoStateLate(PointerWrap &p) {
@@ -2906,7 +2919,22 @@ void __KernelSwitchContext(PSPThread *target, const char *reason) {
 	SceUID oldUID = 0;
 	const char *oldName = hleCurrentThreadName != NULL ? hleCurrentThreadName : "(none)";
 
+	// Everything since the previous switch was spent running the outgoing thread, so bill it to
+	// that thread's runForClocks before we change over. This is the only field that tells a game
+	// how much time a thread has actually had, and it used to always read back as zero: Crazy
+	// Taxi: Fare Wars samples its mp3 thread's run time once a second through
+	// sceKernelReferThreadStatus, and when it never advanced the game decided playback was wedged
+	// and restarted the track, roughly once a second, forever.
+	const u64 nowUs = CoreTiming::GetGlobalTimeUs();
 	PSPThread *cur = __GetCurrentThread();
+	if (cur && nowUs > lastContextSwitchUs) {
+		const u64 ranForUs = nowUs - lastContextSwitchUs;
+		const u64 total = ((u64)cur->nt.runForClocks.hi << 32 | cur->nt.runForClocks.lo) + ranForUs;
+		cur->nt.runForClocks.lo = (u32)total;
+		cur->nt.runForClocks.hi = (u32)(total >> 32);
+	}
+	lastContextSwitchUs = nowUs;
+
 	if (cur)  // It might just have been deleted.
 	{
 		__KernelSaveContext(&cur->context, (cur->nt.attr & PSP_THREAD_ATTR_VFPU) != 0);


### PR DESCRIPTION
Together with #22248  , fixes custom music in Crazy Taxi (#15509 )

## Claude says

nt.runForClocks was zeroed when a thread was created and copied out by sceKernelReferThreadStatus, but nothing ever added to it, so every thread reported having run for zero time forever.

Crazy Taxi: Fare Wars uses it as a liveness check. Its music state machine samples the mp3 thread's run time once every 60 frames and compares it with the previous two samples; when it doesn't move it concludes playback is wedged, sets the stop bit, and the thread tears itself down and exits. The game restarts it, and about a second later decides it's wedged again - custom soundtracks restarted roughly once a second forever, whatever the file.

Bill the time since the previous switch to the outgoing thread, which is exactly the thread that was running for it. The field is already part of the serialized thread struct, so savestates don't change format; the timestamp itself is re-based on load rather than saved, and only on load - saving runs a measure pass and a write pass, and re-basing in those would discard the time the running thread had accumulated since the last switch, letting a save change what the game can observe.

Risk: this runs on every context switch, the hottest path in the scheduler. It adds one CoreTiming read and a 64-bit add. Games that poll thread run times will now see them move, which is correct but is new behavior.