### PR TITLE
sceVaudioChReserve: accept the MP3 frame sizes

### DIFF
--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -42,15 +42,18 @@ void __VaudioDoState(PointerWrap &p) {
 }
 
 static u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
-	// The vaudio channel is pickier than the normal ones: only three sample counts, stereo only,
-	// and the same set of sample rates the SRC channel takes.
+	// The vaudio channel is pickier than the normal ones: a fixed set of sample counts, stereo
+	// only, and the same set of sample rates the SRC channel takes. It tests
+	// 256/576/1024/1152 and then 2048, returning 0x80000104, before it looks at the format at all.
+	// 576 and 1152 are the MPEG-2/2.5 and MPEG-1 Layer III frame sizes, so leaving them out broke
+	// games that feed MP3 frames straight to the vaudio channel.
+	if (sampleCount != 256 && sampleCount != 576 && sampleCount != 1024 && sampleCount != 1152 && sampleCount != 2048) {
+		ERROR_LOG(Log::sceAudio, "sceVaudioChReserve(%i, %i, %i) - invalid sample count", sampleCount, freq, format);
+		return SCE_KERNEL_ERROR_INVALID_SIZE;
+	}
 	if (format != 2) {
 		ERROR_LOG(Log::sceAudio, "sceVaudioChReserve(%i, %i, %i) - unexpected format", sampleCount, freq, format);
 		return SCE_KERNEL_ERROR_INVALID_FORMAT;
-	}
-	if (sampleCount != 256 && sampleCount != 1024 && sampleCount != 2048) {
-		ERROR_LOG(Log::sceAudio, "sceVaudioChReserve(%i, %i, %i) - invalid sample count", sampleCount, freq, format);
-		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	}
 	if (freq != 0 && !SRCFrequencyAllowed(freq)) {
 		ERROR_LOG(Log::sceAudio, "sceVaudioChReserve(%i, %i, %i) - invalid frequency", sampleCount, freq, format);


### PR DESCRIPTION
Likely fixes Dead or Alive mp3 music.

## Claude says

The channel took only 256, 1024 and 2048 samples, so a game that hands it MP3 frames got SCE_KERNEL_ERROR_INVALID_SIZE and no music.

sceVaudioChReserve actually tests the sample count against 256 and 576, then 1024 and 1152, then 2048, and only then rejects it:

576 and 1152 are the MPEG-2/2.5 and MPEG-1 Layer III frame sizes, which is presumably why they're in the list at all.

The format check moves below the sample count check to match: the module returns 0x80000104 for a bad count before it ever looks at the format, so a call with both wrong got the wrong error out of us. The two error codes we already returned are the ones it uses.