### PR TITLE
Run sceFont, sceDeflt, and a bunch more libraries directly without HLE 

### DIFF
--- a/Core/CmdLine.cpp
+++ b/Core/CmdLine.cpp
@@ -212,6 +212,7 @@ static const CommandLineParam g_autoParams[] = {
 	{POFF(unpackUpdater), CmdParamType::String, "unpack-updater", '\0', "Unpack the firmware in an updater EBOOT.PBP into DIR and exit", CmdLineMode::Headless},
 	{POFF(unpackUpdaterModel), CmdParamType::String, "unpack-updater-model", '\0', "PSP model to unpack for (01g..12g, default any)", CmdLineMode::Headless},
 	{POFF(unpackUpdaterFilter), CmdParamType::String, "unpack-updater-filter", '\0', "Only unpack entries under this path, e.g. flash0:/font/", CmdLineMode::Headless},
+	{POFF(firmwareFromDisc), CmdParamType::Bool, "firmware-from-disc", '\0', "Install the firmware bundled on the booted disc and use it for this run", CmdLineMode::Headless},
 	{POFF(installPkg), CmdParamType::String, "install-pkg", '\0', "Install the game update in a .pkg into DIR and exit", CmdLineMode::Headless},
 	{POFF(reModule), CmdParamType::String, "re-module", '\0', "Load one PRX standalone and write a reverse-engineering report, then exit", CmdLineMode::Headless},
 	{POFF(reOut), CmdParamType::String, "re-out", '\0', "Directory for --re-module output (default: re-out)", CmdLineMode::Headless},

--- a/Core/CmdLine.h
+++ b/Core/CmdLine.h
@@ -88,6 +88,10 @@ struct CommandLineOptions {
 	// (the default) to take whatever file list names each file first.
 	std::optional<std::string> unpackUpdaterModel;
 	std::optional<std::string> unpackUpdaterFilter;
+	// Headless: install the firmware bundled on the disc being booted into a scratch NAND, and
+	// boot against that. Lets a run exercise the paths that need real firmware modules without
+	// having to install one first.
+	std::optional<bool> firmwareFromDisc;
 
 	// Bitmask of DisableHLEFlags: run the real firmware module instead of our HLE for those
 	// libraries. Needs a firmware dump under the NAND directory.

--- a/Core/CmdLine.h
+++ b/Core/CmdLine.h
@@ -89,8 +89,7 @@ struct CommandLineOptions {
 	std::optional<std::string> unpackUpdaterModel;
 	std::optional<std::string> unpackUpdaterFilter;
 	// Headless: install the firmware bundled on the disc being booted into a scratch NAND, and
-	// boot against that. Lets a run exercise the paths that need real firmware modules without
-	// having to install one first.
+	// boot against that.
 	std::optional<bool> firmwareFromDisc;
 
 	// Bitmask of DisableHLEFlags: run the real firmware module instead of our HLE for those

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -154,7 +154,7 @@ enum class RestoreSettingsBits : int {
 };
 ENUM_CLASS_BITOPS(RestoreSettingsBits);
 
-// Modules that are candidates for disabling HLE of.
+// Modules that are candidates for disabling HLE of, and just running the modules directly.
 enum class DisableHLEFlags : int {
 	sceFont = (1 << 0),
 	sceAtrac = (1 << 1),
@@ -167,8 +167,7 @@ enum class DisableHLEFlags : int {
 	// Swaps in flash0:/kd/libmp4.prx and mp4msv.prx, which then decode through our sceAudiocodec.
 	sceMp4 = (1 << 8),
 	// Small leaf libraries games carry on the disc themselves - see AlwaysDisableHLEFlags. None of
-	// them is in any firmware dump, so the game's own copy is the only one there is, and none
-	// imports anything we don't already have.
+	// them is provided in any firmware version.
 	sceDeflt = (1 << 9),
 	sceAdler = (1 << 10),
 	sceMd5 = (1 << 11),

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -166,7 +166,18 @@ enum class DisableHLEFlags : int {
 	sceCcc = (1 << 7),  // character conversion library.
 	// Swaps in flash0:/kd/libmp4.prx and mp4msv.prx, which then decode through our sceAudiocodec.
 	sceMp4 = (1 << 8),
-	Count = 9,
+	// Small leaf libraries games carry on the disc themselves - see AlwaysDisableHLEFlags. None of
+	// them is in any firmware dump, so the game's own copy is the only one there is, and none
+	// imports anything we don't already have.
+	sceDeflt = (1 << 9),
+	sceAdler = (1 << 10),
+	sceMd5 = (1 << 11),
+	sceSha256 = (1 << 12),
+	sceMt19937 = (1 << 13),
+	sceSfmt19937 = (1 << 14),
+	sceHeap = (1 << 15),
+	sceParseUri = (1 << 16),
+	Count = 17,
 	// TODO: Some of the networking libraries may be interesting candidates, like HTTP.
 };
 ENUM_CLASS_BITOPS(DisableHLEFlags);

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -43,6 +43,8 @@
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceKernelModule.h"
+#include "Core/HLE/sceFont.h"
+#include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/HLE/HLE.h"
 
 enum {
@@ -141,8 +143,6 @@ static const HLEModuleMeta g_moduleMeta[] = {
 	{"sceNetAdhocctl_Library"},
 	{"sceNetIfhandle_Service"},
 	{"sceSsl_Module"},
-	{"sceDEFLATE_Library"},
-	{"sceMD5_Library"},
 	{"sceMemab"},  // Underlying AdHoc crypto library
 	{"sceAvcodec_driver"},
 	{"sceAudiocodec_Driver"},
@@ -160,7 +160,17 @@ static const HLEModuleMeta g_moduleMeta[] = {
 	{"sceMp4_library", "sceMp4", DisableHLEFlags::sceMp4},
 	{"mp4msv_module", "mp4msv", DisableHLEFlags::sceMp4},
 	{"SceParseHTTPheader_Library", "sceParseHttp", DisableHLEFlags::sceParseHttp},
-	{"SceParseURI_Library"},
+	{"SceParseURI_Library", "sceParseUri", DisableHLEFlags::sceParseUri},
+	// Leaf libraries games carry on the disc. Module names and export library names read off the
+	// copies on real discs with --re-module disc0:/...; all but sceHeap import nothing at all, and
+	// sceHeap only Kernel_Library and ThreadManForUser.
+	{"sceDEFLATE_Library", "sceDeflt", DisableHLEFlags::sceDeflt},
+	{"sceADLER32_Library", "sceAdler", DisableHLEFlags::sceAdler},
+	{"sceMD5_Library", "sceMd5", DisableHLEFlags::sceMd5},
+	{"sceSHA256_Library", "sceSha256", DisableHLEFlags::sceSha256},
+	{"sceMT19937_Library", "sceMt19937", DisableHLEFlags::sceMt19937},
+	{"sceSfmt19937_Library", "sceSfmt19937", DisableHLEFlags::sceSfmt19937},
+	{"sceHeap_Library", "sceHeap", DisableHLEFlags::sceHeap},
 	// Guessing these names
 	{"sceJpeg", "sceJpeg"},
 	{"sceJpeg_library", "sceJpeg"},
@@ -200,7 +210,25 @@ DisableHLEFlags AlwaysDisableHLEFlags() {
 	//
 	// PSMF testing issue: #20200
 	// sceCcc is simply a character conversion library, zero deps. If available we just load it.
-	return DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer | DisableHLEFlags::sceCcc;
+	// sceDeflt is zip format decompression.
+	// sceSmft19937 and sceMt19937 are random number generation.
+	// sceAdler, sceSha256, sceMd5 are hashes.
+	// sceHeap is a memory allocator wrapper.
+	//
+	// All these are found in game discs, and are basically dependency-less libraries that we
+	// can just run as-is, no need for HLE. Games always ship these if they use them.
+	//
+	// sceFont is the odd one out: the module is on the disc like the others, but it reads its fonts
+	// from flash0:/font, so it is only usable with a firmware dump installed - see
+	// CheckDisableHLEAvailability, which puts the HLE back when those fonts aren't there.
+	//
+	// sceParseUri and sceParseHttp are not here - those two are also in the firmware, and
+	// sceUtility can load them (modules 0x103 and 0x104), so unlike the rest a game may import them
+	// without carrying a copy.
+	return DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer | DisableHLEFlags::sceCcc |
+		DisableHLEFlags::sceDeflt | DisableHLEFlags::sceAdler | DisableHLEFlags::sceMd5 |
+		DisableHLEFlags::sceSha256 | DisableHLEFlags::sceMt19937 | DisableHLEFlags::sceSfmt19937 |
+		DisableHLEFlags::sceHeap | DisableHLEFlags::sceFont;
 }
 
 // Which modules we're HLE-ing is part of the machine's state, not a live setting: it's decided
@@ -314,9 +342,22 @@ static void hleDelayResultFinish(u64 userdata, int cycleslate) {
 static void CheckDisableHLEAvailability() {
 	g_unavailableDisableFlags = (DisableHLEFlags)0;
 
+	// The real libfont.prx a disc ships reads its fonts from flash0:/font and has nothing to fall
+	// back on, so without them it would render nothing at all. Our HLE does have a fallback - the
+	// fonts in assets - so keep it when the NAND set isn't there. Same question the HLE font loader
+	// asks itself, so the same answer: "the fonts this game's firmware would have had", not every
+	// font we know of, since an older game's firmware never had the later ones.
+	if (AlwaysDisableHLEFlags() & DisableHLEFlags::sceFont) {
+		if (!NandFontsComplete()) {
+			g_unavailableDisableFlags |= DisableHLEFlags::sceFont;
+			INFO_LOG(Log::HLE, "flash0:/font doesn't have this firmware's fonts - using the HLE sceFont rather than the disc's.");
+		}
+	}
+
 	if ((DisableHLEFlags)g_Config.iDisableHLE & DisableHLEFlags::sceMp4) {
 		const Path kd = g_Config.nandRootDirectory / "flash0" / "kd";
-		if (!File::Exists(kd / "libmp4.prx") || !File::Exists(kd / "mp4msv.prx")) {
+		if (!pspFileSystem.GetFileInfo("flash0:/kd/libmp4.prx").exists ||
+			!pspFileSystem.GetFileInfo("flash0:/kd/mp4msv.prx").exists) {
 			g_unavailableDisableFlags |= DisableHLEFlags::sceMp4;
 			ERROR_LOG(Log::HLE, "Asked to run the real sceMp4, but %s doesn't have libmp4.prx and "
 				"mp4msv.prx - keeping the HLE.", kd.c_str());

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -161,15 +161,14 @@ static const HLEModuleMeta g_moduleMeta[] = {
 	{"mp4msv_module", "mp4msv", DisableHLEFlags::sceMp4},
 	{"SceParseHTTPheader_Library", "sceParseHttp", DisableHLEFlags::sceParseHttp},
 	{"SceParseURI_Library", "sceParseUri", DisableHLEFlags::sceParseUri},
-	// Leaf libraries games carry on the disc. Module names and export library names read off the
-	// copies on real discs with --re-module disc0:/...; all but sceHeap import nothing at all, and
-	// sceHeap only Kernel_Library and ThreadManForUser.
+	// Dependency-free libraries games carry on the disc (never loaded from firmware).
 	{"sceDEFLATE_Library", "sceDeflt", DisableHLEFlags::sceDeflt},
 	{"sceADLER32_Library", "sceAdler", DisableHLEFlags::sceAdler},
 	{"sceMD5_Library", "sceMd5", DisableHLEFlags::sceMd5},
 	{"sceSHA256_Library", "sceSha256", DisableHLEFlags::sceSha256},
 	{"sceMT19937_Library", "sceMt19937", DisableHLEFlags::sceMt19937},
 	{"sceSfmt19937_Library", "sceSfmt19937", DisableHLEFlags::sceSfmt19937},
+	// sceHeap imports only Kernel_Library and ThreadManForUser.
 	{"sceHeap_Library", "sceHeap", DisableHLEFlags::sceHeap},
 	// Guessing these names
 	{"sceJpeg", "sceJpeg"},
@@ -342,11 +341,8 @@ static void hleDelayResultFinish(u64 userdata, int cycleslate) {
 static void CheckDisableHLEAvailability() {
 	g_unavailableDisableFlags = (DisableHLEFlags)0;
 
-	// The real libfont.prx a disc ships reads its fonts from flash0:/font and has nothing to fall
-	// back on, so without them it would render nothing at all. Our HLE does have a fallback - the
-	// fonts in assets - so keep it when the NAND set isn't there. Same question the HLE font loader
-	// asks itself, so the same answer: "the fonts this game's firmware would have had", not every
-	// font we know of, since an older game's firmware never had the later ones.
+	// libfont.prx/sceFont is shipped on game discs but reads its fonts from flash0:/font and has
+	// nothing to fall back on, so the fonts are required.
 	if (AlwaysDisableHLEFlags() & DisableHLEFlags::sceFont) {
 		if (!NandFontsComplete()) {
 			g_unavailableDisableFlags |= DisableHLEFlags::sceFont;
@@ -444,7 +440,6 @@ const HLEModule *GetHLEModuleByIndex(int index) {
 	return &moduleDB[index];
 }
 
-// TODO: Do something faster.
 const HLEModule *GetHLEModuleByName(std::string_view name) {
 	for (auto &module : moduleDB) {
 		if (name == module.name) {
@@ -454,7 +449,6 @@ const HLEModule *GetHLEModuleByName(std::string_view name) {
 	return nullptr;
 }
 
-// TODO: Do something faster.
 const HLEFunction *GetHLEFuncByName(const HLEModule *module, std::string_view name) {
 	for (int i = 0; i < module->numFunctions; i++) {
 		auto &func = module->funcTable[i];

--- a/Core/HLE/sceAdler.h
+++ b/Core/HLE/sceAdler.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceAdler is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 void Register_sceAdler();

--- a/Core/HLE/sceDeflt.h
+++ b/Core/HLE/sceDeflt.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceDeflt is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 void Register_sceDeflt();

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -907,7 +907,7 @@ static int GameFirmwareVersion() {
 //
 // One directory listing rather than a stat per font, since on Android's scoped storage the
 // individual checks are slow.
-static bool NandFontsComplete() {
+bool NandFontsComplete() {
 	const int firmware = GameFirmwareVersion();
 
 	std::string_view fontDir(g_nandFontPath);

--- a/Core/HLE/sceFont.h
+++ b/Core/HLE/sceFont.h
@@ -5,6 +5,12 @@ class PointerWrap;
 void Register_sceFont();
 void Register_sceLibFttt();
 
+// Whether flash0:/font holds the fonts this game's firmware would have had. Used two ways: the
+// HLE font loader asks so it knows whether to unpack them off the disc's updater first, and
+// CheckDisableHLEAvailability asks because the real libfont.prx a disc ships reads its fonts from
+// there and has nothing to fall back on - so it can only replace our HLE when they're present.
+bool NandFontsComplete();
+
 void __FontInit();
 void __FontShutdown();
 void __FontDoState(PointerWrap &p);

--- a/Core/HLE/sceHeap.h
+++ b/Core/HLE/sceHeap.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceHeap is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 void Register_sceHeap();

--- a/Core/HLE/sceMd5.h
+++ b/Core/HLE/sceMd5.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceMd5 is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 #include "Common/CommonTypes.h"

--- a/Core/HLE/sceMt19937.h
+++ b/Core/HLE/sceMt19937.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceMt19937 is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 void Register_sceMt19937();

--- a/Core/HLE/sceParseHttp.h
+++ b/Core/HLE/sceParseHttp.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: a graduation candidate, but not graduated. sceParseHttp is a small library with no
+// dependencies beyond the kernel, and most games that use it ship their own copy - but it is also
+// in the firmware, and sceUtility can load it (module 0x104), so a game may import it without
+// carrying one. Letting the game's module win would hand that game unresolved imports. It can
+// follow once sceUtility loads the firmware copy the way it does for sceMp3 and sceMp4.
+
 #pragma once
 
 void Register_sceParseHttp();

--- a/Core/HLE/sceParseUri.h
+++ b/Core/HLE/sceParseUri.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: a graduation candidate, but not graduated. sceParseUri is a small library with no
+// dependencies beyond the kernel, and most games that use it ship their own copy - but it is also
+// in the firmware, and sceUtility can load it (module 0x103), so a game may import it without
+// carrying one. Letting the game's module win would hand that game unresolved imports. It can
+// follow once sceUtility loads the firmware copy the way it does for sceMp3 and sceMp4.
+
 #pragma once
 
 #ifdef _MSC_VER

--- a/Core/HLE/sceSfmt19937.h
+++ b/Core/HLE/sceSfmt19937.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceSfmt19937 is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 void Register_sceSfmt19937();

--- a/Core/HLE/sceSha256.h
+++ b/Core/HLE/sceSha256.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: This is now unmaintained legacy code. sceSha256 is a small leaf library that games ship
+// on the disc themselves and that appears in no firmware dump, so we let the game's own module run
+// and this HLE is only a fallback for the rare game that imports it without shipping it, and for
+// old savestates - whose syscall opcodes index these tables, which is why nothing here is removed.
+// See AlwaysDisableHLEFlags in Core/HLE/HLE.cpp.
+
 #pragma once
 
 void Register_sceSha256();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -506,9 +506,6 @@ static bool CPU_Init(FileLoader *fileLoader, IdentifiedFileType type, std::strin
 
 	DisplayHWInit();
 
-	// Init all the HLE modules
-	HLEInit();
-
 	// TODO: Put this somewhere better?
 	if (!g_CoreParameter.mountIso.empty()) {
 		g_CoreParameter.mountIsoLoader = ConstructFileLoader(g_CoreParameter.mountIso);
@@ -520,6 +517,13 @@ static bool CPU_Init(FileLoader *fileLoader, IdentifiedFileType type, std::strin
 	AutoInstallFirmwareFromDisc();
 
 	MountFileSystems();
+
+	// Init all the HLE modules. After the mount, and after the firmware install above, so that the
+	// checks in HLEInit deciding whether a library can run its real module instead of our HLE can
+	// ask the PSP filesystem the way everything else does - and see a firmware this very boot just
+	// installed off the disc. Nothing between CoreTiming::Init above and here touches HLE, and the
+	// kernel and the game's modules both come later, in the switch below.
+	HLEInit();
 
 	// Game-specific settings are load from for example Load_PSP_ISO (which calls g_Config.LoadGameConfig).
 	// We can't do things that depend on these before the below switch. So for example, the adjustment of the GPU core

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -289,6 +289,17 @@ static GraphicsContext *CreateGraphicsContext(GPUCore gpuCore, std::string **dev
 #endif
 }
 
+// Whether what we're booting is homebrew rather than a retail disc. The two want opposite
+// defaults for the graduated HLE modules - see where this is used.
+//
+// By extension, not by content: this runs before the loaders are up, and Identify_File can't even
+// see the file yet. pspautotests is .prx, with .elf as its fallback, and that is the whole set we
+// need to tell apart from a disc.
+static bool BootTargetIsHomebrewExecutable(const std::string &filename) {
+	const std::string ext = Path(filename).GetFileExtension();
+	return ext == ".prx" || ext == ".elf";
+}
+
 struct AutoTestOptions {
 	double timeout;
 	double maxScreenshotError;
@@ -781,13 +792,23 @@ int main(int argc, const char* argv[]) {
 	// overrides above, so a matching command line flag always wins.
 	cmdLineOptions.ApplyToConfig();
 
-	// Run all modules as HLE - a headless run normally has no firmware to load them from, and the
-	// homebrew that pspautotests is made of doesn't ship the user libraries a retail disc does, so
-	// even the graduated modules (scePsmfPlayer and friends) have nothing real to run. An explicit
-	// --disable-hle means the caller does have what's needed and wants the real thing, so leave
-	// the modules they asked for alone - including the graduated ones, which is how you get a disc
-	// game's own libpsmfplayer.prx to run here the way it does in the app.
-	g_Config.iForceEnableHLE = 0xFFFFFFFF & ~g_Config.iDisableHLE;
+	// pspautotests is homebrew PRXes that ship none of the user libraries a retail disc carries, so
+	// the graduated modules (scePsmfPlayer and friends) would have nothing real to run and every
+	// test that touches them would fail on unresolved imports. Force those back to HLE.
+	//
+	// A disc is the opposite case: it brings its own copies and the app runs them for real, so
+	// headless has to as well or it isn't testing what ships. An explicit --disable-hle always
+	// wins, in either case, since the caller is saying they have what's needed.
+	// From the resolved list, not the command line: a test batch arrives as "@-" and is expanded
+	// above, and that is not a disc however it is spelled. A batch is always homebrew; a game run
+	// is exactly one disc. A --vsh run has no file at all and keeps the homebrew treatment, since
+	// the shell's own libraries come from the firmware rather than from a disc.
+	const bool bootIsDisc = testFilenames.size() == 1 &&
+		!BootTargetIsHomebrewExecutable(testFilenames[0]);
+	if (!bootIsDisc) {
+		g_Config.iForceEnableHLE = 0xFFFFFFFF & ~g_Config.iDisableHLE;
+	}
+
 
 
 	// This looks contradictory to the above. But, this preserves the old test behavior which apparently ran the JIT for the CPU
@@ -878,6 +899,35 @@ int main(int argc, const char* argv[]) {
 	}
 	g_Config.nandRootDirectory = GetSysDirectory(DIRECTORY_NAND);
 	coreParameter.nandRoot = g_Config.nandRootDirectory;
+
+	// Most discs carry the firmware they shipped with, which is the right version to run this game
+	// against and saves installing one by hand. Unpacked per disc and kept, so a second run of the
+	// same game reuses it - these are ~25MB each.
+	if (cmdLineOptions.firmwareFromDisc.value_or(false)) {
+		if (!bootIsDisc) {
+			fprintf(stderr, "--firmware-from-disc only applies when booting a disc\n");
+			return 1;
+		}
+		const Path disc(testFilenames[0]);
+		const Path nand = g_Config.memStickDirectory / "PSP" / "NAND_FROM_DISC" / disc.GetFilename();
+		if (File::Exists(nand / "flash0" / "kd")) {
+			printf("Reusing the firmware already unpacked from this disc at %s\n", nand.c_str());
+		} else {
+			PSARUnpackOptions unpackOptions;
+			unpackOptions.verbose = testOptions.verbose;
+			PSARUnpackStats stats;
+			std::string unpackError;
+			if (!UnpackUpdater(disc, nand, unpackOptions, &stats, &unpackError)) {
+				fprintf(stderr, "Couldn't install the firmware on %s: %s\n",
+					disc.GetFilename().c_str(), unpackError.c_str());
+				return 1;
+			}
+			printf("Installed firmware %s from the disc to %s (%d files)\n",
+				stats.firmwareVersion.c_str(), nand.c_str(), stats.written);
+		}
+		g_Config.nandRootDirectory = nand;
+		coreParameter.nandRoot = nand;
+	}
 	// Placed here rather than with the other early-exit subcommands above, because resolving a
 	// "flash0:/kd/foo.prx" module path needs nandRootDirectory, which is only settled just above.
 	if (cmdLineOptions.reDecrypt.has_value()) {

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -886,6 +886,10 @@ int main(int argc, const char* argv[]) {
 	if (cmdLineOptions.reModule.has_value()) {
 		ReverseEngineerOptions reOptions;
 		reOptions.modulePath = cmdLineOptions.reModule.value();
+		// A "disc0:" module path reads out of the disc image given as the positional argument.
+		if (!cmdLineOptions.bootFilenames.empty()) {
+			reOptions.discPath = cmdLineOptions.bootFilenames[0];
+		}
 		reOptions.outDir = cmdLineOptions.reOut.value_or("re-out");
 		reOptions.funcFilter = cmdLineOptions.reFunc.value_or("");
 		reOptions.symsFile = cmdLineOptions.reSyms.value_or("");

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -292,9 +292,8 @@ static GraphicsContext *CreateGraphicsContext(GPUCore gpuCore, std::string **dev
 // Whether what we're booting is homebrew rather than a retail disc. The two want opposite
 // defaults for the graduated HLE modules - see where this is used.
 //
-// By extension, not by content: this runs before the loaders are up, and Identify_File can't even
-// see the file yet. pspautotests is .prx, with .elf as its fallback, and that is the whole set we
-// need to tell apart from a disc.
+// This runs before the loaders are up, and Identify_File can't even see the file yet.
+// pspautotests is .prx, with .elf as its fallback.
 static bool BootTargetIsHomebrewExecutable(const std::string &filename) {
 	const std::string ext = Path(filename).GetFileExtension();
 	return ext == ".prx" || ext == ".elf";
@@ -792,26 +791,17 @@ int main(int argc, const char* argv[]) {
 	// overrides above, so a matching command line flag always wins.
 	cmdLineOptions.ApplyToConfig();
 
-	// pspautotests is homebrew PRXes that ship none of the user libraries a retail disc carries, so
-	// the graduated modules (scePsmfPlayer and friends) would have nothing real to run and every
-	// test that touches them would fail on unresolved imports. Force those back to HLE.
-	//
-	// A disc is the opposite case: it brings its own copies and the app runs them for real, so
-	// headless has to as well or it isn't testing what ships. An explicit --disable-hle always
-	// wins, in either case, since the caller is saying they have what's needed.
-	// From the resolved list, not the command line: a test batch arrives as "@-" and is expanded
-	// above, and that is not a disc however it is spelled. A batch is always homebrew; a game run
-	// is exactly one disc. A --vsh run has no file at all and keeps the homebrew treatment, since
-	// the shell's own libraries come from the firmware rather than from a disc.
+	// pspautotests is plain homebrew PRXes so do not ship user libraries that a retail disc may carry. 
+	// So we must use HLE, unless we install firmware.
+	// A disc brings its own copies and the app runs them for real, so
+	// headless has to as well or it isn't testing what ships.
 	const bool bootIsDisc = testFilenames.size() == 1 &&
 		!BootTargetIsHomebrewExecutable(testFilenames[0]);
 	if (!bootIsDisc) {
 		g_Config.iForceEnableHLE = 0xFFFFFFFF & ~g_Config.iDisableHLE;
 	}
 
-
-
-	// This looks contradictory to the above. But, this preserves the old test behavior which apparently ran the JIT for the CPU
+	// This looks contradictory to above checks. But, this preserves the old test behavior which apparently ran the JIT for the CPU
 	// but ended up running software vertex decoding due to the setting in g_Config. Yeah, it's a mess.
 	CPUCore cpuCore = CPUCore::JIT;
 	if (cmdLineOptions.cpuCore.has_value()) {
@@ -900,9 +890,8 @@ int main(int argc, const char* argv[]) {
 	g_Config.nandRootDirectory = GetSysDirectory(DIRECTORY_NAND);
 	coreParameter.nandRoot = g_Config.nandRootDirectory;
 
-	// Most discs carry the firmware they shipped with, which is the right version to run this game
-	// against and saves installing one by hand. Unpacked per disc and kept, so a second run of the
-	// same game reuses it - these are ~25MB each.
+	// Most discs carry the firmware they shipped with - this option installs it, if one
+	// isn't already installed. TODO: Check version here.
 	if (cmdLineOptions.firmwareFromDisc.value_or(false)) {
 		if (!bootIsDisc) {
 			fprintf(stderr, "--firmware-from-disc only applies when booting a disc\n");
@@ -928,6 +917,7 @@ int main(int argc, const char* argv[]) {
 		g_Config.nandRootDirectory = nand;
 		coreParameter.nandRoot = nand;
 	}
+
 	// Placed here rather than with the other early-exit subcommands above, because resolving a
 	// "flash0:/kd/foo.prx" module path needs nandRootDirectory, which is only settled just above.
 	if (cmdLineOptions.reDecrypt.has_value()) {

--- a/headless/ReverseEngineer.cpp
+++ b/headless/ReverseEngineer.cpp
@@ -44,6 +44,8 @@
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/ELF/PrxDecrypter.h"
 #include "Core/FileSystems/DirectoryFileSystem.h"
+#include "Core/FileSystems/ISOFileSystem.h"
+#include "Core/Loaders.h"
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/sceKernel.h"
@@ -392,7 +394,13 @@ int RunDecryptFile(const std::string &inPath, const std::string &outPath) {
 }
 
 int RunReverseEngineer(const ReverseEngineerOptions &opts) {
-	const Path modulePath = ResolveModulePath(opts.modulePath);
+	// A module inside a disc image rather than on the host - see ReverseEngineerOptions.
+	const bool fromDisc = startsWithNoCase(opts.modulePath, "disc0:") || startsWithNoCase(opts.modulePath, "umd0:");
+	if (fromDisc && opts.discPath.empty()) {
+		fprintf(stderr, "re: a disc0: module path needs the disc image as the positional argument\n");
+		return 1;
+	}
+	const Path modulePath = fromDisc ? Path(opts.discPath) : ResolveModulePath(opts.modulePath);
 	if (!File::Exists(modulePath)) {
 		fprintf(stderr, "re: no such file: %s\n", modulePath.c_str());
 		return 1;
@@ -415,8 +423,16 @@ int RunReverseEngineer(const ReverseEngineerOptions &opts) {
 		return 1;
 	}
 
+	// For a disc, the path inside it; otherwise the containing directory and the leaf name.
+	std::string insideDisc;
+	if (fromDisc) {
+		insideDisc = opts.modulePath.substr(opts.modulePath.find(':') + 1);
+		if (insideDisc.empty() || insideDisc[0] != '/') {
+			insideDisc = "/" + insideDisc;
+		}
+	}
 	const std::string dir = modulePath.GetDirectory();
-	const std::string filename = modulePath.GetFilename();
+	const std::string filename = fromDisc ? Path(insideDisc).GetFilename() : modulePath.GetFilename();
 
 	PSPModule *module = nullptr;
 	std::string moduleName;
@@ -445,12 +461,31 @@ int RunReverseEngineer(const ReverseEngineerOptions &opts) {
 		printf("re: raw image %s at %08x, %d bytes\n", filename.c_str(), base, blockSize);
 		MIPSAnalyst::ScanForFunctions(base, base + blockSize - 4, true);
 	} else {
-		// Mount the containing directory so the normal file-backed loader path can be used.
-		auto hostFs = std::make_shared<DirectoryFileSystem>(&pspFileSystem, Path(dir), FileSystemFlags::FLASH);
-		pspFileSystem.Mount("host0:", hostFs);
+		// Mount whatever holds the module so the normal file-backed loader path can be used: the
+		// disc itself, or the containing directory.
+		std::string loadPath;
+		if (fromDisc) {
+			std::unique_ptr<FileLoader> loader(ConstructFileLoader(modulePath));
+			std::string blockError;
+			std::shared_ptr<BlockDevice> device(loader ? ConstructBlockDevice(loader.get(), &blockError) : nullptr);
+			if (!device) {
+				fprintf(stderr, "re: %s isn't a disc image we can read: %s\n", modulePath.c_str(), blockError.c_str());
+				ShutdownMinimalPSP();
+				return 1;
+			}
+			// The ISO filesystem takes ownership of the block device, which owns the loader.
+			loader.release();
+			auto isoFs = std::make_shared<ISOFileSystem>(&pspFileSystem, device);
+			pspFileSystem.Mount("host0:", isoFs);
+			loadPath = "host0:" + insideDisc;
+		} else {
+			auto hostFs = std::make_shared<DirectoryFileSystem>(&pspFileSystem, Path(dir), FileSystemFlags::FLASH);
+			pspFileSystem.Mount("host0:", hostFs);
+			loadPath = "host0:/" + filename;
+		}
 
 		std::string error;
-		const SceUID uid = KernelLoadModule("host0:/" + filename, &error);
+		const SceUID uid = KernelLoadModule(loadPath, &error);
 		if (uid < 0) {
 			fprintf(stderr, "re: failed to load %s: %s\n", modulePath.c_str(), error.c_str());
 			ShutdownMinimalPSP();

--- a/headless/ReverseEngineer.h
+++ b/headless/ReverseEngineer.h
@@ -22,12 +22,12 @@
 #include "Common/CommonTypes.h"
 
 struct ReverseEngineerOptions {
-	// PRX/ELF to load. A host path; a PSP path like "flash0:/kd/libmp3.prx", resolved against the
-	// configured NAND directory; or "disc0:/PSP_GAME/USRDIR/MODULES/LIBDEFLT.PRX", read out of the
-	// disc image named as the positional argument. The last is how you look at the copy of a
-	// library a game ships rather than the firmware's.
+	// PRX/ELF to load. Can be either a host path or a PSP path like "flash0:/kd/libmp3.prx",
+	// resolved against the configured NAND directory, or even something like
+	// "disc0:/PSP_GAME/USRDIR/MODULES/LIBDEFLT.PRX", read out of the
+	// disc image named as the positional argument.
 	std::string modulePath;
-	// The disc image a "disc0:" modulePath is read from.
+	// The disc image that a "disc0:" modulePath is read from.
 	std::string discPath;
 	// Where to write the report. Created if missing.
 	std::string outDir;

--- a/headless/ReverseEngineer.h
+++ b/headless/ReverseEngineer.h
@@ -22,9 +22,13 @@
 #include "Common/CommonTypes.h"
 
 struct ReverseEngineerOptions {
-	// PRX/ELF to load. A host path, or a PSP path like "flash0:/kd/libmp3.prx" (resolved
-	// against the configured NAND directory).
+	// PRX/ELF to load. A host path; a PSP path like "flash0:/kd/libmp3.prx", resolved against the
+	// configured NAND directory; or "disc0:/PSP_GAME/USRDIR/MODULES/LIBDEFLT.PRX", read out of the
+	// disc image named as the positional argument. The last is how you look at the copy of a
+	// library a game ships rather than the firmware's.
 	std::string modulePath;
+	// The disc image a "disc0:" modulePath is read from.
+	std::string discPath;
 	// Where to write the report. Created if missing.
 	std::string outDir;
 	// If set, only this function is disassembled (by name, or "0x08801234").


### PR DESCRIPTION
These libraries are always shipped on-disc if used, and it's better to just run them than to use our HLE.

Especially sceFont works considerably better than our HLE implementation in some cases, it has more accurate font picking. For example Jeanne D'Arc gets the wrong font, while with this it's correct. However it does require proper firmware fonts to be installed - but that will almost always be the case now that we auto-install firmware from game ISOs at any opportunity.

I know there might be some Chinese translation that relies on our implementation, we'll have to add a compat flag once we figure out which it is. @sum2012 ? (Actually, no, but they need this).

- So turns out it fixes #19111.

Claude helped.